### PR TITLE
feat: extract pdf-context package and fix templates

### DIFF
--- a/apps/chainlit-chat/app.py
+++ b/apps/chainlit-chat/app.py
@@ -6,7 +6,7 @@ import chainlit as cl
 import engineio
 from dotenv import load_dotenv
 from openai import AsyncOpenAI
-from pypdf import PdfReader
+from pdf_context import process_pdf_file
 
 # Increase the number of packets allowed in a single payload to prevent "Too
 # many packets in payload" errors. This is especially helpful during streaming
@@ -105,19 +105,9 @@ async def main(message: cl.Message):
         for element in message.elements:
             if element.name.endswith(".pdf") and element.path:
                 try:
-                    reader = PdfReader(element.path)
-                    text = ""
-                    for page in reader.pages:
-                        text += page.extract_text() + "\n"
-                    file_content += (
-                        f"\n\n--- Content of attached file '{element.name}' ---\n"
-                    )
-                    file_content += text
-                    file_content += "\n--- End of file ---\n"
+                    file_content += process_pdf_file(element.path, element.name)
                 except Exception as e:
-                    file_content += (
-                        f"\n\nError reading PDF '{element.name}': {str(e)}\n"
-                    )
+                    file_content += f"\n\nError reading PDF '{element.name}': {e!s}\n"
 
     user_message = message.content
     if file_content:

--- a/apps/chainlit-chat/pyproject.toml
+++ b/apps/chainlit-chat/pyproject.toml
@@ -3,13 +3,16 @@ name = "chainlit-chat"
 version = "0.1.0"
 description = "Chainlit Chat with OpenAI Functions Streaming"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 dependencies = [
     "chainlit>=1.3.0",
     "openai>=1.0.0",
     "python-dotenv>=1.0.0",
-    "pypdf>=5.0.0",
+    "pdf-context",
 ]
 
 [project.scripts]
 chainlit-chat = "chainlit.cli:run"
+
+[tool.uv.sources]
+pdf-context = { workspace = true }

--- a/packages/pdf-context/README.md
+++ b/packages/pdf-context/README.md
@@ -1,0 +1,124 @@
+# pdf-context
+
+PDF text extraction and context formatting for LLM applications.
+
+## Overview
+
+This package provides utilities for extracting text from PDF files and formatting it for injection into LLM prompts. It uses a "context-injection" approach where the entire PDF content is added to the conversation context, suitable for smaller documents that fit within the model's context window.
+
+## Installation
+
+The package is part of the rag-facile monorepo. It's automatically available when working within the workspace.
+
+```bash
+uv sync
+```
+
+## Usage
+
+### Basic Usage
+
+```python
+from pdf_context import extract_text_from_pdf, format_as_context, process_pdf_file
+
+# Extract raw text from a PDF
+text = extract_text_from_pdf("path/to/document.pdf")
+
+# Format the text for LLM context injection
+context = format_as_context(text, "document.pdf")
+
+# Or use the convenience function that does both
+context = process_pdf_file("path/to/document.pdf")
+```
+
+### Processing Multiple Files
+
+```python
+from pdf_context import process_multiple_files
+
+# Process multiple PDFs at once
+context = process_multiple_files([
+    "path/to/doc1.pdf",
+    "path/to/doc2.pdf",
+])
+```
+
+### Working with Bytes
+
+```python
+from pdf_context import extract_text_from_bytes
+
+# Useful when you have PDF content in memory (e.g., from an upload)
+pdf_bytes = uploaded_file.read()
+text = extract_text_from_bytes(pdf_bytes)
+```
+
+## Integration Examples
+
+### Chainlit
+
+```python
+import chainlit as cl
+from pdf_context import process_pdf_file
+
+@cl.on_message
+async def main(message: cl.Message):
+    file_content = ""
+
+    if message.elements:
+        for element in message.elements:
+            if element.name.endswith(".pdf") and element.path:
+                try:
+                    file_content += process_pdf_file(element.path, element.name)
+                except Exception as e:
+                    file_content += f"\n\nError reading PDF '{element.name}': {e}\n"
+
+    user_message = message.content + file_content
+    # ... rest of your chat logic
+```
+
+### Reflex
+
+```python
+import reflex as rx
+from pdf_context import extract_text_from_bytes, format_as_context
+
+class State(rx.State):
+    async def handle_upload(self, files: list[rx.UploadFile]):
+        for file in files:
+            if file.filename.endswith(".pdf"):
+                content = await file.read()
+                text = extract_text_from_bytes(content)
+                context = format_as_context(text, file.filename)
+                # ... use context in your chat
+```
+
+## Limitations
+
+- **Context window**: The entire PDF content is injected into the prompt. Large PDFs may exceed the model's context window.
+- **Text only**: Only extracts plain text. Images, tables structure, and formatting are not preserved.
+- **No persistence**: Documents are not stored; they must be re-uploaded each session.
+
+For large document collections or advanced retrieval needs, consider implementing a full RAG pipeline with embeddings and vector storage.
+
+## API Reference
+
+### `extract_text_from_pdf(path: str | Path) -> str`
+
+Extract all text content from a PDF file.
+
+### `extract_text_from_bytes(pdf_bytes: bytes) -> str`
+
+Extract all text content from PDF bytes (useful for uploads).
+
+### `format_as_context(text: str, filename: str) -> str`
+
+Format extracted text with delimiters for context injection.
+
+### `process_pdf_file(path: str | Path, filename: str | None = None) -> str`
+
+Convenience function that extracts text and formats it in one call.
+
+### `process_multiple_files(paths: list[str | Path]) -> str`
+
+Process multiple PDF files and combine their formatted context.

