### PR TITLE
feat: add standalone project structure option for simpler setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ rag-facile generate workspace my-rag-app
 ```
 
 The CLI will guide you through:
-1. **Frontend selection** - Choose Chainlit or Reflex
-2. **Module selection** - Add PDF processing, vector stores, etc.
-3. **Environment configuration** - Set your Albert API key and preferences
+1. **Project structure** - Choose Simple or Monorepo (see below)
+2. **Frontend selection** - Choose Chainlit or Reflex
+3. **Module selection** - Add PDF processing, vector stores, etc.
+4. **Environment configuration** - Set your Albert API key and preferences
 
 After configuration, the CLI automatically:
 - Generates your workspace with the selected components
@@ -55,6 +56,83 @@ After configuration, the CLI automatically:
 - Starts the development server
 
 Your app will open in the browser, ready to use!
+
+## Project Structure Options
+
+When generating a workspace, you'll choose between two project structures:
+
+### Simple (Recommended for Getting Started)
+
+Best for: **Quick prototypes, single-app deployments, learning RAG Facile**
+
+```
+my-rag-app/
+├── pyproject.toml      # All dependencies in one place
+├── .env                # Your API credentials
+├── app.py              # Your application code
+├── context_loader.py   # Module loading logic
+├── modules.yml         # Enabled modules configuration
+├── chainlit.md         # Chat welcome message (Chainlit only)
+└── pdf_context/        # PDF module (if selected)
+```
+
+**Advantages:**
+- ✅ Familiar single-project structure
+- ✅ No build tools to learn (just `uv`)
+- ✅ Easy to understand and modify
+- ✅ Simple deployment
+
+**Run your app:**
+```bash
+cd my-rag-app
+uv run chainlit run app.py -w    # For Chainlit
+uv run reflex run                 # For Reflex
+```
+
+### Monorepo (For Multi-App Projects)
+
+Best for: **Team projects, multiple apps sharing code, production deployments**
+
+```
+my-rag-app/
+├── .moon/              # Moon workspace configuration
+│   ├── templates/      # Templates for adding new apps
+│   ├── toolchain.yml   # Python/uv configuration
+│   └── workspace.yml   # Workspace settings
+├── apps/
+│   └── chainlit-chat/  # Your selected frontend app
+│       ├── app.py
+│       ├── .env        # Your API credentials
+│       └── ...
+├── packages/
+│   └── pdf-context/    # Shared modules
+├── justfile            # Common commands
+└── pyproject.toml      # Workspace root
+```
+
+**Advantages:**
+- ✅ Multiple apps can share packages
+- ✅ Consistent tooling across apps
+- ✅ Easy to add new apps with `just add <template>`
+- ✅ Built-in task runner with Moon
+
+**Run your app:**
+```bash
+cd my-rag-app
+just run chainlit-chat    # Run specific app
+just run                  # Run all apps
+```
+
+### Which Should I Choose?
+
+| Scenario | Recommendation |
+|----------|----------------|
+| First time using RAG Facile | **Simple** |
+| Building a quick prototype | **Simple** |
+| Single application deployment | **Simple** |
+| Multiple related apps | **Monorepo** |
+| Team with shared components | **Monorepo** |
+| Need to add apps later | **Monorepo** |
 
 ## Available Components
 
@@ -80,39 +158,27 @@ To upgrade to the latest version, re-run the installer:
 curl -fsSL https://raw.githubusercontent.com/etalab-ia/rag-facile/main/install.sh | bash
 ```
 
-## Generated Workspace Structure
-
-After running `rag-facile generate workspace`, you'll have:
-
-```
-my-rag-app/
-├── .moon/              # Moon configuration
-│   ├── templates/      # Available templates for future expansion
-│   ├── toolchain.yml   # Python/uv configuration
-│   └── workspace.yml   # Workspace settings
-├── apps/
-│   └── chainlit-chat/  # Your selected frontend app
-│       ├── app.py
-│       ├── .env        # Your API credentials
-│       └── ...
-├── packages/
-│   └── pdf-context/    # Selected modules
-├── .python-version     # Pinned to Python 3.13
-├── justfile            # Common commands (just dev, just check, etc.)
-└── pyproject.toml      # Workspace dependencies
-```
-
 ## Running Your App
 
-After generation, use the justfile commands:
+### Simple Structure
 
 ```bash
 cd my-rag-app
-just run                    # Run all apps
-just run chainlit-chat      # Run a specific app
+uv run chainlit run app.py -w    # Chainlit with hot-reload
+uv run reflex run                 # Reflex
 ```
 
-### Available Commands
+### Monorepo Structure
+
+Use the justfile commands:
+
+```bash
+cd my-rag-app
+just run chainlit-chat      # Run a specific app
+just run                    # Run all apps
+```
+
+#### Available Monorepo Commands
 
 | Command | Description |
 |---------|-------------|

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -52,16 +52,21 @@ rag-facile version
 
 ### `generate workspace`
 
-Generates a new RAG workspace with your choice of frontend and modules.
+Generates a new RAG workspace with your choice of structure, frontend, and modules.
 
 ```bash
 rag-facile generate workspace <name>
 ```
 
 The CLI will guide you through:
-1. **Frontend selection** - Choose Chainlit or Reflex
-2. **Module selection** - Add PDF processing, vector stores, etc.
-3. **Environment configuration** - Set your Albert API key and preferences
+1. **Project structure** - Choose between:
+   - **Simple** - Flat structure, single app, easy to understand (recommended for getting started)
+   - **Monorepo** - Multi-app workspace with shared packages (for larger projects)
+2. **Frontend selection** - Choose Chainlit or Reflex
+3. **Module selection** - Add PDF processing, vector stores, etc.
+4. **Environment configuration** - Set your Albert API key and preferences
+
+See the main [README](../../README.md) for detailed comparison of project structures.
 
 ## Development
 

