### PR TITLE
fix: extract conventional commits from PR titles for release-please

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "fix"
+      prefix-development: "chore"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
 	"$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
 	"release-type": "python",
 	"changelog-path": "CHANGELOG.md",
+	"pull-request-title-pattern": "^(feat|fix|docs|chore|refactor|perf|test)(\\(.*\\))?!?: .*$",
 	"packages": {
 		".": {
 			"release-type": "python",


### PR DESCRIPTION
## Summary

Release-please was failing to parse merge commit messages like "Merge pull request #XX..." because they don't follow conventional commit format. This prevented version bumps from working correctly with dependabot and user PRs.

This fix configures release-please to extract conventional commits from PR titles instead of merge messages, which works reliably with GitHub's UI merging and dependabot.

## Changes

- Added `pull-request-title-pattern` to `release-please-config.json` to parse PR titles as conventional commits
- Created `.github/dependabot.yml` to configure dependabot PRs with `fix:` prefix

## Testing

Once merged, the next release-please run will:
- Parse existing and future PR titles for version bump types
- Correctly classify dependabot PRs with `fix:` as patch bumps
- Generate appropriate version numbers across all monorepo packages

🐐 Generated with [Letta Code](https://letta.com)