--- a/packages/pdf-context/pyproject.toml
+++ b/packages/pdf-context/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "pdf-context"
+version = "0.1.0"
+description = "PDF text extraction and context formatting for LLM applications"
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = [
+    "pypdf>=5.0.0",
+]

--- a/packages/pdf-context/src/pdf_context/__init__.py
+++ b/packages/pdf-context/src/pdf_context/__init__.py
@@ -1,0 +1,30 @@
+"""PDF Context - PDF text extraction and context formatting for LLM applications.
+
+This package provides utilities for extracting text from PDF files and
+formatting it for injection into LLM prompts (context-injection approach).
+
+Example usage:
+    from pdf_context import extract_text_from_pdf, format_as_context, process_pdf_file
+
+    # Extract raw text
+    text = extract_text_from_pdf("document.pdf")
+
+    # Format for context injection
+    context = format_as_context(text, "document.pdf")
+
+    # Or use the convenience function
+    context = process_pdf_file("document.pdf")
+"""
+
+from .extractor import extract_text_from_bytes, extract_text_from_pdf
+from .formatter import format_as_context, process_multiple_files, process_pdf_file
+
+__all__ = [
+    "extract_text_from_pdf",
+    "extract_text_from_bytes",
+    "format_as_context",
+    "process_pdf_file",
+    "process_multiple_files",
+]
+
+__version__ = "0.1.0"

--- a/packages/pdf-context/src/pdf_context/extractor.py
+++ b/packages/pdf-context/src/pdf_context/extractor.py
@@ -1,0 +1,73 @@
+"""PDF text extraction module.
+
+Provides functions to extract text content from PDF files using pypdf.
+"""
+
+from pathlib import Path
+
+from pypdf import PdfReader
+from pypdf.errors import PdfReadError
+
+
+def extract_text_from_pdf(path: str | Path) -> str:
+    """Extract all text content from a PDF file.
+
+    Args:
+        path: Path to the PDF file (string or Path object).
+
+    Returns:
+        Extracted text content from all pages, with pages separated by newlines.
+
+    Raises:
+        FileNotFoundError: If the PDF file doesn't exist.
+        PdfReadError: If the PDF is corrupted or password-protected.
+        ValueError: If the path doesn't point to a PDF file.
+    """
+    path = Path(path)
+
+    if not path.exists():
+        raise FileNotFoundError(f"PDF file not found: {path}")
+
+    if not path.suffix.lower() == ".pdf":
+        raise ValueError(f"Expected a PDF file, got: {path.suffix}")
+
+    try:
+        reader = PdfReader(path)
+        text_parts: list[str] = []
+
+        for page in reader.pages:
+            page_text = page.extract_text()
+            if page_text:
+                text_parts.append(page_text)
+
+        return "\n".join(text_parts)
+    except PdfReadError as e:
+        raise PdfReadError(f"Failed to read PDF '{path}': {e}") from e
+
+
+def extract_text_from_bytes(pdf_bytes: bytes) -> str:
+    """Extract all text content from PDF bytes.
+
+    Args:
+        pdf_bytes: Raw PDF file content as bytes.
+
+    Returns:
+        Extracted text content from all pages, with pages separated by newlines.
+
+    Raises:
+        PdfReadError: If the PDF is corrupted or password-protected.
+    """
+    from io import BytesIO
+
+    try:
+        reader = PdfReader(BytesIO(pdf_bytes))
+        text_parts: list[str] = []
+
+        for page in reader.pages:
+            page_text = page.extract_text()
+            if page_text:
+                text_parts.append(page_text)
+
+        return "\n".join(text_parts)
+    except PdfReadError as e:
+        raise PdfReadError(f"Failed to read PDF from bytes: {e}") from e

