### PR TITLE
refactor: separate documentation for users and contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,166 @@
+# Contributing to RAG Facile
+
+Thank you for your interest in contributing to RAG Facile! This document provides information for developers and contributors who want to work on the monorepo.
+
+## Development Setup
+
+### Prerequisites
+
+- **Python 3.13**
+- **uv** (package manager)
+- **just** (command runner)
+- **git**
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/etalab-ia/rag-facile.git
+cd rag-facile
+```
+
+### 2. Install Dependencies
+
+The project uses `uv` for package management. Install all dependencies:
+
+```bash
+just setup
+```
+
+This will:
+- Create a Python 3.13 virtual environment
+- Install all dependencies for all apps and packages
+- Set up the development environment
+
+### 3. Environment Variables
+
+For the chat apps, copy the example environment files and add your credentials:
+
+```bash
+cp apps/reflex-chat/.env.example apps/reflex-chat/.env
+cp apps/chainlit-chat/.env.example apps/chainlit-chat/.env
+```
+
+Using the Albert API requires specifying both `OPENAI_API_KEY` and `OPENAI_BASE_URL`.
+
+## Project Structure
+
+The project is organized as a monorepo with the following structure:
+
+```
+rag-facile/
+├── apps/              # Application components
+│   ├── chainlit-chat/ # ChainLit chat interface
+│   ├── reflex-chat/  # Reflex chat interface
+│   ├── admin/        # Admin UI (Streamlit)
+│   ├── ingestion/    # Data ingestion pipeline
+│   └── cli/          # Command-line interface
+├── packages/         # Shared packages
+│   └── sample/       # Sample package
+├── templates/        # Generated project templates
+├── scripts/          # Utility scripts
+├── pyproject.toml    # Root workspace configuration
+└── justfile         # Command recipes
+```
+
+## Tech Stack
+
+- **Language**: Python 3.13
+- **Package Manager**: `uv`
+- **Monorepo Manager**: `moon`
+- **Command Runner**: `just`
+- **Linting**: `ruff`
+- **Type Checking**: `ty`
+
+## Development Workflow
+
+### Running Applications
+
+Use `just` to run any of the applications from the root directory:
+
+```bash
+just reflex-chat    # Runs at http://localhost:3000
+just chainlit-chat  # Runs at http://localhost:8000
+just admin          # Runs admin UI
+```
+
+### Code Quality
+
+Run linting and type checking:
+
+```bash
+# Lint all code
+just lint
+
+# Type check all code
+just type-check
+
+# Format code
+just format
+```
+
+### Template Management
+
+Parameterized project templates (using [Copier](https://copier.readthedocs.io/)) are generated from the living "Golden Master" apps in the `apps/` directory.
+
+To update all templates after making changes to the source apps:
+
+```bash
+just gen-templates
+```
+
+To instantiate a new project from a template:
+
+```bash
+# Default (chainlit-chat)
+just create-app
+
+# Specific template and destination
+just create-app reflex-chat my-new-project
+```
+
+The generated project will include its own `Justfile` for local development:
+- `just sync`: Properly synchronizes dependencies using Python 3.13
+- `just run`: Runs the application
+
+## Testing
+
+Run tests for the entire monorepo:
+
+```bash
+just test
+```
+
+Run tests for a specific app:
+
+```bash
+cd apps/cli
+uv run pytest
+```
+
+## Pull Request Process
+
+1. **Fork and clone** the repository
+2. **Create a branch** for your changes: `git checkout -b feature/your-feature`
+3. **Make your changes** following the coding conventions
+4. **Run tests** and ensure they pass
+5. **Commit** your changes with a clear message
+6. **Push** to your fork: `git push origin feature/your-feature`
+7. **Create a pull request** to the main repository
+
+## Coding Conventions
+
+- Follow PEP 8 style guidelines
+- Use type hints for all functions
+- Write docstrings for public functions and classes
+- Keep functions focused and small
+- Use descriptive variable names
+
+## Getting Help
+
+- Open an issue for bugs or feature requests
+- Start a discussion for questions
+- Check existing issues and discussions first
+
+## License
+
+By contributing to RAG Facile, you agree that your contributions will be licensed under the same license as the project.

--- a/README.md
+++ b/README.md
@@ -1,99 +1,77 @@
 # RAG Facile
- > [!IMPORTANT]
- > This project is a starter kit for RAG applications in the French government.
+
+> [!IMPORTANT]
+> This project is a starter kit for RAG applications in the French government.
 
 ## Overview
-This starter kit provides a foundation for building RAG (Retrieval-Augmented Generation) applications in the French government, specifically using the [Albert API](https://albert.sites.beta.gouv.fr/). It is designed for exploratory greenfield projects.
 
-## Components
-The project is organized as a monorepo with the following foundational components:
-- **Chat Interface**: Built with ChainLit (`apps/chainlit-chat`).
-- **Reflex Chat**: Interactive chat built with Reflex (`apps/reflex-chat`).
-- **Admin UI**: Administration interface (`apps/admin`).
-- **Ingestion Pipeline**: Data processing pipeline (`apps/ingestion`).
-- **CLI**: Command-line interface (`apps/cli`).
+RAG Facile provides a foundation for building RAG (Retrieval-Augmented Generation) applications in the French government, specifically using the [Albert API](https://albert.sites.beta.gouv.fr/). It is designed for exploratory greenfield projects.
 
-## Tech Stack
-- **Language**: Python 3.13
-- **Package Manager**: `uv`
-- **Monorepo Manager**: `moon`
-- **Command Runner**: `just`
-- **Linting**: `ruff`
-- **Type Checking**: `ty`
+## Installation
 
-## Getting Started
+### Prerequisites
 
-### 1. Prerequisite
-Ensure you have `uv` and `just` installed on your system.
+Ensure you have `uv` installed on your system:
 
-### 2. Install the CLI (Optional)
-You can install the RAG Facile CLI (`rf`) globally using `uv`:
+```bash
+# macOS/Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
 
