### PR TITLE
chore: consolidate release-please config to single rag-facile package

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,3 @@
 {
-  "apps/cli": "0.2.0",
-  "apps/chainlit-chat": "0.2.0",
-  "apps/reflex-chat": "0.2.0",
-  "packages/pdf-context": "0.2.0"
+	".": "0.2.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rag-facile"
-version = "0.1.0"
+version = "0.2.0"
 description = "RAG Starter Kit for French Government"
 readme = "README.md"
 requires-python = ">=3.13, <3.14"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,43 +1,18 @@
 {
-  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "python",
-  "changelog-path": "CHANGELOG.md",
-  "packages": {
-    "apps/cli": {
-      "changelog-path": "CHANGELOG.md",
-      "version-file": "pyproject.toml",
-      "release-type": "python",
-      "component": "cli"
-    },
-    "apps/chainlit-chat": {
-      "changelog-path": "CHANGELOG.md",
-      "version-file": "pyproject.toml",
-      "release-type": "python",
-      "component": "chainlit-chat"
-    },
-    "apps/reflex-chat": {
-      "changelog-path": "CHANGELOG.md",
-      "version-file": "pyproject.toml",
-      "release-type": "python",
-      "component": "reflex-chat"
-    },
-    "packages/pdf-context": {
-      "changelog-path": "CHANGELOG.md",
-      "version-file": "pyproject.toml",
-      "release-type": "python",
-      "component": "pdf-context"
-    }
-  },
-  "plugins": [
-    {
-      "type": "linked-versions",
-      "groupName": "rag-facile",
-      "components": [
-        "cli",
-        "chainlit-chat",
-        "reflex-chat",
-        "pdf-context"
-      ]
-    }
-  ]
+	"$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+	"release-type": "python",
+	"changelog-path": "CHANGELOG.md",
+	"packages": {
+		".": {
+			"release-type": "python",
+			"changelog-path": "CHANGELOG.md",
+			"version-file": "pyproject.toml",
+			"extra-files": [
+				"apps/cli/pyproject.toml",
+				"apps/chainlit-chat/pyproject.toml",
+				"apps/reflex-chat/pyproject.toml",
+				"packages/pdf-context/pyproject.toml"
+			]
+		}
+	}
 }


### PR DESCRIPTION
This PR updates the `release-please` configuration to treat the repository as a single package (`rag-facile`) rather than releasing individual components separately.

Changes:
- Updated `release-please-config.json` to "linked-versions" / single package mode.
- Updated `.release-please-manifest.json` to track the root version.
- Bumped root `pyproject.toml` version to 0.2.0 to align with existing components.