### PR TITLE
fix: add explicit permissions to checks workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint & Format


### PR DESCRIPTION
## Summary

Resolves GitHub Code Scanning alert by adding explicit least-privilege permissions to the checks workflow.

The workflow only reads from the repository (checkout, linting, type checking, tests), so it only needs `contents: read` permission.

## Why This Matters

GitHub Actions jobs without explicit permissions inherit repository-level default permissions, which may grant excessive access. This follows the principle of least privilege recommended by [GitHub security guidelines](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#granting-additional-permissions).

Note: The `release.yml` workflow already has appropriate explicit permissions set.

## Test Plan

- [x] Verify the checks workflow syntax is valid
- [x] Confirm GitHub Code Scanning no longer flags the checks workflow
- [x] Ensure all existing checks still pass

🐢 Generated with [Letta Code](https://letta.com)