### PR TITLE
fix: use named capture groups in pull-request-title-pattern

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
 	"$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
 	"release-type": "python",
 	"changelog-path": "CHANGELOG.md",
-	"pull-request-title-pattern": "^(feat|fix|docs|chore|refactor|perf|test)(\\(.*\\))?!?: .*$",
+	"pull-request-title-pattern": "^(?<type>feat|fix|docs|chore|refactor|perf|test)(?:\\((?<scope>.*)\\))?(?<breaking>!)?:\\s(?<description>.*)$",
 	"packages": {
 		".": {
 			"release-type": "python",


### PR DESCRIPTION
## Summary

Release-please v17 requires named capture groups in the PR title pattern to properly parse and validate PR titles. The previous pattern was causing warnings about missing template variables and preventing PR validation.

## Changes

Updated `pull-request-title-pattern` to use explicit named capture groups:
- `type`: commit type (feat, fix, chore, etc)
- `scope`: optional scope in parentheses  
- `breaking`: optional `!` for breaking changes
- `description`: the commit message description

This allows release-please to correctly extract all components from PR titles and validate them properly.

🐐 Generated with [Letta Code](https://letta.com)