### PR TITLE
docs: align documentation wording on just and moon commands

### DIFF
--- a/.moon/templates/chainlit-chat/README.md
+++ b/.moon/templates/chainlit-chat/README.md
@@ -24,7 +24,7 @@ This is a simple Chainlit-based chat application designed to benchmark the OpenG
 
 ## Running the App
 
-You can run the application using the `just` command runner.
+Use the `just` command runner to run the application.
 
 If you are at the **root of the monorepo**:
 ```bash
@@ -35,9 +35,4 @@ If you are in **this directory** (or using the generated template):
 ```bash
 just sync  # Setup dependencies (Python 3.13)
 just run   # Run the application
-```
-
-Or directly using `uv`:
-```bash
-uv run chainlit run app.py -w
 ```

--- a/.moon/templates/reflex-chat/README.md
+++ b/.moon/templates/reflex-chat/README.md
@@ -20,6 +20,8 @@ Edit the `.env` file to add your `OPENAI_API_KEY` and `OPENAI_BASE_URL`.
 
 ### 2. Run the application
 
+Use the `just` command runner to run the application.
+
 If you are at the **root of the monorepo**:
 ```bash
 just reflex-chat
@@ -29,11 +31,6 @@ If you are in **this directory** (or using the generated template):
 ```bash
 just sync  # Setup dependencies (Python 3.13)
 just run   # Run the application
-```
-
-Or directly using `uv`:
-```bash
-uv run reflex run
 ```
 
 # Features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ uv sync
 
 ## Code Quality
 
-### Using Just
+### Using `just`
 
 With [just](https://github.com/casey/just) installed:
 
@@ -52,7 +52,7 @@ just type-check   # Run type checker
 just check        # Run all checks
 ```
 
-### Using Moon directly
+### Using `moon run` Directly
 
 ```bash
 moon run tools:format       # Format code

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ my-rag-app/
 
 **Advantages:**
 - ✅ Familiar single-project structure
-- ✅ No build tools to learn (only `uv`)
+- ✅ No build tools to learn
 - ✅ Easy to understand and modify
 - ✅ Simple deployment
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ my-rag-app/
 
 **Advantages:**
 - ✅ Familiar single-project structure
-- ✅ No build tools to learn (just `uv`)
+- ✅ No build tools to learn (only `uv`)
 - ✅ Easy to understand and modify
 - ✅ Simple deployment
 
@@ -173,7 +173,7 @@ uv run reflex run                 # Reflex
 
 ### Monorepo Structure
 
-Use the justfile commands:
+Use the `just` commands:
 
 ```bash
 cd my-rag-app
@@ -181,7 +181,7 @@ just run chainlit-chat      # Run a specific app
 just run                    # Run all apps
 ```
 
-#### Available Monorepo Commands
+#### Available `just` Commands
 
 | Command | Description |
 |---------|-------------|

--- a/uv.lock
+++ b/uv.lock
@@ -287,7 +287,7 @@ wheels = [
 
 [[package]]
 name = "chainlit-chat"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "apps/chainlit-chat" }
 dependencies = [
     { name = "chainlit" },
@@ -1885,7 +1885,7 @@ wheels = [
 
 [[package]]
 name = "pdf-context"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "packages/pdf-context" }
 dependencies = [
     { name = "pypdf" },
@@ -2281,7 +2281,7 @@ wheels = [
 
 [[package]]
 name = "rag-facile"
-version = "0.6.0"
+version = "0.6.1"
 source = { virtual = "." }
 dependencies = [
     { name = "chainlit-chat" },
@@ -2318,7 +2318,7 @@ dev = [
 
 [[package]]
 name = "rag-facile-cli"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "apps/cli" }
 dependencies = [
     { name = "datasets" },
@@ -2413,7 +2413,7 @@ wheels = [
 
 [[package]]
 name = "reflex-chat"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "apps/reflex-chat" }
 dependencies = [
     { name = "openai" },


### PR DESCRIPTION
## Summary

Fixes #49 - Standardizes documentation to consistently refer to commands and tools throughout the project.

## Changes

### Main README.md
- Changed "No build tools to learn (just \`uv\`)" → "No build tools to learn (only \`uv\`)"
  - Avoids confusion between the word "just" and the \`just\` tool name
- Changed "Use the justfile commands:" → "Use the \`just\` commands:"
  - Consistent formatting with backticks for command names
- Updated section header "Available Monorepo Commands" → "Available \`just\` Commands"
  - Clearer about which tool provides these commands

### CONTRIBUTING.md
- Section header "Using Just" → "Using \`just\`"
- Section header "Using Moon directly" → "Using \`moon run\` Directly"
  - Consistent backtick formatting and more descriptive

### Template READMEs (.moon/templates/)
- Removed "Or directly using \`uv\`:" alternatives from chainlit-chat and reflex-chat templates
- Users in generated monorepo workspaces are now consistently directed to use \`just\` commands from the justfile

## Test Plan

- ✅ All code quality checks pass (ruff format + lint)
- ✅ Full test suite runs (70/71 passing, 1 pre-existing unrelated failure)
- ✅ Documentation reflects consistent tool usage patterns