### PR TITLE
feat: integrate release-please for unified monorepo versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,6 @@
+{
+  "apps/cli": "0.1.0",
+  "apps/chainlit-chat": "0.1.0",
+  "apps/reflex-chat": "0.1.0",
+  "packages/pdf-context": "0.1.0"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,77 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-02-03
+
+### Added
+
+- **CLI Enhancements** (#18, #17)
+  - Rename CLI to `rag-facile` for consistency
+  - Add ASCII banner on CLI startup for better UX
+  - Add Justfile for generated projects to simplify common tasks
+  - Make CLI installable via `uv tool install` for easy distribution
+
+- **Bootstrap Installer** (#16)
+  - Create comprehensive bootstrap installer (`install.sh`)
+  - Bundle templates into CLI at build time for zero-dependency deployment
+  - Support for system prerequisites auto-installation on Debian/Ubuntu
+
+- **Template System Overhaul** (#14, #7)
+  - Refactor from simple string templates to Moon codegen for production-grade template handling
+  - Implement hybrid LibCST + ast-grep pipeline for intelligent code transformation
+  - Support code-aware template generation for Python and other languages
+
+- **Application Templates** (#5, #6)
+  - Add `chainlit-chat` template with Grit-based code generation
+  - Add support for `reflex-chat` in template generation CLI
+  - Enable template generation CLI to scaffold multiple app types
+
+- **Core Applications** (#4, #3)
+  - Implement `chainlit-chat` application with Albert API integration
+  - Add `reflex-chat` application with Albert API support
+  - Integrate PDF context support in reflex-chat for document-aware RAG
+
+- **PDF Context Package** (#12, #13)
+  - Extract PDF context handling into reusable `pdf-context` package
+  - Add PDF context support to reflex-chat application
+  - Implement refined UI for PDF interaction
+
+- **Workspace Generation** (#15)
+  - Create `rf generate` command for one-command workspace scaffolding
+  - Enable rapid project initialization with all necessary boilerplate
+
+- **Development Tools & Documentation** (#8, #9, #10, #11, #2)
+  - Add direnv configuration for automatic environment setup
+  - Separate user-facing and contributor documentation
+  - Add AGENTS.md with comprehensive project knowledge
+  - Clarify available vs planned application templates in README
+
+### Initial Release
+
+- Project setup with monorepo structure using moonrepo and uv
+- Foundation for multi-app RAG framework targeting French government use cases
+- Python 3.13+ codebase with ruff (linting/formatting) and ty (type checking)
+- Extensible template system for scaffolding new applications
+
+---
+
+## How to Read This Changelog
+
+- **Added**: New features and capabilities
+- **Changed**: Modifications to existing features
+- **Fixed**: Bug fixes
+- **Deprecated**: Features marked for future removal
+- **Removed**: Features that have been removed
+- **Security**: Security-related fixes
+
+## Release History
+
+| Version | Date | Notes |
+|---------|------|-------|
+| 0.1.0 | 2026-02-03 | Initial release with core RAG framework and applications |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,77 @@ rag-facile generate workspace my-rag-app
 
 The install script will automatically install other prerequisites (git, xz-utils) on Debian/Ubuntu.
 
+## Commit Messages
+
+We use [Conventional Commits](https://www.conventionalcommits.org/) for consistent versioning and changelogs. This enables automated release management via [release-please](https://github.com/googleapis/release-please).
+
+### Format
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Types
+
+Use these prefixes to indicate how commits should affect versioning:
+
+- **`feat:`** - New feature (minor version bump)
+- **`fix:`** - Bug fix (patch version bump)
+- **`feat!:` or `fix!:`** - Breaking change (major version bump)
+- **`docs:`** - Documentation changes (no release)
+- **`chore:`** - Internal changes (no release)
+- **`refactor:`** - Code reorganization (no release unless with `!`)
+
+### Examples
+
+**Single feature:**
+```bash
+git commit -m "feat: add support for PDF annotations"
+```
+
+**Bug fix:**
+```bash
+git commit -m "fix: resolve memory leak in pdf-context"
+```
+
+**Multiple changes in one commit:**
+```bash
+git commit -m "feat: add PDF viewer
+
+This adds comprehensive PDF viewing capabilities
+to reflex-chat.
+
+fix: resolve rendering bug in pdf-context
+Fixes #245"
+```
+
+**Breaking change:**
+```bash
+git commit -m "feat!: redesign CLI command interface
+
+BREAKING CHANGE: the old 'rf init' command is now 'rf generate init'"
+```
+
+### Automated Releases
+
+When commits with conventional prefixes (`feat:`, `fix:`, etc.) are merged to main, release-please automatically:
+
+1. Creates a Release PR with:
+   - Version bumps for affected packages
+   - Generated changelog entries from commits
+   - Updated `CHANGELOG.md` files
+
+2. When the Release PR is merged:
+   - Versions are locked in `pyproject.toml`
+   - GitHub Release is created with release notes
+   - Commit is tagged with version number
+
+**No manual steps needed!** Just use conventional commits and release-please handles the rest.
+
 ## CI Checks
 
 The CI pipeline runs:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "python",
+  "changelog-path": "CHANGELOG.md",
+  "packages": {
+    "apps/cli": {
+      "changelog-path": "CHANGELOG.md",
+      "version-file": "pyproject.toml",
+      "release-type": "python",
+      "component": "cli"
+    },
+    "apps/chainlit-chat": {
+      "changelog-path": "CHANGELOG.md",
+      "version-file": "pyproject.toml",
+      "release-type": "python",
+      "component": "chainlit-chat"
+    },
+    "apps/reflex-chat": {
+      "changelog-path": "CHANGELOG.md",
+      "version-file": "pyproject.toml",
+      "release-type": "python",
+      "component": "reflex-chat"
+    },
+    "packages/pdf-context": {
+      "changelog-path": "CHANGELOG.md",
+      "version-file": "pyproject.toml",
+      "release-type": "python",
+      "component": "pdf-context"
+    }
+  },
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "groupName": "rag-facile",
+      "components": [
+        "cli",
+        "chainlit-chat",
+        "reflex-chat",
+        "pdf-context"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Integrate release-please with the `linked-versions` plugin to automate versioning and changelog generation across all packages and apps. All components (cli, chainlit-chat, reflex-chat, pdf-context) will maintain a single, unified version number.

## Changes

- **`.release-please-manifest.json`**: Version tracking for all packages
- **`release-please-config.json`**: Monorepo setup with linked-versions plugin (all packages bump together)
- **`.github/workflows/release.yml`**: GitHub Action that runs on pushes to main
- **`CONTRIBUTING.md`**: Added Conventional Commits guide and release workflow documentation

## How It Works

1. Developers write conventional commits (`feat:`, `fix:`, `feat!:`, etc.)
2. release-please detects releasable commits and creates a Release PR
3. Release PR shows all changes and bumps versions in all `pyproject.toml` files together
4. All changelogs are generated from commit messages
5. Merging the Release PR triggers tagging and GitHub Release creation

## Unified Versioning

The `linked-versions` plugin ensures all packages maintain the same version number:
- If any package has a feature → all bump to minor version
- If only bugfixes → all bump to patch version
- If breaking changes → all bump to major version

## Next Steps

1. Merge this PR to main
2. Wait ~5 minutes for GitHub Action to run
3. Review the automatically created Release PR
4. Merge Release PR to trigger tagging and GitHub Release

🐿️ Generated with [Letta Code](https://letta.com)