### PR TITLE
fix: remove pull-request-title-pattern from root config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,6 @@
 	"$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
 	"release-type": "python",
 	"changelog-path": "CHANGELOG.md",
-	"pull-request-title-pattern": "^(?<type>feat|fix|docs|chore|refactor|perf|test)(?:\\((?<scope>.*)\\))?(?<breaking>!)?:\\s(?<description>.*)$",
 	"packages": {
 		".": {
 			"release-type": "python",


### PR DESCRIPTION
The pull-request-title-pattern is for parsing/matching PR titles, not for creating them. Having it at the root level was causing release-please to use the regex pattern itself as the PR title. This removes it to let release-please use its default PR title format.