--- a/packages/pdf-context/src/pdf_context/formatter.py
+++ b/packages/pdf-context/src/pdf_context/formatter.py
@@ -1,0 +1,79 @@
+"""Context formatting module.
+
+Provides functions to format extracted text for LLM context injection.
+"""
+
+from pathlib import Path
+
+from .extractor import extract_text_from_pdf
+
+
+def format_as_context(text: str, filename: str) -> str:
+    """Format extracted text with delimiters for context injection.
+
+    Wraps the text with clear delimiters indicating the source file,
+    making it easy for LLMs to understand the context boundaries.
+
+    Args:
+        text: The extracted text content.
+        filename: The name of the source file (for labeling).
+
+    Returns:
+        Formatted text with file delimiters.
+    """
+    return (
+        f"\n\n--- Content of attached file '{filename}' ---\n"
+        f"{text}\n"
+        f"--- End of file ---\n"
+    )
+
+
+def process_pdf_file(path: str | Path, filename: str | None = None) -> str:
+    """Extract text from a PDF and format it for context injection.
+
+    Convenience function that combines extraction and formatting.
+
+    Args:
+        path: Path to the PDF file.
+        filename: Optional display name for the file.
+                  If not provided, uses the file's basename.
+
+    Returns:
+        Formatted text ready for context injection.
+
+    Raises:
+        FileNotFoundError: If the PDF file doesn't exist.
+        PdfReadError: If the PDF is corrupted or password-protected.
+    """
+    path = Path(path)
+    display_name = filename if filename else path.name
+
+    text = extract_text_from_pdf(path)
+    return format_as_context(text, display_name)
+
+
+def process_multiple_files(paths: list[str | Path]) -> str:
+    """Process multiple PDF files and combine their context.
+
+    Args:
+        paths: List of paths to PDF files.
+
+    Returns:
+        Combined formatted text from all files.
+
+    Raises:
+        FileNotFoundError: If any PDF file doesn't exist.
+        PdfReadError: If any PDF is corrupted or password-protected.
+    """
+    results: list[str] = []
+
+    for path in paths:
+        try:
+            formatted = process_pdf_file(path)
+            results.append(formatted)
+        except Exception as e:
+            # Include error message in context so LLM knows about the failure
+            path_obj = Path(path)
+            results.append(f"\n\nError reading PDF '{path_obj.name}': {e!s}\n")
+
+    return "".join(results)

--- a/packages/sample/pyproject.toml
+++ b/packages/sample/pyproject.toml
@@ -1,7 +1,0 @@
-[project]
-name = "sample-package"
-version = "0.1.0"
-description = "Sample shared package"
-readme = "README.md"
-requires-python = ">=3.13"
-dependencies = []

--- a/packages/sample/src/sample_package/__init__.py
+++ b/packages/sample/src/sample_package/__init__.py
@@ -1,5 +1,0 @@
-"""Sample Shared Package"""
-
-
-def sample_function() -> str:
-    return "Hello from sample package"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "admin",
     "ingestion",
     "cli",
-    "sample-package",
+    "pdf-context",
     "reflex-chat",
 ]
 
