### PR TITLE
fix: update install script to reference current setup command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -139,7 +139,7 @@ if [[ ":$ORIGINAL_PATH:" == *":$LOCAL_BIN:"* ]]; then
     echo "✓ RAG Facile CLI installed successfully!"
     echo ""
     echo "Get started with:"
-    echo "  rag-facile generate workspace my-rag-app"
+    echo "  rag-facile setup my-rag-app"
 else
     echo "rag-facile was installed to $LOCAL_BIN which is not in your PATH."
     echo ""
@@ -159,7 +159,7 @@ else
         echo "  source $profile"
         echo ""
         echo "Or open a new terminal, then:"
-        echo "  rag-facile generate workspace my-rag-app"
+        echo "  rag-facile setup my-rag-app"
     else
         echo ""
         echo "To use rag-facile, add this to your shell profile:"


### PR DESCRIPTION
## Summary

Fixes references to pre-0.6.1 command structure in the install script. The install.sh script still contained references to the old `rag-facile generate workspace` command, which was replaced with `rag-facile setup` in version 0.6.1.

## Changes

- Updated lines 142 and 162 in `install.sh` to reference the current command: `rag-facile setup my-rag-app`

## Verification

✅ Verified no other user-facing documentation contains pre-0.6.1 command references
✅ All CHANGELOG references are historical (correctly document past changes)
✅ All current documentation uses correct command names

Fixes #48

🐐 Generated with [Letta Code](https://letta.com)