-#### Option 1: Persistent Installation (Recommended)
-Install once and use everywhere:
+# Or with Homebrew
+brew install uv
+
+# Windows
+powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+### Install the CLI
+
+Install the RAG Facile CLI (`rf`) globally using `uv`:
+
 ```bash
 uv tool install rf --from git+https://github.com/etalab-ia/rag-facile.git#subdirectory=apps/cli
 ```
 
-Then use the tool directly:
+Verify the installation:
+
 ```bash
 rf version
-rf template generate --app chainlit-chat
 ```
 
-To upgrade the CLI:
+To upgrade to the latest version:
+
 ```bash
 uv tool install rf --force --from git+https://github.com/etalab-ia/rag-facile.git#subdirectory=apps/cli
 ```
 
-#### Option 2: One-time Usage
-Run directly without installing:
+## Usage
+
+The `rf` CLI provides commands for managing RAG applications:
+
 ```bash
-uvx --from git+https://github.com/etalab-ia/rag-facile.git#subdirectory=apps/cli rf version
+# Show available commands
+rf --help
+
+# Generate a template
+rf template generate --app chainlit-chat
+
+# Check version
+rf version
 ```
 
-**Benefits of persistent installation:**
-- Tool stays installed and available in PATH
-- No need to create shell aliases
-- Better tool management with `uv tool list`, `uv tool upgrade`, `uv tool uninstall`
+## Components
 
-### 3. Setup
-Install all dependencies and prepare the workspace:
-```bash
-just setup
-```
+RAG Facile includes several application templates:
 
-### 3. Environment Variables
-For the chat apps, copy the example environment files and add your credentials. Using the Albert API requires specifying both `OPENAI_API_KEY` and `OPENAI_BASE_URL`:
-```bash
-cp apps/reflex-chat/.env.example apps/reflex-chat/.env
-cp apps/chainlit-chat/.env.example apps/chainlit-chat/.env
-```
+- **ChainLit Chat**: A chat interface built with ChainLit
+- **Reflex Chat**: Interactive chat built with Reflex
+- **Admin UI**: Administration interface
+- **Ingestion Pipeline**: Data processing pipeline
 
-### 4. Running the Applications
-Use `just` to run any of the applications from the root directory:
-- `just reflex-chat`: Runs the Reflex chat app at http://localhost:3000
-- `just chainlit-chat`: Runs the ChainLit chat app at http://localhost:8000
-- `just admin`: Runs the Streamlit admin app
+## Contributing
 
