### PR TITLE
docs: Add AGENTS.md with project knowledge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# Project Knowledge: RAG Starter Kit
+
+## 1. Project Architecture & Toolchain
+- **Fact**: Python 3.14 monorepo managed by **moon** (repo tooling) and **uv** (package manager).
+- **Rule**: Always use `uv sync` to install dependencies and update lockfiles. Never use `pip` or `poetry`.
+- **Rule**: Linting and formatting are handled by `ruff` (v0.9.3+), and type checking by `ty` (Astral's type checker).
+
+## 2. UV Workspace Configuration Pattern
+- **Insight**: For development tools (like `ty` (LSP) or `mypy`) to correctly resolve imports from local workspace packages (e.g., `packages/sample`), those packages **must** be explicitly listed in the root `pyproject.toml` under `dependencies` **and** mapped in `[tool.uv.sources]`.
+- **Example**:
+    ```toml
+    # pyproject.toml
+    [project]
+    dependencies = ["my-lib"]
+
+    [tool.uv.sources]
+    my-lib = { workspace = true }
+    ```
+
+## 3. CLI Development Patterns
+- **Fact**: The project CLI is named `rf` (rag-facile), not `rag-cli`.
+- **Gotcha**: Typer collapses the CLI structure if only one command exists.
+- **Rule**: Maintain at least two commands (e.g., `hello` and `version`) in `apps/cli` to enforce standard subcommand routing (`rf <command>`).
+
+## 4. Configuration Specifics
+- **Gotcha**: The `ty` pre-commit hook requires the `entry` to be explicitly set to `uv run ty check`. The default entry may fail or lack the necessary context.


### PR DESCRIPTION
Adds `AGENTS.md` to the repository root to capture project knowledge and patterns for agent collaboration.

## Contents
- Project Architecture & Toolchain
- UV Workspace Configuration Patterns
- CLI Development Patterns
- Configuration Specifics (pre-commit)