@@ -18,7 +18,7 @@ chainlit-chat = { workspace = true }
 admin = { workspace = true }
 ingestion = { workspace = true }
 cli = { workspace = true }
-sample-package = { workspace = true }
+pdf-context = { workspace = true }
 reflex-chat = { workspace = true }
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -8,9 +8,9 @@ members = [
     "chainlit-chat",
     "cli",
     "ingestion",
+    "pdf-context",
     "rag-facile",
     "reflex-chat",
-    "sample-package",
 ]
 
 [[package]]
@@ -339,7 +339,7 @@ source = { editable = "apps/chainlit-chat" }
 dependencies = [
     { name = "chainlit" },
     { name = "openai" },
-    { name = "pypdf" },
+    { name = "pdf-context" },
     { name = "python-dotenv" },
 ]
 
@@ -347,7 +347,7 @@ dependencies = [
 requires-dist = [
     { name = "chainlit", specifier = ">=1.3.0" },
     { name = "openai", specifier = ">=1.0.0" },
-    { name = "pypdf", specifier = ">=5.0.0" },
+    { name = "pdf-context", editable = "packages/pdf-context" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
 ]
 
@@ -1902,6 +1902,17 @@ wheels = [
 ]
 
 [[package]]
+name = "pdf-context"
+version = "0.1.0"
+source = { editable = "packages/pdf-context" }
+dependencies = [
+    { name = "pypdf" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pypdf", specifier = ">=5.0.0" }]
+
+[[package]]
 name = "pillow"
 version = "12.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2280,8 +2291,8 @@ dependencies = [
     { name = "chainlit-chat" },
     { name = "cli" },
     { name = "ingestion" },
+    { name = "pdf-context" },
     { name = "reflex-chat" },
-    { name = "sample-package" },
 ]
 
 [package.dev-dependencies]
@@ -2297,8 +2308,8 @@ requires-dist = [
     { name = "chainlit-chat", editable = "apps/chainlit-chat" },
     { name = "cli", editable = "apps/cli" },
     { name = "ingestion", editable = "apps/ingestion" },
+    { name = "pdf-context", editable = "packages/pdf-context" },
     { name = "reflex-chat", editable = "apps/reflex-chat" },
-    { name = "sample-package", editable = "packages/sample" },
 ]
 
 [package.metadata.requires-dev]
@@ -2481,11 +2492,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/87/44/90fa543014c45560cae1fffc63ea059fb3575ee6e1cb654562197e5d16fb/ruff-0.14.14-py3-none-win_amd64.whl", hash = "sha256:3dde1435e6b6fe5b66506c1dff67a421d0b7f6488d466f651c07f4cab3bf20fd", size = 11630486, upload-time = "2026-01-22T22:30:10.852Z" },
     { url = "https://files.pythonhosted.org/packages/9e/6a/40fee331a52339926a92e17ae748827270b288a35ef4a15c9c8f2ec54715/ruff-0.14.14-py3-none-win_arm64.whl", hash = "sha256:56e6981a98b13a32236a72a8da421d7839221fa308b223b9283312312e5ac76c", size = 10920448, upload-time = "2026-01-22T22:30:15.417Z" },
 ]
-
-[[package]]
-name = "sample-package"
-version = "0.1.0"
-source = { editable = "packages/sample" }
 
 [[package]]
 name = "shellingham"


### PR DESCRIPTION
## Summary

Extracted PDF context injection functionality into a reusable `pdf-context` package and updated templates to support standalone app generation with this dependency.

### Changes

- **New Package**: `packages/pdf-context` with `extractor.py` and `formatter.py`.
- **Chainlit App**: Refactored to use the new package and bumped python version to `>=3.13`.
- **Template Generation**: 
  - Updated `gen_template.py` to bundle `pdf-context` into generated apps.
  - Fixed `ast-grep` warnings by suppressing pnpm logs.
- **Cleanup**: Removed `packages/sample`.

## Verification

- [x] `uv sync` passes in workspace.
- [x] `ty check` and `ruff check` pass.
- [x] `just gen-templates` runs without warnings.
- [x] Standalone app creation verified with `just create-app`.