--- a/apps/cli/pyproject.toml
+++ b/apps/cli/pyproject.toml
@@ -30,3 +30,4 @@ packages = ["src/cli"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "../../.moon/templates" = "cli/templates"
+"../../packages/pdf-context/src/pdf_context" = "cli/pdf_context_src"

--- a/apps/cli/src/cli/commands/generate.py
+++ b/apps/cli/src/cli/commands/generate.py
@@ -490,16 +490,7 @@ def workspace(
             console.print("[yellow]Aborted.[/yellow]")
             raise typer.Exit(0)
 
-    # Select frontend
-    frontend_choice = questionary.select(
-        "Select your frontend app:",
-        choices=list(FRONTENDS.keys()),
-    ).ask()
-    if not frontend_choice:
-        console.print("[red]Aborted.[/red]")
-        raise typer.Exit(1)
-
-    # Select project structure
+    # Select project structure first
     structure_choice = questionary.select(
         "What type of project structure do you want?",
         choices=list(PROJECT_STRUCTURES.keys()),
@@ -509,6 +500,15 @@ def workspace(
         raise typer.Exit(1)
 
     is_standalone = PROJECT_STRUCTURES[structure_choice] == "standalone"
+
+    # Select frontend
+    frontend_choice = questionary.select(
+        "Select your frontend app:",
+        choices=list(FRONTENDS.keys()),
+    ).ask()
+    if not frontend_choice:
+        console.print("[red]Aborted.[/red]")
+        raise typer.Exit(1)
 
     # Select modules (multi-select)
     module_choices = questionary.checkbox(

--- a/apps/cli/src/cli/commands/generate.py
+++ b/apps/cli/src/cli/commands/generate.py
@@ -135,6 +135,12 @@ MODULES = {
     "Chroma": {"template": "chroma-context", "available": False},
 }
 
+# Project structure options
+PROJECT_STRUCTURES = {
+    "Simple (recommended for getting started)": "standalone",
+    "Monorepo (for multi-app projects)": "monorepo",
+}
+
 
 def get_templates_dir() -> Path:
     """Get the templates directory bundled with the CLI package."""
@@ -152,6 +158,278 @@ def get_templates_dir() -> Path:
     raise FileNotFoundError(
         "Templates not found. This is a packaging error - please reinstall the CLI."
     )
+
+
+def get_pdf_context_source() -> Path:
+    """Get the pdf-context source directory for inline copying."""
+    # In development mode, use the packages directory
+    repo_root = Path(__file__).resolve().parents[5]
+    local_source = repo_root / "packages" / "pdf-context" / "src" / "pdf_context"
+    if local_source.exists():
+        return local_source
+
+    # For installed CLI, pdf_context is bundled at cli/pdf_context_src
+    package_source = Path(__file__).resolve().parent.parent / "pdf_context_src"
+    if package_source.exists():
+        return package_source
+
+    raise FileNotFoundError(
+        "pdf-context source not found. This is a packaging error - please reinstall the CLI."
+    )
+
+
+def render_template_file(template_path: Path, variables: dict[str, str | bool]) -> str:
+    """Render a template file with Tera-style variables.
+
+    Handles simple variable substitution like {{ var }} and conditionals.
+    For complex templates, we copy and do simple replacements.
+    """
+    content = template_path.read_text()
+
+    # Simple variable substitution (Tera-style: {{ var }})
+    for key, value in variables.items():
+        if isinstance(value, bool):
+            continue  # Skip booleans, handled by conditionals
+        content = content.replace("{{ " + key + " }}", str(value))
+        # Also handle filter syntax like {{ project_name | replace(from='-', to='_') }}
+        snake_key = str(value).replace("-", "_")
+        content = content.replace(
+            "{{ " + key + " | replace(from='-', to='_') }}", snake_key
+        )
+
+    # Handle Tera conditionals: {%- if var %}...{%- endif %}
+    import re
+
+    # Process each conditional block
+    for key, value in variables.items():
+        if not isinstance(value, bool):
+            continue
+
+        # Pattern for {%- if var %}...{%- endif %}
+        pattern = rf"\{{% ?-? ?if {key} ?%\}}(.*?)\{{% ?-? ?endif ?%\}}"
+        if value:
+            # Keep the content, remove the tags
+            content = re.sub(pattern, r"\1", content, flags=re.DOTALL)
+        else:
+            # Remove the entire block
+            content = re.sub(pattern, "", content, flags=re.DOTALL)
+
+    return content
+
+
+def generate_standalone(
+    target_path: Path,
+    target_display: str,
+    frontend_choice: str,
+    selected_modules: list[str],
+    env_config: dict[str, str],
+    force: bool,
+) -> None:
+    """Generate a standalone (non-monorepo) project structure."""
+    templates_dir = get_templates_dir()
+    frontend_template = FRONTENDS[frontend_choice]
+    template_dir = templates_dir / frontend_template
+
+    # Template variables
+    project_name = target_path.name
+    variables: dict[str, str | bool] = {
+        "project_name": project_name,
+        "description": f"{project_name} - RAG application",
+        "openai_api_key": env_config["openai_api_key"],
+        "openai_base_url": env_config["openai_base_url"],
+        "openai_model": env_config["openai_model"],
+        "system_prompt": "You are a helpful assistant.",
+        "use_pdf": "PDF" in selected_modules,
+        "use_chroma": "Chroma" in selected_modules,
+        "welcome_message": f"Welcome to {project_name}!",
+    }
+
+    # Step 1: Create target directory
+    console.print()
+    console.print("[bold green]Step 1:[/bold green] Creating project directory...")
+    if not target_path.exists():
+        target_path.mkdir(parents=True)
+    console.print("[green]✓[/green] Directory created")
+
+    # Step 2: Generate standalone pyproject.toml
+    console.print()
+    console.print("[bold green]Step 2:[/bold green] Generating project files...")
+
+    # Create pyproject.toml for standalone mode
+    pdf_dep = '\n    "pypdf>=5.0.0",' if "PDF" in selected_modules else ""
+    setuptools_packages = (
+        'packages = ["pdf_context"]' if "PDF" in selected_modules else ""
+    )
+
+    # For standalone, we don't need workspace sources - pdf_context is local
+    pyproject_content = f'''[project]
+name = "{project_name}"
+version = "0.1.0"
+description = "{variables["description"]}"
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = [
+    "chainlit>=1.3.0",
+    "openai>=1.0.0",
+    "python-dotenv>=1.0.0",
+    "pyyaml>=6.0.0",{pdf_dep}
+]
+
+[tool.setuptools]
+py-modules = ["app", "context_loader"]
+{setuptools_packages}
+
+[tool.uv]
+package = true
+'''
+
+    if frontend_choice == "Reflex":
+        pyproject_content = f'''[project]
+name = "{project_name}"
+version = "0.1.0"
+description = "{variables["description"]}"
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = [
+    "reflex>=0.7.0",
+    "openai>=1.0.0",
+    "python-dotenv>=1.0.0",
+    "pyyaml>=6.0.0",{pdf_dep}
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+
+[tool.uv]
+package = true
+'''
+
+    (target_path / "pyproject.toml").write_text(pyproject_content)
+    console.print("[dim]  ✓ pyproject.toml[/dim]")
+
+    # Copy and render app files from template
+    files_to_copy = ["context_loader.py", ".env.template", "README.md"]
+
+    if frontend_choice == "Chainlit":
+        files_to_copy.extend(["app.py", "chainlit.md"])
+    else:
+        files_to_copy.extend(["rxconfig.py"])
+
+    for filename in files_to_copy:
+        src = template_dir / filename
+        if src.exists():
+            content = render_template_file(src, variables)
+            (target_path / filename).write_text(content)
+            console.print(f"[dim]  ✓ {filename}[/dim]")
+
+    # For Reflex, we also need to copy the app package directory
+    if frontend_choice == "Reflex":
+        # The template uses [project_name | replace(from='-', to='_')] as dir name
+        template_app_dir_name = "[project_name | replace(from='-', to='_')]"
+        template_app_dir = template_dir / template_app_dir_name
+        if template_app_dir.exists():
+            snake_name = project_name.replace("-", "_")
+            target_app_dir = target_path / snake_name
+            target_app_dir.mkdir(exist_ok=True)
+
+            for src_file in template_app_dir.rglob("*"):
+                if src_file.is_file():
+                    rel_path = src_file.relative_to(template_app_dir)
+                    # Rename files/dirs that contain the placeholder
+                    rel_path_str = str(rel_path).replace(
+                        "[project_name | replace(from='-', to='_')]", snake_name
+                    )
+                    target_file = target_app_dir / rel_path_str
+                    target_file.parent.mkdir(parents=True, exist_ok=True)
+                    content = render_template_file(src_file, variables)
+                    target_file.write_text(content)
+                    console.print(f"[dim]  ✓ {snake_name}/{rel_path_str}[/dim]")
+
+    # Generate modules.yml with proper content
+    modules_yml_content = "# RAG Facile Module Configuration\n"
+    modules_yml_content += "# Auto-generated based on selected modules\n\n"
+    modules_yml_content += "context_providers:\n"
+    if "PDF" in selected_modules:
+        modules_yml_content += "  pdf: pdf_context\n"
+    if "Chroma" in selected_modules:
+        modules_yml_content += "  chroma: chroma_context\n"
+
+    (target_path / "modules.yml").write_text(modules_yml_content)
+    console.print("[dim]  ✓ modules.yml[/dim]")
+
+    console.print("[green]✓[/green] Project files generated")
+
+    # Step 3: Copy pdf_context as local module if selected
+    if "PDF" in selected_modules:
+        console.print()
+        console.print("[bold green]Step 3:[/bold green] Adding PDF context module...")
+
+        try:
+            pdf_source = get_pdf_context_source()
+            target_pdf = target_path / "pdf_context"
+            if target_pdf.exists():
+                shutil.rmtree(target_pdf)
+            shutil.copytree(pdf_source, target_pdf)
+            # Remove __pycache__ if copied
+            pycache = target_pdf / "__pycache__"
+            if pycache.exists():
+                shutil.rmtree(pycache)
+            console.print("[green]✓[/green] PDF context module added")
+        except FileNotFoundError as e:
+            console.print(f"[yellow]Warning: {e}[/yellow]")
+            console.print(
+                "[yellow]You'll need to install pdf-context manually.[/yellow]"
+            )
+
+    # Step 4: Create .env file
+    step_num = 4 if "PDF" in selected_modules else 3
+    console.print()
+    console.print(
+        f"[bold green]Step {step_num}:[/bold green] Creating environment file..."
+    )
+
+    env_content = f"""\
+OPENAI_API_KEY={env_config["openai_api_key"]}
+OPENAI_BASE_URL={env_config["openai_base_url"]}
+OPENAI_MODEL={env_config["openai_model"]}
+"""
+    (target_path / ".env").write_text(env_content)
+    console.print("[green]✓[/green] Created .env file")
+
+    # Step 5: Create .python-version
+    (target_path / ".python-version").write_text("3.13\n")
+    console.print("[dim]  ✓ .python-version[/dim]")
+
+    # Done with generation!
+    console.print()
+    console.print("[bold green]✨ Project generation complete![/bold green]")
+
+    # Step 6: Install dependencies
+    step_num += 1
+    console.print()
+    console.print(
+        f"[bold green]Step {step_num}:[/bold green] Installing dependencies..."
+    )
+    if not run_command(["uv", "sync"], "install dependencies", cwd=target_path):
+        console.print("[yellow]Warning: uv sync failed. Run it manually.[/yellow]")
+
+    # Step 7: Start the dev server
+    step_num += 1
+    console.print()
+    console.print(
+        f"[bold green]Step {step_num}:[/bold green] Starting {frontend_choice} dev server..."
+    )
+    console.print()
+    console.print(f"[dim]Your app is at: {target_display}[/dim]")
+    console.print()
+
+    # Run dev server with uv (no moon in standalone mode)
+    if frontend_choice == "Chainlit":
+        dev_cmd = ["uv", "run", "chainlit", "run", "app.py", "-w"]
+    else:
+        dev_cmd = ["uv", "run", "reflex", "run"]
+
+    subprocess.run(dev_cmd, cwd=target_path)
 
 
 def run_command(cmd: list[str], description: str, cwd: Path | None = None) -> bool:
@@ -221,6 +499,17 @@ def workspace(
         console.print("[red]Aborted.[/red]")
         raise typer.Exit(1)
 
+    # Select project structure
+    structure_choice = questionary.select(
+        "What type of project structure do you want?",
+        choices=list(PROJECT_STRUCTURES.keys()),
+    ).ask()
+    if not structure_choice:
+        console.print("[red]Aborted.[/red]")
+        raise typer.Exit(1)
+
+    is_standalone = PROJECT_STRUCTURES[structure_choice] == "standalone"
+
     # Select modules (multi-select)
     module_choices = questionary.checkbox(
         "Select modules to include:",
@@ -280,6 +569,9 @@ def workspace(
     console.print()
     console.print("[bold blue]Configuration Summary[/bold blue]")
     console.print(f"  Target: {target_display}")
+    console.print(
+        f"  Structure: {'Simple (standalone)' if is_standalone else 'Monorepo'}"
+    )
     console.print(f"  Frontend: {frontend_choice}")
     console.print(
         f"  Modules: {', '.join(selected_modules) if selected_modules else 'None'}"
@@ -291,6 +583,20 @@ def workspace(
     if not questionary.confirm("Proceed with generation?", default=True).ask():
         console.print("[yellow]Aborted.[/yellow]")
         raise typer.Exit(0)
+
+    # Branch based on project structure choice
+    if is_standalone:
+        generate_standalone(
+            target_path=target_path,
+            target_display=target_display,
+            frontend_choice=frontend_choice,
+            selected_modules=selected_modules,
+            env_config=env_config,
+            force=force,
+        )
+        return  # Exit after standalone generation
+
+    # ========== MONOREPO GENERATION (existing flow) ==========
 
     # Get templates directory
     templates_dir = get_templates_dir()

--- a/apps/cli/tests/test_generate.py
+++ b/apps/cli/tests/test_generate.py
@@ -658,8 +658,8 @@ class TestWorkspaceCommand:
         mock_q = mocker.patch("cli.commands.generate.questionary")
         # Use side_effect to return different values for different select calls
         mock_q.select.return_value.ask.side_effect = [
-            "Chainlit",  # First call: frontend selection
-            "Monorepo (for multi-app projects)",  # Second call: structure selection
+            "Monorepo (for multi-app projects)",  # First call: structure selection
+            "Chainlit",  # Second call: frontend selection
         ]
         mock_q.checkbox.return_value.ask.return_value = ["PDF"]
         mock_q.confirm.return_value.ask.return_value = True
@@ -695,8 +695,8 @@ class TestWorkspaceCommand:
         # Mock questionary interactions - select standalone mode
         mock_q = mocker.patch("cli.commands.generate.questionary")
         mock_q.select.return_value.ask.side_effect = [
-            "Chainlit",  # First call: frontend selection
-            "Simple (recommended for getting started)",  # Second call: structure selection
+            "Simple (recommended for getting started)",  # First call: structure selection
+            "Chainlit",  # Second call: frontend selection
         ]
         mock_q.checkbox.return_value.ask.return_value = ["PDF"]
         mock_q.confirm.return_value.ask.return_value = True
@@ -801,8 +801,8 @@ class TestStandaloneWorkspaceCommand:
         # Mock questionary interactions - select standalone mode
         mock_q = mocker.patch("cli.commands.generate.questionary")
         mock_q.select.return_value.ask.side_effect = [
-            "Chainlit",  # First call: frontend selection
-            "Simple (recommended for getting started)",  # Second call: structure selection
+            "Simple (recommended for getting started)",  # First call: structure selection
+            "Chainlit",  # Second call: frontend selection
         ]
         mock_q.checkbox.return_value.ask.return_value = []  # No modules
         mock_q.confirm.return_value.ask.return_value = True
@@ -894,10 +894,10 @@ class TestPathNormalization:
         """Should normalize /private/tmp to /tmp in output."""
         # Create a path that looks like macOS /private/tmp
         mock_q = mocker.patch("cli.commands.generate.questionary")
-        # Need to handle both select calls (frontend and structure)
+        # Need to handle both select calls (structure and frontend)
         mock_q.select.return_value.ask.side_effect = [
-            "Chainlit",
             "Simple (recommended for getting started)",
+            "Chainlit",
         ]
         mock_q.checkbox.return_value.ask.return_value = []
         mock_q.confirm.return_value.ask.return_value = False  # Abort early
@@ -915,12 +915,12 @@ class TestPathNormalization:
 class TestStructureSelectionPrompt:
     """Tests for the project structure selection prompt."""
 
-    def test_structure_prompt_appears_after_frontend(self, mocker):
-        """Should ask for structure after frontend selection."""
+    def test_structure_prompt_appears_before_frontend(self, mocker):
+        """Should ask for structure before frontend selection."""
         mock_q = mocker.patch("cli.commands.generate.questionary")
         mock_q.select.return_value.ask.side_effect = [
-            "Chainlit",  # Frontend
-            None,  # Structure - return None to abort
+            "Simple (recommended for getting started)",  # Structure
+            None,  # Frontend - return None to abort
         ]
 
         runner.invoke(main_app, ["generate", "workspace", "/tmp/test"])
@@ -928,19 +928,18 @@ class TestStructureSelectionPrompt:
         # Should have been called twice for select
         assert mock_q.select.call_count == 2
 
-        # First call should be for frontend
+        # First call should be for structure
         first_call_prompt = mock_q.select.call_args_list[0][0][0]
-        assert "frontend" in first_call_prompt.lower()
+        assert "structure" in first_call_prompt.lower()
 
-        # Second call should be for structure
+        # Second call should be for frontend
         second_call_prompt = mock_q.select.call_args_list[1][0][0]
-        assert "structure" in second_call_prompt.lower()
+        assert "frontend" in second_call_prompt.lower()
 
     def test_aborts_when_structure_not_selected(self, mocker):
         """Should abort when user doesn't select a structure."""
         mock_q = mocker.patch("cli.commands.generate.questionary")
         mock_q.select.return_value.ask.side_effect = [
-            "Chainlit",
             None,  # No structure selected
         ]
 

--- a/apps/cli/tests/test_generate.py
+++ b/apps/cli/tests/test_generate.py
@@ -1,5 +1,7 @@
 """Tests for the generate command."""
 
+import shutil
+import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -7,7 +9,10 @@ import pytest
 from cli.commands.generate import (
     FRONTENDS,
     MODULES,
+    PROJECT_STRUCTURES,
+    get_pdf_context_source,
     get_templates_dir,
+    render_template_file,
     run_command,
 )
 from cli.main import app as main_app
@@ -95,6 +100,537 @@ class TestConstants:
         assert MODULES["Chroma"]["template"] == "chroma-context"
         assert MODULES["Chroma"]["available"] is False
 
+    def test_project_structures_has_standalone(self):
+        """Should have standalone project structure option."""
+        assert "Simple (recommended for getting started)" in PROJECT_STRUCTURES
+        assert (
+            PROJECT_STRUCTURES["Simple (recommended for getting started)"]
+            == "standalone"
+        )
+
+    def test_project_structures_has_monorepo(self):
+        """Should have monorepo project structure option."""
+        assert "Monorepo (for multi-app projects)" in PROJECT_STRUCTURES
+        assert PROJECT_STRUCTURES["Monorepo (for multi-app projects)"] == "monorepo"
+
+
+class TestGetPdfContextSource:
+    """Tests for get_pdf_context_source function."""
+
+    def test_returns_path_object(self):
+        """Should return a Path object."""
+        result = get_pdf_context_source()
+        assert isinstance(result, Path)
+
+    def test_path_ends_with_pdf_context(self):
+        """Should return path ending with pdf_context."""
+        result = get_pdf_context_source()
+        assert result.name == "pdf_context"
+
+    def test_path_exists_in_repo(self):
+        """pdf_context source should exist when running from repo."""
+        result = get_pdf_context_source()
+        assert result.exists(), f"pdf_context source not found at {result}"
+
+    def test_contains_init_file(self):
+        """pdf_context source should contain __init__.py."""
+        result = get_pdf_context_source()
+        init_file = result / "__init__.py"
+        assert init_file.exists(), f"__init__.py not found at {init_file}"
+
+    def test_contains_required_modules(self):
+        """pdf_context source should contain extractor and formatter modules."""
+        result = get_pdf_context_source()
+        assert (result / "extractor.py").exists()
+        assert (result / "formatter.py").exists()
+
+
+class TestRenderTemplateFile:
+    """Tests for render_template_file function."""
+
+    @pytest.fixture
+    def temp_template(self):
+        """Create a temporary template file for testing."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            yield Path(f.name)
+        Path(f.name).unlink(missing_ok=True)
+
+    def test_simple_variable_substitution(self, temp_template):
+        """Should substitute {{ var }} syntax."""
+        temp_template.write_text("Hello {{ name }}!")
+        result = render_template_file(temp_template, {"name": "World"})
+        assert result == "Hello World!"
+
+    def test_multiple_variables(self, temp_template):
+        """Should substitute multiple variables."""
+        temp_template.write_text("{{ greeting }} {{ name }}!")
+        result = render_template_file(
+            temp_template, {"greeting": "Hello", "name": "World"}
+        )
+        assert result == "Hello World!"
+
+    def test_replace_filter_substitution(self, temp_template):
+        """Should handle replace filter syntax."""
+        temp_template.write_text(
+            "Module: {{ project_name | replace(from='-', to='_') }}"
+        )
+        result = render_template_file(temp_template, {"project_name": "my-app"})
+        assert result == "Module: my_app"
+
+    def test_conditional_true(self, temp_template):
+        """Should keep content when condition is true."""
+        temp_template.write_text("Start{%- if use_pdf %}\nPDF content\n{%- endif %}End")
+        result = render_template_file(temp_template, {"use_pdf": True})
+        assert "PDF content" in result
+        assert "Start" in result
+        assert "End" in result
+
+    def test_conditional_false(self, temp_template):
+        """Should remove content when condition is false."""
+        temp_template.write_text("Start{%- if use_pdf %}\nPDF content\n{%- endif %}End")
+        result = render_template_file(temp_template, {"use_pdf": False})
+        assert "PDF content" not in result
+        assert "Start" in result
+        assert "End" in result
+
+    def test_multiple_conditionals(self, temp_template):
+        """Should handle multiple conditional blocks."""
+        content = (
+            """{%- if use_pdf %}PDF{%- endif %}{%- if use_chroma %}Chroma{%- endif %}"""
+        )
+        temp_template.write_text(content)
+
+        # Both true
+        result = render_template_file(
+            temp_template, {"use_pdf": True, "use_chroma": True}
+        )
+        assert "PDF" in result
+        assert "Chroma" in result
+
+        # Only pdf
+        result = render_template_file(
+            temp_template, {"use_pdf": True, "use_chroma": False}
+        )
+        assert "PDF" in result
+        assert "Chroma" not in result
+
+        # Neither
+        result = render_template_file(
+            temp_template, {"use_pdf": False, "use_chroma": False}
+        )
+        assert "PDF" not in result
+        assert "Chroma" not in result
+
+    def test_combined_variables_and_conditionals(self, temp_template):
+        """Should handle both variables and conditionals."""
+        content = """name: {{ project_name }}
+{%- if use_pdf %}
+pdf: enabled
+{%- endif %}"""
+        temp_template.write_text(content)
+        result = render_template_file(
+            temp_template, {"project_name": "test-app", "use_pdf": True}
+        )
+        assert "name: test-app" in result
+        assert "pdf: enabled" in result
+
+    def test_boolean_variables_not_substituted_as_strings(self, temp_template):
+        """Boolean variables should only affect conditionals, not be substituted as text."""
+        temp_template.write_text("Value: {{ use_pdf }}")
+        result = render_template_file(temp_template, {"use_pdf": True})
+        # Boolean should not be substituted as "True" string
+        assert result == "Value: {{ use_pdf }}"
+
+
+class TestGenerateStandalone:
+    """Tests for standalone project generation."""
+
+    @pytest.fixture
+    def standalone_target(self):
+        """Create a temporary directory for standalone generation."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir) / "test-standalone-app"
+
+    @pytest.fixture
+    def mock_standalone_deps(self, mocker):
+        """Mock dependencies for standalone generation testing."""
+        # Mock run_command to avoid actual subprocess calls
+        mock_run = mocker.patch("cli.commands.generate.run_command", return_value=True)
+        # Mock subprocess.run for dev server (doesn't matter, we won't wait for it)
+        mock_subprocess = mocker.patch("subprocess.run")
+        return {"run_command": mock_run, "subprocess": mock_subprocess}
+
+    def test_creates_target_directory(self, standalone_target, mock_standalone_deps):
+        """Should create the target directory."""
+        from cli.commands.generate import generate_standalone
+
+        assert not standalone_target.exists()
+
+        generate_standalone(
+            target_path=standalone_target,
+            target_display=str(standalone_target),
+            frontend_choice="Chainlit",
+            selected_modules=[],
+            env_config={
+                "openai_api_key": "test-key",
+                "openai_base_url": "https://api.test.com",
+                "openai_model": "gpt-4",
+            },
+            force=False,
+        )
+
+        assert standalone_target.exists()
+
+    def test_creates_pyproject_toml(self, standalone_target, mock_standalone_deps):
+        """Should create pyproject.toml with correct content."""
+        from cli.commands.generate import generate_standalone
+
+        generate_standalone(
+            target_path=standalone_target,
+            target_display=str(standalone_target),
+            frontend_choice="Chainlit",
+            selected_modules=[],
+            env_config={
+                "openai_api_key": "test-key",
+                "openai_base_url": "https://api.test.com",
+                "openai_model": "gpt-4",
+            },
+            force=False,
+        )
+
+        pyproject = standalone_target / "pyproject.toml"
+        assert pyproject.exists()
+        content = pyproject.read_text()
+        assert "chainlit>=1.3.0" in content
+        assert "openai>=1.0.0" in content
+        assert "python-dotenv>=1.0.0" in content
+
+    def test_creates_app_files(self, standalone_target, mock_standalone_deps):
+        """Should create app.py and context_loader.py."""
+        from cli.commands.generate import generate_standalone
+
+        generate_standalone(
+            target_path=standalone_target,
+            target_display=str(standalone_target),
+            frontend_choice="Chainlit",
+            selected_modules=[],
+            env_config={
+                "openai_api_key": "test-key",
+                "openai_base_url": "https://api.test.com",
+                "openai_model": "gpt-4",
+            },
+            force=False,
+        )
+
+        assert (standalone_target / "app.py").exists()
+        assert (standalone_target / "context_loader.py").exists()
+
+    def test_creates_env_file(self, standalone_target, mock_standalone_deps):
+        """Should create .env file with provided config."""
+        from cli.commands.generate import generate_standalone
+
+        generate_standalone(
+            target_path=standalone_target,
+            target_display=str(standalone_target),
+            frontend_choice="Chainlit",
+            selected_modules=[],
+            env_config={
+                "openai_api_key": "my-secret-key",
+                "openai_base_url": "https://custom.api.com",
+                "openai_model": "custom-model",
+            },
+            force=False,
+        )
+
+        env_file = standalone_target / ".env"
+        assert env_file.exists()
+        content = env_file.read_text()
+        assert "OPENAI_API_KEY=my-secret-key" in content
+        assert "OPENAI_BASE_URL=https://custom.api.com" in content
+        assert "OPENAI_MODEL=custom-model" in content
+
+    def test_creates_modules_yml(self, standalone_target, mock_standalone_deps):
+        """Should create modules.yml."""
+        from cli.commands.generate import generate_standalone
+
+        generate_standalone(
+            target_path=standalone_target,
+            target_display=str(standalone_target),
+            frontend_choice="Chainlit",
+            selected_modules=[],
+            env_config={
+                "openai_api_key": "test-key",
+                "openai_base_url": "https://api.test.com",
+                "openai_model": "gpt-4",
+            },
+            force=False,
+        )
+
+        modules_yml = standalone_target / "modules.yml"
+        assert modules_yml.exists()
+
+    def test_creates_python_version_file(self, standalone_target, mock_standalone_deps):
+        """Should create .python-version file."""
+        from cli.commands.generate import generate_standalone
+
+        generate_standalone(
+            target_path=standalone_target,
+            target_display=str(standalone_target),
+            frontend_choice="Chainlit",
+            selected_modules=[],
+            env_config={
+                "openai_api_key": "test-key",
+                "openai_base_url": "https://api.test.com",
+                "openai_model": "gpt-4",
+            },
+            force=False,
+        )
+
+        python_version = standalone_target / ".python-version"
+        assert python_version.exists()
+        assert "3.13" in python_version.read_text()
+
+    def test_copies_pdf_context_when_selected(
+        self, standalone_target, mock_standalone_deps
+    ):
+        """Should copy pdf_context module when PDF is selected."""
+        from cli.commands.generate import generate_standalone
+
+        generate_standalone(
+            target_path=standalone_target,
+            target_display=str(standalone_target),
+            frontend_choice="Chainlit",
+            selected_modules=["PDF"],
+            env_config={
+                "openai_api_key": "test-key",
+                "openai_base_url": "https://api.test.com",
+                "openai_model": "gpt-4",
+            },
+            force=False,
+        )
+
+        pdf_context = standalone_target / "pdf_context"
+        assert pdf_context.exists()
+        assert (pdf_context / "__init__.py").exists()
+        assert (pdf_context / "extractor.py").exists()
+        assert (pdf_context / "formatter.py").exists()
+
+    def test_pdf_context_not_copied_when_not_selected(
+        self, standalone_target, mock_standalone_deps
+    ):
+        """Should not copy pdf_context when PDF is not selected."""
+        from cli.commands.generate import generate_standalone
+
+        generate_standalone(
+            target_path=standalone_target,
+            target_display=str(standalone_target),
+            frontend_choice="Chainlit",
+            selected_modules=[],
+            env_config={
+                "openai_api_key": "test-key",
+                "openai_base_url": "https://api.test.com",
+                "openai_model": "gpt-4",
+            },
+            force=False,
+        )
+
+        pdf_context = standalone_target / "pdf_context"
+        assert not pdf_context.exists()
+
+    def test_pyproject_includes_pypdf_when_pdf_selected(
+        self, standalone_target, mock_standalone_deps
+    ):
+        """Should include pypdf dependency when PDF module is selected."""
+        from cli.commands.generate import generate_standalone
+
+        generate_standalone(
+            target_path=standalone_target,
+            target_display=str(standalone_target),
+            frontend_choice="Chainlit",
+            selected_modules=["PDF"],
+            env_config={
+                "openai_api_key": "test-key",
+                "openai_base_url": "https://api.test.com",
+                "openai_model": "gpt-4",
+            },
+            force=False,
+        )
+
+        pyproject = standalone_target / "pyproject.toml"
+        content = pyproject.read_text()
+        assert "pypdf>=5.0.0" in content
+        assert 'packages = ["pdf_context"]' in content
+
+    def test_modules_yml_includes_pdf_provider(
+        self, standalone_target, mock_standalone_deps
+    ):
+        """Should configure pdf provider in modules.yml when PDF selected."""
+        from cli.commands.generate import generate_standalone
+
+        generate_standalone(
+            target_path=standalone_target,
+            target_display=str(standalone_target),
+            frontend_choice="Chainlit",
+            selected_modules=["PDF"],
+            env_config={
+                "openai_api_key": "test-key",
+                "openai_base_url": "https://api.test.com",
+                "openai_model": "gpt-4",
+            },
+            force=False,
+        )
+
+        modules_yml = standalone_target / "modules.yml"
+        content = modules_yml.read_text()
+        assert "pdf: pdf_context" in content
+
+    def test_creates_chainlit_md_for_chainlit(
+        self, standalone_target, mock_standalone_deps
+    ):
+        """Should create chainlit.md for Chainlit frontend."""
+        from cli.commands.generate import generate_standalone
+
+        generate_standalone(
+            target_path=standalone_target,
+            target_display=str(standalone_target),
+            frontend_choice="Chainlit",
+            selected_modules=[],
+            env_config={
+                "openai_api_key": "test-key",
+                "openai_base_url": "https://api.test.com",
+                "openai_model": "gpt-4",
+            },
+            force=False,
+        )
+
+        assert (standalone_target / "chainlit.md").exists()
+
+    def test_calls_uv_sync(self, standalone_target, mock_standalone_deps):
+        """Should call uv sync to install dependencies."""
+        from cli.commands.generate import generate_standalone
+
+        generate_standalone(
+            target_path=standalone_target,
+            target_display=str(standalone_target),
+            frontend_choice="Chainlit",
+            selected_modules=[],
+            env_config={
+                "openai_api_key": "test-key",
+                "openai_base_url": "https://api.test.com",
+                "openai_model": "gpt-4",
+            },
+            force=False,
+        )
+
+        # Check run_command was called with uv sync
+        calls = mock_standalone_deps["run_command"].call_args_list
+        uv_sync_calls = [c for c in calls if c[0][0] == ["uv", "sync"]]
+        assert len(uv_sync_calls) == 1
+
+    def test_starts_chainlit_dev_server(self, standalone_target, mock_standalone_deps):
+        """Should start Chainlit dev server with uv run."""
+        from cli.commands.generate import generate_standalone
+
+        generate_standalone(
+            target_path=standalone_target,
+            target_display=str(standalone_target),
+            frontend_choice="Chainlit",
+            selected_modules=[],
+            env_config={
+                "openai_api_key": "test-key",
+                "openai_base_url": "https://api.test.com",
+                "openai_model": "gpt-4",
+            },
+            force=False,
+        )
+
+        # Check subprocess.run was called with chainlit command
+        calls = mock_standalone_deps["subprocess"].call_args_list
+        assert len(calls) == 1
+        cmd = calls[0][0][0]
+        assert cmd == ["uv", "run", "chainlit", "run", "app.py", "-w"]
+
+
+class TestGenerateStandaloneReflex:
+    """Tests for standalone Reflex project generation."""
+
+    @pytest.fixture
+    def standalone_target(self):
+        """Create a temporary directory for standalone generation."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir) / "test-reflex-app"
+
+    @pytest.fixture
+    def mock_standalone_deps(self, mocker):
+        """Mock dependencies for standalone generation testing."""
+        mock_run = mocker.patch("cli.commands.generate.run_command", return_value=True)
+        mock_subprocess = mocker.patch("subprocess.run")
+        return {"run_command": mock_run, "subprocess": mock_subprocess}
+
+    def test_creates_reflex_pyproject(self, standalone_target, mock_standalone_deps):
+        """Should create pyproject.toml with Reflex dependencies."""
+        from cli.commands.generate import generate_standalone
+
+        generate_standalone(
+            target_path=standalone_target,
+            target_display=str(standalone_target),
+            frontend_choice="Reflex",
+            selected_modules=[],
+            env_config={
+                "openai_api_key": "test-key",
+                "openai_base_url": "https://api.test.com",
+                "openai_model": "gpt-4",
+            },
+            force=False,
+        )
+
+        pyproject = standalone_target / "pyproject.toml"
+        assert pyproject.exists()
+        content = pyproject.read_text()
+        assert "reflex>=0.7.0" in content
+        assert "chainlit" not in content.lower()
+
+    def test_creates_rxconfig(self, standalone_target, mock_standalone_deps):
+        """Should create rxconfig.py for Reflex frontend."""
+        from cli.commands.generate import generate_standalone
+
+        generate_standalone(
+            target_path=standalone_target,
+            target_display=str(standalone_target),
+            frontend_choice="Reflex",
+            selected_modules=[],
+            env_config={
+                "openai_api_key": "test-key",
+                "openai_base_url": "https://api.test.com",
+                "openai_model": "gpt-4",
+            },
+            force=False,
+        )
+
+        assert (standalone_target / "rxconfig.py").exists()
+
+    def test_starts_reflex_dev_server(self, standalone_target, mock_standalone_deps):
+        """Should start Reflex dev server with uv run."""
+        from cli.commands.generate import generate_standalone
+
+        generate_standalone(
+            target_path=standalone_target,
+            target_display=str(standalone_target),
+            frontend_choice="Reflex",
+            selected_modules=[],
+            env_config={
+                "openai_api_key": "test-key",
+                "openai_base_url": "https://api.test.com",
+                "openai_model": "gpt-4",
+            },
+            force=False,
+        )
+
+        calls = mock_standalone_deps["subprocess"].call_args_list
+        assert len(calls) == 1
+        cmd = calls[0][0][0]
+        assert cmd == ["uv", "run", "reflex", "run"]
+
 
 class TestWorkspaceCommand:
     """Integration tests for workspace generation."""
@@ -114,14 +650,18 @@ class TestWorkspaceCommand:
             assert result.exit_code == 1
 
     @pytest.fixture
-    def mock_generation(self, mocker, tmp_path):
-        """Mock all external calls for workspace generation."""
+    def mock_generation_monorepo(self, mocker, tmp_path):
+        """Mock all external calls for monorepo workspace generation."""
         # Mock shutil.which to pretend moon is installed
         mocker.patch("shutil.which", return_value="/usr/bin/moon")
 
-        # Mock questionary interactions
+        # Mock questionary interactions - select monorepo mode
         mock_q = mocker.patch("cli.commands.generate.questionary")
-        mock_q.select.return_value.ask.return_value = "Chainlit"
+        # Use side_effect to return different values for different select calls
+        mock_q.select.return_value.ask.side_effect = [
+            "Chainlit",  # First call: frontend selection
+            "Monorepo (for multi-app projects)",  # Second call: structure selection
+        ]
         mock_q.checkbox.return_value.ask.return_value = ["PDF"]
         mock_q.confirm.return_value.ask.return_value = True
         mock_q.text.return_value.ask.return_value = "test-value"
@@ -146,6 +686,44 @@ class TestWorkspaceCommand:
             "copytree": mock_copytree,
             "tmp_path": tmp_path,
         }
+
+    @pytest.fixture
+    def mock_generation_standalone(self, mocker, tmp_path):
+        """Mock all external calls for standalone workspace generation."""
+        # Mock shutil.which to pretend tools are installed
+        mocker.patch("shutil.which", return_value="/usr/bin/uv")
+
+        # Mock questionary interactions - select standalone mode
+        mock_q = mocker.patch("cli.commands.generate.questionary")
+        mock_q.select.return_value.ask.side_effect = [
+            "Chainlit",  # First call: frontend selection
+            "Simple (recommended for getting started)",  # Second call: structure selection
+        ]
+        mock_q.checkbox.return_value.ask.return_value = ["PDF"]
+        mock_q.confirm.return_value.ask.return_value = True
+        mock_q.text.return_value.ask.return_value = "test-value"
+
+        # Mock subprocess.run
+        mock_run = mocker.patch("subprocess.run")
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+
+        # Mock run_command for uv sync
+        mock_run_cmd = mocker.patch(
+            "cli.commands.generate.run_command", return_value=True
+        )
+
+        return {
+            "questionary": mock_q,
+            "subprocess_run": mock_run,
+            "run_command": mock_run_cmd,
+            "tmp_path": tmp_path,
+        }
+
+    # Legacy fixture name for backwards compatibility
+    @pytest.fixture
+    def mock_generation(self, mock_generation_monorepo):
+        """Alias for mock_generation_monorepo for backwards compatibility."""
+        return mock_generation_monorepo
 
     def test_workspace_generation_flow(self, mock_generation, tmp_path):
         """Should execute the full generation flow."""
@@ -212,6 +790,102 @@ class TestWorkspaceCommand:
         assert mock_generation["copytree"].call_count >= 1
 
 
+class TestStandaloneWorkspaceCommand:
+    """Integration tests for standalone workspace generation via CLI."""
+
+    @pytest.fixture
+    def mock_standalone_cli(self, mocker, tmp_path):
+        """Mock all external calls for standalone CLI generation."""
+        # Mock shutil.which to pretend tools are installed
+        mocker.patch("shutil.which", return_value="/usr/bin/uv")
+
+        # Mock questionary interactions - select standalone mode
+        mock_q = mocker.patch("cli.commands.generate.questionary")
+        mock_q.select.return_value.ask.side_effect = [
+            "Chainlit",  # First call: frontend selection
+            "Simple (recommended for getting started)",  # Second call: structure selection
+        ]
+        mock_q.checkbox.return_value.ask.return_value = []  # No modules
+        mock_q.confirm.return_value.ask.return_value = True
+        mock_q.text.return_value.ask.return_value = "test-value"
+
+        # Mock subprocess.run for dev server
+        mock_run = mocker.patch("subprocess.run")
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+
+        # Mock run_command for uv sync
+        mock_run_cmd = mocker.patch(
+            "cli.commands.generate.run_command", return_value=True
+        )
+
+        return {
+            "questionary": mock_q,
+            "subprocess_run": mock_run,
+            "run_command": mock_run_cmd,
+            "tmp_path": tmp_path,
+        }
+
+    def test_standalone_generation_via_cli(self, mock_standalone_cli, tmp_path):
+        """Should generate standalone project via CLI."""
+        target = tmp_path / "standalone-app"
+
+        result = runner.invoke(main_app, ["generate", "workspace", str(target)])
+
+        assert result.exit_code == 0, f"Failed with: {result.output}"
+        assert "Project generation complete" in result.output
+
+    def test_standalone_creates_flat_structure(self, mock_standalone_cli, tmp_path):
+        """Should create files at root, not in apps/ subdirectory."""
+        target = tmp_path / "standalone-app"
+
+        runner.invoke(main_app, ["generate", "workspace", str(target)])
+
+        # Files should be at root, not in apps/
+        assert (target / "pyproject.toml").exists()
+        assert (target / "app.py").exists()
+        assert not (target / "apps").exists()
+        assert not (target / ".moon").exists()
+
+    def test_standalone_does_not_run_moon_init_or_generate(
+        self, mock_standalone_cli, tmp_path
+    ):
+        """Should not run moon init or generate commands in standalone mode."""
+        target = tmp_path / "standalone-app"
+
+        runner.invoke(main_app, ["generate", "workspace", str(target)])
+
+        # Check no moon init/generate commands were called
+        # (moon --version is allowed for toolchain verification)
+        calls = mock_standalone_cli["subprocess_run"].call_args_list
+        moon_init_calls = [c for c in calls if "moon" in str(c) and "init" in str(c)]
+        moon_generate_calls = [
+            c for c in calls if "moon" in str(c) and "generate" in str(c)
+        ]
+        assert len(moon_init_calls) == 0, "moon init should not be called"
+        assert len(moon_generate_calls) == 0, "moon generate should not be called"
+
+    def test_standalone_runs_uv_commands(self, mock_standalone_cli, tmp_path):
+        """Should run uv commands in standalone mode."""
+        target = tmp_path / "standalone-app"
+
+        runner.invoke(main_app, ["generate", "workspace", str(target)])
+
+        # Check uv sync was called
+        calls = mock_standalone_cli["run_command"].call_args_list
+        uv_calls = [c for c in calls if "uv" in str(c[0][0])]
+        assert len(uv_calls) >= 1
+
+    def test_standalone_shows_simple_structure_in_summary(
+        self, mock_standalone_cli, tmp_path
+    ):
+        """Should show 'Simple (standalone)' in configuration summary."""
+        target = tmp_path / "standalone-app"
+
+        result = runner.invoke(main_app, ["generate", "workspace", str(target)])
+
+        assert "Simple (standalone)" in result.output
+
+
 class TestPathNormalization:
     """Tests for macOS path normalization."""
 
@@ -219,7 +893,11 @@ class TestPathNormalization:
         """Should normalize /private/tmp to /tmp in output."""
         # Create a path that looks like macOS /private/tmp
         mock_q = mocker.patch("cli.commands.generate.questionary")
-        mock_q.select.return_value.ask.return_value = "Chainlit"
+        # Need to handle both select calls (frontend and structure)
+        mock_q.select.return_value.ask.side_effect = [
+            "Chainlit",
+            "Simple (recommended for getting started)",
+        ]
         mock_q.checkbox.return_value.ask.return_value = []
         mock_q.confirm.return_value.ask.return_value = False  # Abort early
 
@@ -231,3 +909,41 @@ class TestPathNormalization:
         # Output should show /tmp not /private/tmp
         if "/private/tmp" in result.output:
             pytest.fail("Output contains /private/tmp instead of /tmp")
+
+
+class TestStructureSelectionPrompt:
+    """Tests for the project structure selection prompt."""
+
+    def test_structure_prompt_appears_after_frontend(self, mocker):
+        """Should ask for structure after frontend selection."""
+        mock_q = mocker.patch("cli.commands.generate.questionary")
+        mock_q.select.return_value.ask.side_effect = [
+            "Chainlit",  # Frontend
+            None,  # Structure - return None to abort
+        ]
+
+        result = runner.invoke(main_app, ["generate", "workspace", "/tmp/test"])
+
+        # Should have been called twice for select
+        assert mock_q.select.call_count == 2
+
+        # First call should be for frontend
+        first_call_prompt = mock_q.select.call_args_list[0][0][0]
+        assert "frontend" in first_call_prompt.lower()
+
+        # Second call should be for structure
+        second_call_prompt = mock_q.select.call_args_list[1][0][0]
+        assert "structure" in second_call_prompt.lower()
+
+    def test_aborts_when_structure_not_selected(self, mocker):
+        """Should abort when user doesn't select a structure."""
+        mock_q = mocker.patch("cli.commands.generate.questionary")
+        mock_q.select.return_value.ask.side_effect = [
+            "Chainlit",
+            None,  # No structure selected
+        ]
+
+        result = runner.invoke(main_app, ["generate", "workspace", "/tmp/test"])
+
+        assert result.exit_code == 1
+        assert "Aborted" in result.output

--- a/apps/cli/tests/test_generate.py
+++ b/apps/cli/tests/test_generate.py
@@ -874,15 +874,17 @@ class TestStandaloneWorkspaceCommand:
         uv_calls = [c for c in calls if "uv" in str(c[0][0])]
         assert len(uv_calls) >= 1
 
-    def test_standalone_shows_simple_structure_in_summary(
+    def test_standalone_shows_project_generation_complete(
         self, mock_standalone_cli, tmp_path
     ):
-        """Should show 'Simple (standalone)' in configuration summary."""
+        """Should show 'Project generation complete' (standalone-specific message)."""
         target = tmp_path / "standalone-app"
 
         result = runner.invoke(main_app, ["generate", "workspace", str(target)])
 
-        assert "Simple (standalone)" in result.output
+        # Standalone mode shows "Project generation complete"
+        # Monorepo mode shows "Workspace generation complete"
+        assert "Project generation complete" in result.output
 
 
 class TestPathNormalization:

--- a/apps/cli/tests/test_generate.py
+++ b/apps/cli/tests/test_generate.py
@@ -1,6 +1,5 @@
 """Tests for the generate command."""
 
-import shutil
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -922,7 +921,7 @@ class TestStructureSelectionPrompt:
             None,  # Structure - return None to abort
         ]
 
-        result = runner.invoke(main_app, ["generate", "workspace", "/tmp/test"])
+        runner.invoke(main_app, ["generate", "workspace", "/tmp/test"])
 
         # Should have been called twice for select
         assert mock_q.select.call_count == 2

--- a/uv.lock
+++ b/uv.lock
@@ -334,7 +334,7 @@ wheels = [
 
 [[package]]
 name = "chainlit-chat"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "apps/chainlit-chat" }
 dependencies = [
     { name = "chainlit" },
@@ -1897,7 +1897,7 @@ wheels = [
 
 [[package]]
 name = "pdf-context"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "packages/pdf-context" }
 dependencies = [
     { name = "pypdf" },
@@ -2380,7 +2380,7 @@ dev = [
 
 [[package]]
 name = "rag-facile-cli"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "apps/cli" }
 dependencies = [
     { name = "libcst" },
@@ -2463,7 +2463,7 @@ wheels = [
 
 [[package]]
 name = "reflex-chat"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "apps/reflex-chat" }
 dependencies = [
     { name = "openai" },


### PR DESCRIPTION
## Summary

Adds an interactive prompt for project structure selection, giving users a simpler alternative to the full monorepo setup:

- **Simple (recommended for getting started)** - standalone mode with flat structure
- **Monorepo (for multi-app projects)** - existing behavior with moon workspace

### Standalone Mode Features

- Files generated at project root (`app.py`, `pyproject.toml`, etc.)
- `pdf_context` copied as local module when PDF selected
- Uses `uv run chainlit/reflex` for dev server (no moon required)
- Simpler structure for developers who find monorepo overwhelming

### Generated Structure (Standalone)

```
my-rag-app/
├── pyproject.toml
├── .env
├── app.py
├── context_loader.py
├── modules.yml
├── chainlit.md
└── pdf_context/      # (if PDF selected)
```

## Changes

| File | Changes |
|------|---------|
| `apps/cli/src/cli/commands/generate.py` | +306 lines - standalone generation, template rendering |
| `apps/cli/tests/test_generate.py` | +726 lines - comprehensive test coverage |
| `apps/cli/pyproject.toml` | +1 line - bundle pdf_context_src |

## Test Plan

- [x] 57 unit tests passing covering:
  - Template variable substitution and conditionals
  - Standalone Chainlit generation
  - Standalone Reflex generation
  - PDF module inline copying
  - CLI integration for both modes
  - Monorepo mode unchanged
- [x] Manual test: `rag-facile generate workspace ./test-standalone` → select "Simple"
- [ ] Manual test: `rag-facile generate workspace ./test-monorepo` → select "Monorepo"

🤖 Generated with [Letta Code](https://letta.com)