### PR TITLE
feat: make CLI installable via uv tool install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,7 +211,5 @@ marimo/_lsp/
 # Templates (generated dynamically)
 /templates/
 
-# (Optional) If you want to be extra safe, you can ignore the whole folder
-.letta/*
-# and strictly allow the shared settings file
-!.letta/settings.json
+# Letta local files
+.letta

--- a/README.md
+++ b/README.md
@@ -26,7 +26,38 @@ The project is organized as a monorepo with the following foundational component
 ### 1. Prerequisite
 Ensure you have `uv` and `just` installed on your system.
 
-### 2. Setup
+### 2. Install the CLI (Optional)
+You can install the RAG Facile CLI (`rf`) globally using `uv`:
+
+#### Option 1: Persistent Installation (Recommended)
+Install once and use everywhere:
+```bash
+uv tool install rf --from git+https://github.com/etalab-ia/rag-facile.git#subdirectory=apps/cli
+```
+
+Then use the tool directly:
+```bash
+rf version
+rf template generate --app chainlit-chat
+```
+
+To upgrade the CLI:
+```bash
+uv tool install rf --force --from git+https://github.com/etalab-ia/rag-facile.git#subdirectory=apps/cli
+```
+
+#### Option 2: One-time Usage
+Run directly without installing:
+```bash
+uvx --from git+https://github.com/etalab-ia/rag-facile.git#subdirectory=apps/cli rf version
+```
+
+**Benefits of persistent installation:**
+- Tool stays installed and available in PATH
+- No need to create shell aliases
+- Better tool management with `uv tool list`, `uv tool upgrade`, `uv tool uninstall`
+
+### 3. Setup
 Install all dependencies and prepare the workspace:
 ```bash
 just setup

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -3,17 +3,47 @@
 The CLI provides utility commands for managing the RAG Facile ecosystem.
 
 ## Installation
-The CLI is part of the `rag-facile` monorepo workspace.
+
+### Option 1: Persistent Installation (Recommended)
+Install globally using `uv`:
+
+```bash
+uv tool install rf --from git+https://github.com/etalab-ia/rag-facile.git#subdirectory=apps/cli
+```
+
+Then use the tool directly:
+
+```bash
+rf version
+rf template generate --app chainlit-chat
+```
+
+To upgrade:
+
+```bash
+uv tool install rf --force --from git+https://github.com/etalab-ia/rag-facile.git#subdirectory=apps/cli
+```
+
+### Option 2: One-time Usage
+Run directly without installing:
+
+```bash
+uvx --from git+https://github.com/etalab-ia/rag-facile.git#subdirectory=apps/cli rf [command]
+```
+
+### Option 3: As Part of Monorepo
+The CLI is part of the `rag-facile` monorepo workspace:
 
 ```bash
 uv sync
+uv run rf [command]
 ```
 
 ## Usage
-The CLI is accessible via the `rf` command when running through `uv`:
+When installed globally, the CLI is accessible via the `rf` command:
 
 ```bash
-uv run rf [command]
+rf [command]
 ```
 
 ### Commands

--- a/apps/cli/pyproject.toml
+++ b/apps/cli/pyproject.toml
@@ -12,3 +12,10 @@ dependencies = [
 
 [project.scripts]
 rf = "cli.main:app"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/cli"]


### PR DESCRIPTION
## Summary
- Add build system configuration to enable `uv tool install` from GitHub
- Update documentation with installation instructions (persistent, one-time, monorepo)
- Users can now install `rf` CLI globally: `uv tool install rf --from git+https://github.com/etalab-ia/rag-facile.git#subdirectory=apps/cli`

## Test plan
- [x] Build package locally with `uv build` in apps/cli
- [x] Install CLI from local path with `uv tool install --force --from /path/to/apps/cli cli`
- [x] Verify `rf version` command works correctly
- [x] Test `rf template generate --app chainlit-chat` command
- [x] Update documentation in both root and CLI READMEs

👾 Generated with [Letta Code](https://letta.com)