-### 5. Template Management
-Parameterized project templates (using [Copier](https://copier.readthedocs.io/)) are generated from the living "Golden Master" apps in the `apps/` directory.
+We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and contribution guidelines.
 
-To update all templates after making changes to the source apps:
-```bash
-just gen-templates
-```
+## License
 
-### 6. Using Templates
-To instantiate a new project from a template:
-```bash
-# Default (chainlit-chat)
-just create-app
-
-# Specific template and destination
-just create-app reflex-chat my-new-project
-```
-
-The generated project will include its own `Justfile` for local development:
-- `just sync`: Properly synchronizes dependencies using Python 3.13.
-- `just run`: Runs the application.
+See [LICENSE](LICENSE) for details.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,10 +1,11 @@
 # RAG Facile CLI
 
-The CLI provides utility commands for managing the RAG Facile ecosystem.
+The `rf` CLI provides utility commands for managing the RAG Facile ecosystem.
 
 ## Installation
 
 ### Option 1: Persistent Installation (Recommended)
+
 Install globally using `uv`:
 
 ```bash
@@ -25,34 +26,34 @@ uv tool install rf --force --from git+https://github.com/etalab-ia/rag-facile.gi
 ```
 
 ### Option 2: One-time Usage
+
 Run directly without installing:
 
 ```bash
 uvx --from git+https://github.com/etalab-ia/rag-facile.git#subdirectory=apps/cli rf [command]
 ```
 
-### Option 3: As Part of Monorepo
-The CLI is part of the `rag-facile` monorepo workspace:
-
-```bash
-uv sync
-uv run rf [command]
-```
-
 ## Usage
-When installed globally, the CLI is accessible via the `rf` command:
 
 ```bash
-rf [command]
+# Show all available commands
+rf --help
+
+# Show help for a specific command
+rf template generate --help
+
+# Check version
+rf version
 ```
 
-### Commands
+## Commands
 
-#### `template generate`
-Generates a parameterized [Copier](https://copier.readthedocs.io/) template from an existing application in the `apps/` directory.
+### `template generate`
+
+Generates a parameterized [Copier](https://copier.readthedocs.io/) template from an existing application.
 
 ```bash
-uv run rf template generate --app <app-type>
+rf template generate --app <app-type>
 ```
 
 **Arguments:**
@@ -60,15 +61,20 @@ uv run rf template generate --app <app-type>
     - `chainlit-chat`
     - `reflex-chat`
 
-**Description:**
-1. Copies the source application to `templates/<app-type>`.
-2. Removes development artifacts (`.venv`, `.env`, `__pycache__`, etc.).
-3. Applies Jinja2 parameterization to key files (`pyproject.toml`, `.env`, `README.md`, etc.).
-4. For Reflex apps, automatically renames the main package and updates internal imports.
-5. Generates the `copier.yml` configuration.
+**Process:**
+1. Copies the source application to `templates/<app-type>`
+2. Removes development artifacts (`.venv`, `.env`, `__pycache__`, etc.)
+3. Applies Jinja2 parameterization to key files (`pyproject.toml`, `.env`, `README.md`, etc.)
+4. For Reflex apps, automatically renames the main package and updates internal imports
+5. Generates the `copier.yml` configuration
 
 ## Development
+
 The CLI is built with [Typer](https://typer.tiangolo.com/).
-Source code is located in `src/cli/`.
-Command definitions are in `src/cli/commands/`.
-Copier configurations are in `src/cli/configs/`.
+
+For development setup and contribution guidelines, see the main [CONTRIBUTING.md](../../CONTRIBUTING.md) file.
+
+**Source code structure:**
+- `src/cli/` - Main CLI package
+- `src/cli/commands/` - Command definitions
+- `src/cli/configs/` - Copier configurations


### PR DESCRIPTION
## Summary
- Split documentation into two distinct audiences: CLI users and contributors
- Rewrite README.md to focus on CLI users (the happy path)
- Create CONTRIBUTING.md with development setup and contribution guidelines
- Update apps/cli/README.md to remove monorepo-specific instructions

## Rationale
Most users will:
1. Install `rf` via `uv tool install` from GitHub
2. Use CLI commands without cloning the repo
3. Eventually use `rf init` (future feature) to set up their monorepo

The documentation should reflect this user journey rather than assuming everyone will clone the monorepo.

## Changes
- **README.md**: Now focused on installation and usage for CLI users
- **CONTRIBUTING.md**: New file with development setup, project structure, workflow, and contribution guidelines
- **apps/cli/README.md**: Removed monorepo-specific instructions, focused on CLI usage with link to CONTRIBUTING.md for development

## Test plan
- [x] Verify README.md is clear and concise for CLI users
- [x] Verify CONTRIBUTING.md has all necessary development information
- [x] Verify apps/cli/README.md is focused on CLI usage
- [x] Check that all links and cross-references are correct

👾 Generated with [Letta Code](https://letta.com)