### PR TITLE
docs: clarify available vs planned application templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,17 @@ rf version
 
 ## Components
 
-RAG Facile includes several application templates:
+RAG Facile provides application templates for building RAG applications:
+
+### Currently Available
 
 - **ChainLit Chat**: A chat interface built with ChainLit
 - **Reflex Chat**: Interactive chat built with Reflex
-- **Admin UI**: Administration interface
-- **Ingestion Pipeline**: Data processing pipeline
+
+### Planned Templates
+
+- **Admin UI**: Administration interface (coming soon)
+- **Ingestion Pipeline**: Data processing pipeline (coming soon)
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- Updated README to distinguish between currently available application templates (ChainLit Chat and Reflex Chat) and planned templates
- Marked Admin UI and Ingestion Pipeline as "coming soon" to set accurate user expectations

## Test plan

- [x] README.md updated to reflect current state of available templates
- [x] Changes reviewed for accuracy
- [x] Branch pushed to remote

👾 Generated with [Letta Code](https://letta.com)