### PR TITLE
refactor: consolidate OpenAI dependency to albert-client only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Letta Code (for AI coding assistance)
+LETTA_API_KEY=your_letta_api_key_here
+LETTA_BASE_URL=https://api.letta.com
+
+# OpenAI-compatible API (Albert API or OpenAI)
+# For Albert API: https://albert.api.etalab.gouv.fr/v1
+# For OpenAI: https://api.openai.com/v1
+OPENAI_API_KEY=your_api_key_here
+OPENAI_BASE_URL=https://albert.api.etalab.gouv.fr/v1
+OPENAI_MODEL=openai/gpt-oss-120b
+
+# Hugging Face (for dataset access)
+HF_TOKEN=your_huggingface_token_here
+
+# Data Foundry Agent ID (for generate-dataset command with Letta provider)
+DATA_FOUNDRY_AGENT_ID=your_agent_id_here

--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ LETTA_API_KEY=your_letta_api_key_here
 LETTA_BASE_URL=https://api.letta.com
 
 # OpenAI-compatible API (Albert API or OpenAI)
+# Use either ALBERT_API_KEY or OPENAI_API_KEY (both work)
 # For Albert API: https://albert.api.etalab.gouv.fr/v1
 # For OpenAI: https://api.openai.com/v1
 OPENAI_API_KEY=your_api_key_here

--- a/.moon/templates/albert-client/CHANGELOG.md
+++ b/.moon/templates/albert-client/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to albert-client will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project uses independent versioning (matches Albert API spec, not monorepo releases).
+
+## [0.3.7] - 2026-02-07
+
+### Added
+
+- Initial SDK implementation with OpenAI-compatible passthrough
+- `AlbertClient` class for sync operations
+- `AsyncAlbertClient` class for async/await operations  
+- Full type safety with Pydantic models (`.to_dict()`, `.to_json()` helpers)
+- OpenAI-compatible endpoints: `chat`, `embeddings`, `audio`, `models`
+- Environment variable support (`ALBERT_API_KEY`)
+- Comprehensive test suite with respx mocking
+
+### Architecture
+
+- Composition pattern: wraps `openai.OpenAI` client internally
+- Clean separation between OpenAI-compatible and Albert-specific features
+- Pydantic `BaseModel` for all response types (following OpenAI SDK pattern)
+
+[0.3.7]: https://github.com/etalab-ia/rag-facile/tree/v0.3.7/packages/albert-client

--- a/.moon/templates/albert-client/README.md
+++ b/.moon/templates/albert-client/README.md
@@ -1,0 +1,224 @@
+# Albert Client
+
+Official Python SDK for France's [Albert API](https://albert.api.etalab.gouv.fr/) - a sovereign AI platform providing OpenAI-compatible endpoints plus French government-specific features.
+
+## Why Use This SDK?
+
+- **OpenAI-Compatible**: Use the same code you know from OpenAI with French sovereign models
+- **Single Dependency**: The only dependency in RAG Facile that requires the OpenAI SDK - all apps and packages use albert-client
+- **RAG Made Easy**: Built-in hybrid search, reranking, and collections management
+- **Type-Safe**: Full autocomplete and type checking in your IDE
+- **Production-Ready**: Async support, comprehensive error handling, battle-tested
+
+## Features
+
+- OpenAI-compatible endpoints: chat, embeddings, audio, models
+- Hybrid/semantic/lexical search across document collections  
+- BGE reranking for improved relevance
+- Collections and document management
+- OCR with bounding boxes and document parsing
+- Usage tracking with carbon footprint metrics
+- Both sync and async clients
+
+## Installation
+
+```bash
+# With pip
+pip install albert-client
+
+# With uv (recommended)
+uv add albert-client
+
+# From source (development)
+git clone https://github.com/etalab-ia/rag-facile.git
+cd rag-facile
+uv pip install -e packages/albert-client
+```
+
+## Quick Start
+
+### Installation
+
+```bash
+pip install albert-client
+```
+
+### Basic Chat (OpenAI-Compatible)
+
+```python
+from albert_client import AlbertClient
+
+client = AlbertClient(
+    api_key="albert_...",  # Or set OPENAI_API_KEY env var
+    base_url="https://albert.api.etalab.gouv.fr/v1"
+)
+
+response = client.chat.completions.create(
+    model="openweight-small",  # or "openweight-medium", "openweight-large"
+    messages=[
+        {"role": "user", "content": "Qu'est-ce que la loi Énergie Climat ?"}
+    ]
+)
+print(response.choices[0].message.content)
+```
+
+### Hybrid Search + Reranking
+
+```python
+# Search across your document collections
+results = client.search(
+    query="transition énergétique",
+    collections=[1, 2],
+    method="hybrid",
+    k=10
+)
+
+# Rerank for better precision
+reranked = client.rerank(
+    query="énergies renouvelables",
+    documents=[doc.chunk.content for doc in results.data],
+    top_n=3
+)
+```
+
+### Async Usage
+
+```python
+from albert_client import AsyncAlbertClient
+
+async with AsyncAlbertClient(api_key="albert_...") as client:
+    response = await client.chat.completions.create(
+        model="openweight-small",
+        messages=[{"role": "user", "content": "Hello!"}]
+    )
+```
+
+## Common Use Cases
+
+### Chat Completion (OpenAI-Compatible)
+
+```python
+response = client.chat.completions.create(
+    model="openweight-small",
+    messages=[{"role": "user", "content": "Question?"}]
+)
+```
+
+### Embeddings (OpenAI-Compatible)
+
+```python
+embedding = client.embeddings.create(
+    model="openweight-embeddings",
+    input="Text to embed"
+)
+```
+
+### Building a RAG System
+
+**1. Create a collection:**
+```python
+collection = client.create_collection(
+    name="Documentation",
+    model="openweight-embeddings"
+)
+```
+
+**2. Upload documents:**
+```python
+doc = client.upload_document(
+    file_path="document.pdf",
+    collection_id=collection.id
+)
+```
+
+**3. Search + rerank:**
+```python
+results = client.search(query="...", collections=[collection.id])
+reranked = client.rerank(
+    query="...", 
+    documents=[doc.chunk.content for doc in results.data]
+)
+```
+
+**4. Generate answer with context:**
+```python
+# Build context from reranked results
+context = "\n".join([
+    results.data[r.index].chunk.content 
+    for r in reranked.results
+])
+
+response = client.chat.completions.create(
+    model="openweight-small",
+    messages=[
+        {"role": "system", "content": f"Context:\n{context}"},
+        {"role": "user", "content": "Question?"}
+    ]
+)
+```
+
+### Document Processing
+
+**OCR:**
+```python
+result = client.ocr(document="file.pdf", include_image_base64=True)
+```
+
+**Parse to markdown:**
+```python
+parsed = client.parse(file_path="doc.pdf", output_format="markdown")
+```
+
+### Monitoring
+
+**Track usage and carbon footprint:**
+```python
+usage = client.get_usage(start_date="2024-01-01")
+print(f"CO2: {usage.records[0].carbon_footprint_g}g")
+```
+
+## Full API Reference
+
+For a complete list of methods and parameters, see the [API documentation](https://albert.api.etalab.gouv.fr/docs).
+
+## Contributing
+
+Interested in contributing to the SDK? We welcome improvements!
+
+### Development Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/etalab-ia/rag-facile.git
+cd rag-facile
+
+# Install dependencies
+uv sync
+
+# Run tests
+pytest packages/albert-client/tests/
+
+# Run with coverage
+pytest packages/albert-client/tests/ --cov=albert_client
+```
+
+### SDK Development Status
+
+The SDK is feature-complete with 136/136 tests passing:
+
+- ✅ **Phase 1**: Core client + OpenAI passthrough (30 tests)
+- ✅ **Phase 2**: Search + Rerank (35 tests)
+- ✅ **Phase 3**: Collections + Documents + Chunks (44 tests)
+- ✅ **Phase 4**: Usage + OCR + Parsing + File Management + Monitoring (27 tests)
+
+See the main [CONTRIBUTING.md](../../CONTRIBUTING.md) for project guidelines and workflow.
+
+## License
+
+MIT - See [LICENSE](../../LICENSE) for details.
+
+## Links
+
+- [Albert API Documentation](https://albert.api.etalab.gouv.fr/docs)
+- [OpenAI Python SDK](https://github.com/openai/openai-python) (compatibility layer)
+- [RAG Facile](https://github.com/etalab-ia/rag-facile) (parent project)

--- a/.moon/templates/albert-client/pyproject.toml
+++ b/.moon/templates/albert-client/pyproject.toml
@@ -1,0 +1,40 @@
+[project]
+name = "albert-client"
+version = "0.3.7"
+description = "Official Python SDK for France's Albert API - a sovereign AI platform"
+authors = [
+    { name = "Etalab", email = "etalab@modernisation.gouv.fr" }
+]
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.11"
+dependencies = [
+    "openai>=1.0.0",
+    "httpx>=0.24.0",
+    "pydantic>=2.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-asyncio>=0.21.0",
+    "respx>=0.20.0",
+    "ruff>=0.1.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/etalab-ia/rag-facile"
+Documentation = "https://github.com/etalab-ia/rag-facile/tree/main/packages/albert-client"
+Repository = "https://github.com/etalab-ia/rag-facile"
+Issues = "https://github.com/etalab-ia/rag-facile/issues"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/albert_client"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/.moon/templates/albert-client/src/albert_client/__init__.py
+++ b/.moon/templates/albert-client/src/albert_client/__init__.py
@@ -1,0 +1,82 @@
+"""Albert Client - Official Python SDK for France's Albert API.
+
+A sovereign AI platform providing OpenAI-compatible endpoints plus
+French government-specific features like RAG search, collections management,
+and carbon footprint tracking.
+"""
+
+# Third-party imports
+from openai.types.chat import ChatCompletionMessageParam
+
+# Local imports
+from albert_client._async_client import AsyncAlbertClient
+from albert_client._version import __version__
+from albert_client.client import AlbertClient
+from albert_client.types import (
+    BoundingBox,
+    Chunk,
+    ChunkList,
+    Collection,
+    CollectionList,
+    CollectionVisibility,
+    Document,
+    DocumentList,
+    FileUploadResponse,
+    HealthStatus,
+    MetricsData,
+    OCRPageObject,
+    OCRResponse,
+    OCRText,
+    OCRUsage,
+    ParsedDocument,
+    ParsedDocumentOutputFormat,
+    ParsedDocumentPage,
+    RerankResponse,
+    RerankResult,
+    SearchMethod,
+    SearchResponse,
+    SearchResult,
+    Usage,
+    UsageList,
+    UsageRecord,
+)
+
+
+__all__ = [
+    # Clients
+    "AlbertClient",
+    "AsyncAlbertClient",
+    # OpenAI type re-exports
+    "ChatCompletionMessageParam",
+    # Search & Rerank types
+    "Chunk",
+    "ChunkList",
+    "RerankResult",
+    "RerankResponse",
+    "SearchMethod",
+    "SearchResult",
+    "SearchResponse",
+    "Usage",
+    # Collections & Documents types
+    "Collection",
+    "CollectionList",
+    "CollectionVisibility",
+    "Document",
+    "DocumentList",
+    # Tools, Parsing & Monitoring types
+    "BoundingBox",
+    "FileUploadResponse",
+    "HealthStatus",
+    "MetricsData",
+    "OCRPageObject",
+    "OCRResponse",
+    "OCRText",
+    "OCRUsage",
+    "ParsedDocument",
+    "ParsedDocumentOutputFormat",
+    "ParsedDocumentPage",
+    "UsageList",
+    "UsageRecord",
+    # Metadata
+    "__version__",
+]

--- a/.moon/templates/albert-client/src/albert_client/_async_client.py
+++ b/.moon/templates/albert-client/src/albert_client/_async_client.py
@@ -1,0 +1,801 @@
+"""Async Albert Client implementation."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from openai import AsyncOpenAI
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from albert_client.types import (
+        Chunk,
+        ChunkList,
+        Collection,
+        CollectionList,
+        CollectionVisibility,
+        Document,
+        DocumentList,
+        FileUploadResponse,
+        HealthStatus,
+        MetricsData,
+        OCRResponse,
+        ParsedDocument,
+        ParsedDocumentOutputFormat,
+        RerankResponse,
+        SearchResponse,
+        UsageList,
+    )
+
+
+class AsyncAlbertClient:
+    """Async version of Albert Client.
+
+    Provides the same interface as AlbertClient but with async/await support.
+
+    Example:
+        ```python
+        from albert_client import AsyncAlbertClient
+
+        # Initialize async client
+        client = AsyncAlbertClient(
+            api_key="albert_...",
+            base_url="https://albert.api.etalab.gouv.fr/v1"
+        )
+
+        # OpenAI-compatible endpoints
+        response = await client.chat.completions.create(
+            model="AgentPublic/llama3-instruct-8b",
+            messages=[{"role": "user", "content": "Hello!"}]
+        )
+
+        # Albert-specific endpoints (coming in Phase 2+)
+        # results = await client.search(prompt="...", collections=["..."])
+        ```
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = "https://albert.api.etalab.gouv.fr/v1",
+        **kwargs,
+    ):
+        """Initialize async Albert client.
+
+        Args:
+            api_key: Albert API key. If not provided, reads from ALBERT_API_KEY or OPENAI_API_KEY env var.
+            base_url: Base URL for Albert API (includes /v1 suffix).
+            **kwargs: Additional arguments passed to AsyncOpenAI client.
+        """
+        # Get API key from env if not provided (check both ALBERT_API_KEY and OPENAI_API_KEY)
+        if api_key is None:
+            api_key = os.environ.get("ALBERT_API_KEY") or os.environ.get(
+                "OPENAI_API_KEY"
+            )
+
+        if not api_key:
+            raise ValueError(
+                "Albert API key is required. Provide via api_key parameter or "
+                "ALBERT_API_KEY/OPENAI_API_KEY environment variable."
+            )
+
+        # Initialize wrapped AsyncOpenAI client
+        self._client = AsyncOpenAI(api_key=api_key, base_url=base_url, **kwargs)
+
+        # OpenAI-Compatible Passthrough
+        self.chat = self._client.chat
+        self.embeddings = self._client.embeddings
+        self.audio = self._client.audio
+        self.models = self._client.models
+
+        # Albert-Specific Resources (will be implemented in Phase 2+)
+        # self.collections = AsyncCollections(self._client)
+        # self.documents = AsyncDocuments(self._client)
+        # self.tools = AsyncTools(self._client)
+        # self.management = AsyncManagement(self._client)
+
+    @property
+    def api_key(self) -> str:
+        """Get the API key."""
+        return self._client.api_key
+
+    @property
+    def base_url(self) -> str:
+        """Get the base URL."""
+        return str(self._client.base_url)
+
+    async def close(self) -> None:
+        """Close the underlying httpx client."""
+        await self._client.close()
+
+    async def __aenter__(self):
+        """Async context manager entry."""
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit."""
+        await self.close()
+
+    # Phase 2: Search and Rerank async methods
+
+    async def search(
+        self,
+        prompt: str,
+        collections: list[str | int] | None = None,
+        limit: int = 10,
+        offset: int = 0,
+        method: str = "semantic",
+        score_threshold: float | None = None,
+        rff_k: int = 20,
+    ) -> SearchResponse:
+        """Async hybrid RAG search across collections.
+
+        Searches for relevant chunks in the specified collections using the given prompt.
+        Supports semantic, lexical, or hybrid search methods.
+
+        Args:
+            prompt: Search query to find relevant chunks.
+            collections: List of collection IDs to search in. Defaults to all collections.
+            limit: Maximum number of results to return (1-200). Defaults to 10.
+            offset: Pagination offset. Defaults to 0.
+            method: Search method - "semantic", "lexical", or "hybrid". Defaults to "semantic".
+            score_threshold: Minimum cosine similarity score (0.0-1.0). Only for semantic search.
+            rff_k: RFF algorithm constant. Defaults to 20.
+
+        Returns:
+            SearchResponse with results, usage info, and metadata.
+
+        Raises:
+            httpx.HTTPStatusError: If the API request fails.
+
+        Example:
+            ```python
+            async with AsyncAlbertClient(api_key="albert_...") as client:
+                results = await client.search(
+                    prompt="Loi Énergie Climat",
+                    collections=["col_123"],
+                    limit=5,
+                    method="hybrid"
+                )
+                for result in results.data:
+                    print(f"Score: {result.score:.3f}")
+            ```
+        """
+        from albert_client.types import SearchResponse
+
+        # Build request body
+        body = {
+            "prompt": prompt,
+            "collections": collections or [],
+            "limit": limit,
+            "offset": offset,
+            "method": method,
+            "rff_k": rff_k,
+        }
+        if score_threshold is not None:
+            body["score_threshold"] = score_threshold
+
+        # Make request using internal httpx client
+        response = await self._client._client.post("/search", json=body)
+        response.raise_for_status()
+
+        # Parse and return Pydantic model
+        return SearchResponse(**response.json())
+
+    async def rerank(
+        self,
+        query: str,
+        documents: list[str],
+        model: str,
+        top_n: int | None = None,
+    ) -> RerankResponse:
+        """Async rerank documents by relevance to a query.
+
+        Takes a list of documents and reorders them by relevance to the query.
+        Useful for improving RAG retrieval quality.
+
+        Args:
+            query: The search query to rank documents against.
+            documents: List of document texts to rerank.
+            model: Reranker model to use (e.g., "BAAI/bge-reranker-v2-m3").
+            top_n: Return only top N results. If None, returns all documents.
+
+        Returns:
+            RerankResponse with reranked results and scores.
+
+        Raises:
+            httpx.HTTPStatusError: If the API request fails.
+
+        Example:
+            ```python
+            async with AsyncAlbertClient(api_key="albert_...") as client:
+                results = await client.rerank(
+                    query="transition énergétique",
+                    documents=["doc1", "doc2", "doc3"],
+                    model="BAAI/bge-reranker-v2-m3",
+                    top_n=2
+                )
+            ```
+        """
+        from albert_client.types import RerankResponse
+
+        # Build request body
+        body = {
+            "query": query,
+            "documents": documents,
+            "model": model,
+        }
+        if top_n is not None:
+            body["top_n"] = top_n
+
+        # Make request using internal httpx client
+        response = await self._client._client.post("/rerank", json=body)
+        response.raise_for_status()
+
+        # Parse and return Pydantic model
+        return RerankResponse(**response.json())
+
+    # Phase 3: Collections methods (async)
+
+    async def create_collection(
+        self,
+        name: str,
+        description: str | None = None,
+        visibility: CollectionVisibility = "private",
+    ) -> Collection:
+        """Create a new RAG collection (async).
+
+        Collections organize documents for semantic search. Each collection has its
+        own embedding model and access permissions.
+
+        Args:
+            name: Name of the collection (required).
+            description: Optional description of the collection.
+            visibility: "private" (owner only) or "public" (all users). Defaults to "private".
+
+        Returns:
+            Collection object with ID and metadata.
+
+        Raises:
+            httpx.HTTPStatusError: If the API request fails.
+
+        Example:
+            ```python
+            async with AsyncAlbertClient(api_key="albert_...") as client:
+                collection = await client.create_collection(
+                    name="French Legal Documents",
+                    visibility="private"
+                )
+            ```
+        """
+        from albert_client.types import Collection
+
+        body = {"name": name, "visibility": visibility}
+        if description is not None:
+            body["description"] = description
+
+        response = await self._client._client.post("/collections", json=body)
+        response.raise_for_status()
+
+        return Collection(**response.json())
+
+    async def list_collections(self) -> CollectionList:
+        """List all accessible collections (async).
+
+        Returns collections owned by the user plus any public collections.
+
+        Returns:
+            CollectionList containing all accessible collections.
+
+        Raises:
+            httpx.HTTPStatusError: If the API request fails.
+
+        Example:
+            ```python
+            async with AsyncAlbertClient(api_key="albert_...") as client:
+                collections = await client.list_collections()
+                for collection in collections.data:
+                    print(f"{collection.name}: {collection.documents} documents")
+            ```
+        """
+        from albert_client.types import CollectionList
+
+        response = await self._client._client.get("/collections")
+        response.raise_for_status()
+
+        return CollectionList(**response.json())
+
+    async def get_collection(self, collection_id: int) -> Collection:
+        """Get a specific collection by ID (async).
+
+        Args:
+            collection_id: The collection ID.
+
+        Returns:
+            Collection object with full metadata.
+
+        Raises:
+            httpx.HTTPStatusError: If the collection doesn't exist or isn't accessible.
+
+        Example:
+            ```python
+            async with AsyncAlbertClient(api_key="albert_...") as client:
+                collection = await client.get_collection(123)
+            ```
+        """
+        from albert_client.types import Collection
+
+        response = await self._client._client.get(f"/collections/{collection_id}")
+        response.raise_for_status()
+
+        return Collection(**response.json())
+
+    async def update_collection(
+        self,
+        collection_id: int,
+        name: str | None = None,
+        description: str | None = None,
+        visibility: CollectionVisibility | None = None,
+    ) -> Collection:
+        """Update a collection's metadata (async).
+
+        Only the collection owner can update it. At least one field must be provided.
+
+        Args:
+            collection_id: The collection ID to update.
+            name: New name for the collection (optional).
+            description: New description (optional).
+            visibility: New visibility setting (optional).
+
+        Returns:
+            Updated Collection object.
+
+        Raises:
+            httpx.HTTPStatusError: If the update fails or user lacks permission.
+        """
+        from albert_client.types import Collection
+
+        body = {}
+        if name is not None:
+            body["name"] = name
+        if description is not None:
+            body["description"] = description
+        if visibility is not None:
+            body["visibility"] = visibility
+
+        response = await self._client._client.patch(
+            f"/collections/{collection_id}", json=body
+        )
+        response.raise_for_status()
+
+        return Collection(**response.json())
+
+    async def delete_collection(self, collection_id: int) -> None:
+        """Delete a collection and all its documents (async).
+
+        Only the collection owner can delete it. This action is irreversible.
+
+        Args:
+            collection_id: The collection ID to delete.
+
+        Raises:
+            httpx.HTTPStatusError: If the deletion fails or user lacks permission.
+        """
+        response = await self._client._client.delete(f"/collections/{collection_id}")
+        response.raise_for_status()
+
+    # Phase 3: Documents methods (async)
+
+    async def upload_document(
+        self,
+        file_path: str | Path,
+        collection_id: int,
+        chunk_size: int = 2048,
+        chunk_overlap: int = 0,
+        **kwargs,
+    ) -> Document:
+        """Upload a document to a collection (async).
+
+        The document will be parsed, chunked, and embedded according to the collection's
+        settings. Supports PDF, DOCX, TXT, and other common formats.
+
+        Args:
+            file_path: Path to the file to upload.
+            collection_id: The collection ID to add the document to.
+            chunk_size: Size of text chunks for embedding (default: 2048).
+            chunk_overlap: Overlap between chunks (default: 0).
+            **kwargs: Additional upload parameters (page_range, force_ocr, etc.).
+
+        Returns:
+            Document object with ID and metadata.
+
+        Raises:
+            httpx.HTTPStatusError: If the upload fails.
+
+        Example:
+            ```python
+            async with AsyncAlbertClient(api_key="albert_...") as client:
+                doc = await client.upload_document(
+                    file_path="./legal_doc.pdf",
+                    collection_id=123,
+                    chunk_size=1024
+                )
+            ```
+        """
+        from pathlib import Path
+
+        from albert_client.types import Document
+
+        file_path = Path(file_path)
+
+        form_data = {
+            "collection": collection_id,
+            "chunk_size": chunk_size,
+            "chunk_overlap": chunk_overlap,
+        }
+        form_data.update(kwargs)
+
+        with open(file_path, "rb") as f:
+            files = {"file": (file_path.name, f, "application/octet-stream")}
+            response = await self._client._client.post(
+                "/documents", data=form_data, files=files
+            )
+            response.raise_for_status()
+
+        return Document(**response.json())
+
+    async def list_documents(self, collection_id: int | None = None) -> DocumentList:
+        """List documents in a collection or all accessible documents (async).
+
+        Args:
+            collection_id: Filter to specific collection. If None, returns all accessible documents.
+
+        Returns:
+            DocumentList containing matching documents.
+
+        Raises:
+            httpx.HTTPStatusError: If the request fails.
+        """
+        from albert_client.types import DocumentList
+
+        params = {}
+        if collection_id is not None:
+            params["collection"] = collection_id
+
+        response = await self._client._client.get("/documents", params=params)
+        response.raise_for_status()
+
+        return DocumentList(**response.json())
+
+    async def get_document(self, document_id: int) -> Document:
+        """Get a specific document by ID (async).
+
+        Args:
+            document_id: The document ID.
+
+        Returns:
+            Document object with metadata.
+
+        Raises:
+            httpx.HTTPStatusError: If the document doesn't exist or isn't accessible.
+        """
+        from albert_client.types import Document
+
+        response = await self._client._client.get(f"/documents/{document_id}")
+        response.raise_for_status()
+
+        return Document(**response.json())
+
+    async def delete_document(self, document_id: int) -> None:
+        """Delete a document and all its chunks (async).
+
+        This action is irreversible. The document's embeddings will also be removed.
+
+        Args:
+            document_id: The document ID to delete.
+
+        Raises:
+            httpx.HTTPStatusError: If the deletion fails.
+        """
+        response = await self._client._client.delete(f"/documents/{document_id}")
+        response.raise_for_status()
+
+    # Phase 3: Chunks methods (async)
+
+    async def list_chunks(self, document_id: int) -> ChunkList:
+        """List all chunks for a specific document (async).
+
+        Returns the text chunks that were created when the document was uploaded.
+
+        Args:
+            document_id: The document ID.
+
+        Returns:
+            ChunkList containing all chunks for the document.
+
+        Raises:
+            httpx.HTTPStatusError: If the request fails.
+        """
+        from albert_client.types import ChunkList
+
+        response = await self._client._client.get(f"/chunks/{document_id}")
+        response.raise_for_status()
+
+        return ChunkList(**response.json())
+
+    async def get_chunk(self, document_id: int, chunk_id: int) -> Chunk:
+        """Get a specific chunk by document and chunk ID (async).
+
+        Args:
+            document_id: The document ID.
+            chunk_id: The chunk ID.
+
+        Returns:
+            Chunk object with content and metadata.
+
+        Raises:
+            httpx.HTTPStatusError: If the chunk doesn't exist.
+        """
+        from albert_client.types import Chunk
+
+        response = await self._client._client.get(f"/chunks/{document_id}/{chunk_id}")
+        response.raise_for_status()
+
+        return Chunk(**response.json())
+
+    # Phase 4: Usage tracking (async)
+
+    async def get_usage(
+        self, start_date: str | None = None, end_date: str | None = None
+    ) -> UsageList:
+        """Get API usage statistics (async).
+
+        Returns usage data (tokens, cost, carbon) aggregated by date.
+
+        Args:
+            start_date: Filter from this date (ISO format YYYY-MM-DD). Optional.
+            end_date: Filter until this date (ISO format YYYY-MM-DD). Optional.
+
+        Returns:
+            UsageList with usage records per date.
+
+        Raises:
+            httpx.HTTPStatusError: If the request fails.
+
+        Example:
+            ```python
+            async with AsyncAlbertClient(api_key="albert_...") as client:
+                usage = await client.get_usage(start_date="2024-01-01")
+            ```
+        """
+        from albert_client.types import UsageList
+
+        params = {}
+        if start_date is not None:
+            params["start_date"] = start_date
+        if end_date is not None:
+            params["end_date"] = end_date
+
+        response = await self._client._client.get("/me/usage", params=params)
+        response.raise_for_status()
+
+        return UsageList(**response.json())
+
+    # Phase 4: OCR & Parsing methods (async)
+
+    async def ocr(
+        self,
+        document: dict[str, str] | str,
+        model: str | None = None,
+        pages: list[int] | None = None,
+        include_image_base64: bool = False,
+        **kwargs,
+    ) -> OCRResponse:
+        """Perform OCR on a document with advanced options (async).
+
+        Advanced OCR with support for JSON mode, bounding boxes, and image extraction.
+
+        Args:
+            document: Document to OCR. Can be:
+                - Dict with 'url' key for document URL
+                - Dict with 'image_url' key for image URL
+                - Direct URL string
+            model: Model to use for OCR (optional).
+            pages: Specific pages to process (0-indexed). If None, processes all pages.
+            include_image_base64: Include base64-encoded images in response.
+            **kwargs: Additional OCR options.
+
+        Returns:
+            OCRResponse with pages, text, and optional bounding boxes.
+
+        Raises:
+            httpx.HTTPStatusError: If the OCR request fails.
+        """
+        from albert_client.types import OCRResponse
+
+        body = {}
+
+        if isinstance(document, str):
+            body["document"] = {"url": document}
+        else:
+            body["document"] = document
+
+        if model is not None:
+            body["model"] = model
+        if pages is not None:
+            body["pages"] = pages
+        if include_image_base64:
+            body["include_image_base64"] = include_image_base64
+
+        body.update(kwargs)
+
+        response = await self._client._client.post("/ocr", json=body)
+        response.raise_for_status()
+
+        return OCRResponse(**response.json())
+
+    async def ocr_beta(
+        self,
+        file_path: str | Path,
+        model: str,
+        dpi: int = 150,
+        prompt: str | None = None,
+    ) -> ParsedDocument:
+        """Perform simple file-based OCR (async, beta).
+
+        Simpler OCR method that takes a file and returns parsed text.
+
+        Args:
+            file_path: Path to the file to OCR.
+            model: Model to use for OCR (required).
+            dpi: DPI for rendering pages as images (100-600, default: 150).
+            prompt: Custom prompt for OCR extraction (optional).
+
+        Returns:
+            ParsedDocument with OCR results per page.
+
+        Raises:
+            httpx.HTTPStatusError: If the OCR request fails.
+        """
+        from pathlib import Path
+
+        from albert_client.types import ParsedDocument
+
+        file_path = Path(file_path)
+
+        form_data = {"model": model, "dpi": dpi}
+        if prompt is not None:
+            form_data["prompt"] = prompt
+
+        with open(file_path, "rb") as f:
+            files = {"file": (file_path.name, f, "application/octet-stream")}
+            response = await self._client._client.post(
+                "/ocr-beta", data=form_data, files=files
+            )
+            response.raise_for_status()
+
+        return ParsedDocument(**response.json())
+
+    async def parse(
+        self,
+        file_path: str | Path,
+        output_format: ParsedDocumentOutputFormat = "markdown",
+        force_ocr: bool = False,
+        page_range: str = "",
+        paginate_output: bool = False,
+    ) -> ParsedDocument:
+        """Parse a document to markdown, JSON, or HTML (async).
+
+        Extract and convert document content to structured format.
+
+        Args:
+            file_path: Path to the file to parse.
+            output_format: Output format - "markdown", "json", or "html".
+            force_ocr: Force OCR on all pages (default: False).
+            page_range: Page range to convert (e.g., "0,5-10,20").
+            paginate_output: Separate pages with horizontal rules.
+
+        Returns:
+            ParsedDocument with parsed pages.
+
+        Raises:
+            httpx.HTTPStatusError: If the parsing fails.
+        """
+        from pathlib import Path
+
+        from albert_client.types import ParsedDocument
+
+        file_path = Path(file_path)
+
+        form_data = {
+            "output_format": output_format,
+            "force_ocr": force_ocr,
+            "page_range": page_range,
+            "paginate_output": paginate_output,
+        }
+
+        with open(file_path, "rb") as f:
+            files = {"file": (file_path.name, f, "application/octet-stream")}
+            response = await self._client._client.post(
+                "/parse-beta", data=form_data, files=files
+            )
+            response.raise_for_status()
+
+        return ParsedDocument(**response.json())
+
+    # Phase 4: File management (async)
+
+    async def upload_file(
+        self, file_path: str | Path, purpose: str | None = None
+    ) -> FileUploadResponse:
+        """Upload a file to Albert API (async).
+
+        Generic file upload (different from uploading documents to collections).
+
+        Args:
+            file_path: Path to the file to upload.
+            purpose: Purpose of the file upload (optional).
+
+        Returns:
+            FileUploadResponse with file ID and metadata.
+
+        Raises:
+            httpx.HTTPStatusError: If the upload fails.
+        """
+        from pathlib import Path
+
+        from albert_client.types import FileUploadResponse
+
+        file_path = Path(file_path)
+
+        form_data = {}
+        if purpose is not None:
+            form_data["purpose"] = purpose
+
+        with open(file_path, "rb") as f:
+            files = {"file": (file_path.name, f, "application/octet-stream")}
+            response = await self._client._client.post(
+                "/files", data=form_data, files=files
+            )
+            response.raise_for_status()
+
+        return FileUploadResponse(**response.json())
+
+    # Phase 4: Health & Monitoring (async)
+
+    async def health_check(self) -> HealthStatus:
+        """Check API health status (async).
+
+        Returns:
+            HealthStatus with current API status.
+
+        Raises:
+            httpx.HTTPStatusError: If the health check fails.
+        """
+        from albert_client.types import HealthStatus
+
+        response = await self._client._client.get("/health")
+        response.raise_for_status()
+
+        return HealthStatus(**response.json())
+
+    async def get_metrics(self) -> MetricsData:
+        """Get API metrics (async).
+
+        Returns performance and usage metrics for the API.
+
+        Returns:
+            MetricsData with API metrics.
+
+        Raises:
+            httpx.HTTPStatusError: If the metrics request fails.
+        """
+        from albert_client.types import MetricsData
+
+        response = await self._client._client.get("/metrics")
+        response.raise_for_status()
+
+        return MetricsData(**response.json())

--- a/.moon/templates/albert-client/src/albert_client/_models.py
+++ b/.moon/templates/albert-client/src/albert_client/_models.py
@@ -1,0 +1,41 @@
+"""Base models for Albert API responses.
+
+Follows OpenAI SDK pattern of extending Pydantic with helper methods.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import ConfigDict
+
+
+class BaseModel(PydanticBaseModel):
+    """Base model for all Albert API response types.
+
+    Provides helper methods matching OpenAI SDK patterns:
+    - to_dict(): Convert to dictionary
+    - to_json(): Convert to JSON string
+    """
+
+    model_config = ConfigDict(
+        # Allow extra fields from API (forward compatibility)
+        extra="allow",
+        # Use attribute names as-is (no camelCase conversion)
+        populate_by_name=True,
+    )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert model to dictionary.
+
+        Returns:
+            Dictionary representation of the model.
+        """
+        return self.model_dump()
+
+    def to_json(self) -> str:
+        """Convert model to JSON string.
+
+        Returns:
+            JSON string representation of the model.
+        """
+        return self.model_dump_json()

--- a/.moon/templates/albert-client/src/albert_client/_version.py
+++ b/.moon/templates/albert-client/src/albert_client/_version.py
@@ -1,0 +1,3 @@
+"""Albert Client SDK version."""
+
+__version__ = "0.3.7"

--- a/.moon/templates/albert-client/src/albert_client/client.py
+++ b/.moon/templates/albert-client/src/albert_client/client.py
@@ -1,0 +1,932 @@
+"""Main Albert Client implementation."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from openai import OpenAI
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from albert_client.types import (
+        Chunk,
+        ChunkList,
+        Collection,
+        CollectionList,
+        CollectionVisibility,
+        Document,
+        DocumentList,
+        FileUploadResponse,
+        HealthStatus,
+        MetricsData,
+        OCRResponse,
+        ParsedDocument,
+        ParsedDocumentOutputFormat,
+        RerankResponse,
+        SearchResponse,
+        UsageList,
+    )
+
+
+class AlbertClient:
+    """Official Python SDK for France's Albert API.
+
+    Provides OpenAI-compatible endpoints (chat, embeddings, audio, models) and
+    Albert-specific endpoints (search, rerank, collections, documents, tools, management).
+
+    Example:
+        ```python
+        from albert_client import AlbertClient
+
+        # Initialize client
+        client = AlbertClient(
+            api_key="albert_...",  # Or set ALBERT_API_KEY env var
+            base_url="https://albert.api.etalab.gouv.fr/v1"
+        )
+
+        # OpenAI-compatible endpoints
+        response = client.chat.completions.create(
+            model="AgentPublic/llama3-instruct-8b",
+            messages=[{"role": "user", "content": "Hello!"}]
+        )
+
+        # Albert-specific endpoints (coming in Phase 2+)
+        # results = client.search(prompt="...", collections=["..."])
+        ```
+
+    Architecture:
+        - Wraps internal OpenAI client for OpenAI-compatible endpoints
+        - Provides custom implementations for Albert-specific features
+        - All responses use Pydantic models for type safety
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = "https://albert.api.etalab.gouv.fr/v1",
+        **kwargs,
+    ):
+        """Initialize Albert client.
+
+        Args:
+            api_key: Albert API key. If not provided, reads from ALBERT_API_KEY or OPENAI_API_KEY env var.
+            base_url: Base URL for Albert API (includes /v1 suffix).
+            **kwargs: Additional arguments passed to OpenAI client (timeout, max_retries, etc.).
+        """
+        # Get API key from env if not provided (check both ALBERT_API_KEY and OPENAI_API_KEY)
+        if api_key is None:
+            api_key = os.environ.get("ALBERT_API_KEY") or os.environ.get(
+                "OPENAI_API_KEY"
+            )
+
+        if not api_key:
+            raise ValueError(
+                "Albert API key is required. Provide via api_key parameter or "
+                "ALBERT_API_KEY/OPENAI_API_KEY environment variable."
+            )
+
+        # Initialize wrapped OpenAI client
+        self._client = OpenAI(api_key=api_key, base_url=base_url, **kwargs)
+
+        # OpenAI-Compatible Passthrough (direct proxy to internal client)
+        self.chat = self._client.chat
+        self.embeddings = self._client.embeddings
+        self.audio = self._client.audio
+        self.models = self._client.models
+
+        # Albert-Specific Resources (will be implemented in Phase 2+)
+        # self.collections = Collections(self._client)
+        # self.documents = Documents(self._client)
+        # self.tools = Tools(self._client)
+        # self.management = Management(self._client)
+
+    @property
+    def api_key(self) -> str:
+        """Get the API key."""
+        return self._client.api_key
+
+    @property
+    def base_url(self) -> str:
+        """Get the base URL."""
+        return str(self._client.base_url)
+
+    # Phase 2: Search and Rerank methods
+
+    def search(
+        self,
+        prompt: str,
+        collections: list[str | int] | None = None,
+        limit: int = 10,
+        offset: int = 0,
+        method: str = "semantic",
+        score_threshold: float | None = None,
+        rff_k: int = 20,
+    ) -> SearchResponse:
+        """Hybrid RAG search across collections.
+
+        Searches for relevant chunks in the specified collections using the given prompt.
+        Supports semantic, lexical, or hybrid search methods.
+
+        Args:
+            prompt: Search query to find relevant chunks.
+            collections: List of collection IDs to search in. Defaults to all collections.
+            limit: Maximum number of results to return (1-200). Defaults to 10.
+            offset: Pagination offset. Defaults to 0.
+            method: Search method - "semantic", "lexical", or "hybrid". Defaults to "semantic".
+            score_threshold: Minimum cosine similarity score (0.0-1.0). Only for semantic search.
+            rff_k: RFF algorithm constant. Defaults to 20.
+
+        Returns:
+            SearchResponse with results, usage info, and metadata.
+
+        Raises:
+            httpx.HTTPStatusError: If the API request fails.
+
+        Example:
+            ```python
+            results = client.search(
+                prompt="Loi Énergie Climat",
+                collections=["col_123"],
+                limit=5,
+                method="hybrid"
+            )
+            for result in results.data:
+                print(f"Score: {result.score:.3f}")
+                print(f"Content: {result.chunk.content[:100]}...")
+            ```
+        """
+        from albert_client.types import SearchResponse
+
+        # Build request body
+        body = {
+            "prompt": prompt,
+            "collections": collections or [],
+            "limit": limit,
+            "offset": offset,
+            "method": method,
+            "rff_k": rff_k,
+        }
+        if score_threshold is not None:
+            body["score_threshold"] = score_threshold
+
+        # Make request using internal httpx client
+        response = self._client._client.post("/search", json=body)
+        response.raise_for_status()
+
+        # Parse and return Pydantic model
+        return SearchResponse(**response.json())
+
+    def rerank(
+        self,
+        query: str,
+        documents: list[str],
+        model: str,
+        top_n: int | None = None,
+    ) -> RerankResponse:
+        """Rerank documents by relevance to a query using BGE reranker.
+
+        Takes a list of documents and reorders them by relevance to the query.
+        Useful for improving RAG retrieval quality.
+
+        Args:
+            query: The search query to rank documents against.
+            documents: List of document texts to rerank.
+            model: Reranker model to use (e.g., "BAAI/bge-reranker-v2-m3").
+            top_n: Return only top N results. If None, returns all documents.
+
+        Returns:
+            RerankResponse with reranked results and scores.
+
+        Raises:
+            httpx.HTTPStatusError: If the API request fails.
+
+        Example:
+            ```python
+            results = client.rerank(
+                query="transition énergétique",
+                documents=[
+                    "La loi Énergie Climat vise à...",
+                    "Le changement climatique est...",
+                    "Les énergies renouvelables..."
+                ],
+                model="BAAI/bge-reranker-v2-m3",
+                top_n=2
+            )
+            for result in results.results:
+                print(f"Rank {result.index}: Score {result.relevance_score:.3f}")
+            ```
+        """
+        from albert_client.types import RerankResponse
+
+        # Build request body
+        body = {
+            "query": query,
+            "documents": documents,
+            "model": model,
+        }
+        if top_n is not None:
+            body["top_n"] = top_n
+
+        # Make request using internal httpx client
+        response = self._client._client.post("/rerank", json=body)
+        response.raise_for_status()
+
+        # Parse and return Pydantic model
+        return RerankResponse(**response.json())
+
+    # Phase 3: Collections methods
+
+    def create_collection(
+        self,
+        name: str,
+        description: str | None = None,
+        visibility: CollectionVisibility = "private",
+    ) -> Collection:
+        """Create a new RAG collection.
+
+        Collections organize documents for semantic search. Each collection has its
+        own embedding model and access permissions.
+
+        Args:
+            name: Name of the collection (required).
+            description: Optional description of the collection.
+            visibility: "private" (owner only) or "public" (all users). Defaults to "private".
+
+        Returns:
+            Collection object with ID and metadata.
+
+        Raises:
+            httpx.HTTPStatusError: If the API request fails.
+
+        Example:
+            ```python
+            collection = client.create_collection(
+                name="French Legal Documents",
+                description="Collection of French government legal texts",
+                visibility="private"
+            )
+            print(f"Created collection {collection.id}")
+            ```
+        """
+        from albert_client.types import Collection
+
+        # Build request body
+        body = {"name": name, "visibility": visibility}
+        if description is not None:
+            body["description"] = description
+
+        # Make request
+        response = self._client._client.post("/collections", json=body)
+        response.raise_for_status()
+
+        return Collection(**response.json())
+
+    def list_collections(self) -> CollectionList:
+        """List all accessible collections.
+
+        Returns collections owned by the user plus any public collections.
+
+        Returns:
+            CollectionList containing all accessible collections.
+
+        Raises:
+            httpx.HTTPStatusError: If the API request fails.
+
+        Example:
+            ```python
+            collections = client.list_collections()
+            for collection in collections.data:
+                print(f"{collection.name}: {collection.documents} documents")
+            ```
+        """
+        from albert_client.types import CollectionList
+
+        response = self._client._client.get("/collections")
+        response.raise_for_status()
+
+        return CollectionList(**response.json())
+
+    def get_collection(self, collection_id: int) -> Collection:
+        """Get a specific collection by ID.
+
+        Args:
+            collection_id: The collection ID.
+
+        Returns:
+            Collection object with full metadata.
+
+        Raises:
+            httpx.HTTPStatusError: If the collection doesn't exist or isn't accessible.
+
+        Example:
+            ```python
+            collection = client.get_collection(123)
+            print(f"Collection: {collection.name}")
+            print(f"Documents: {collection.documents}")
+            ```
+        """
+        from albert_client.types import Collection
+
+        response = self._client._client.get(f"/collections/{collection_id}")
+        response.raise_for_status()
+
+        return Collection(**response.json())
+
+    def update_collection(
+        self,
+        collection_id: int,
+        name: str | None = None,
+        description: str | None = None,
+        visibility: CollectionVisibility | None = None,
+    ) -> Collection:
+        """Update a collection's metadata.
+
+        Only the collection owner can update it. At least one field must be provided.
+
+        Args:
+            collection_id: The collection ID to update.
+            name: New name for the collection (optional).
+            description: New description (optional).
+            visibility: New visibility setting (optional).
+
+        Returns:
+            Updated Collection object.
+
+        Raises:
+            httpx.HTTPStatusError: If the update fails or user lacks permission.
+
+        Example:
+            ```python
+            updated = client.update_collection(
+                123,
+                name="Updated Collection Name",
+                visibility="public"
+            )
+            ```
+        """
+        from albert_client.types import Collection
+
+        # Build request body with only provided fields
+        body = {}
+        if name is not None:
+            body["name"] = name
+        if description is not None:
+            body["description"] = description
+        if visibility is not None:
+            body["visibility"] = visibility
+
+        response = self._client._client.patch(
+            f"/collections/{collection_id}", json=body
+        )
+        response.raise_for_status()
+
+        return Collection(**response.json())
+
+    def delete_collection(self, collection_id: int) -> None:
+        """Delete a collection and all its documents.
+
+        Only the collection owner can delete it. This action is irreversible.
+
+        Args:
+            collection_id: The collection ID to delete.
+
+        Raises:
+            httpx.HTTPStatusError: If the deletion fails or user lacks permission.
+
+        Example:
+            ```python
+            client.delete_collection(123)
+            print("Collection deleted")
+            ```
+        """
+        response = self._client._client.delete(f"/collections/{collection_id}")
+        response.raise_for_status()
+
+    # Phase 3: Documents methods
+
+    def upload_document(
+        self,
+        file_path: str | Path,
+        collection_id: int,
+        chunk_size: int = 2048,
+        chunk_overlap: int = 0,
+        **kwargs,
+    ) -> Document:
+        """Upload a document to a collection.
+
+        The document will be parsed, chunked, and embedded according to the collection's
+        settings. Supports PDF, DOCX, TXT, and other common formats.
+
+        Args:
+            file_path: Path to the file to upload.
+            collection_id: The collection ID to add the document to.
+            chunk_size: Size of text chunks for embedding (default: 2048).
+            chunk_overlap: Overlap between chunks (default: 0).
+            **kwargs: Additional upload parameters (page_range, force_ocr, etc.).
+
+        Returns:
+            Document object with ID and metadata.
+
+        Raises:
+            httpx.HTTPStatusError: If the upload fails.
+
+        Example:
+            ```python
+            doc = client.upload_document(
+                file_path="./legal_doc.pdf",
+                collection_id=123,
+                chunk_size=1024
+            )
+            print(f"Uploaded document {doc.id} with {doc.chunks} chunks")
+            ```
+        """
+        from pathlib import Path
+
+        from albert_client.types import Document
+
+        # Convert to Path object
+        file_path = Path(file_path)
+
+        # Build form data
+        form_data = {
+            "collection": collection_id,
+            "chunk_size": chunk_size,
+            "chunk_overlap": chunk_overlap,
+        }
+        # Add any additional parameters
+        form_data.update(kwargs)
+
+        # Open and upload file
+        with open(file_path, "rb") as f:
+            files = {"file": (file_path.name, f, "application/octet-stream")}
+            response = self._client._client.post(
+                "/documents", data=form_data, files=files
+            )
+            response.raise_for_status()
+
+        return Document(**response.json())
+
+    def list_documents(self, collection_id: int | None = None) -> DocumentList:
+        """List documents in a collection or all accessible documents.
+
+        Args:
+            collection_id: Filter to specific collection. If None, returns all accessible documents.
+
+        Returns:
+            DocumentList containing matching documents.
+
+        Raises:
+            httpx.HTTPStatusError: If the request fails.
+
+        Example:
+            ```python
+            # List all documents in a collection
+            docs = client.list_documents(collection_id=123)
+            for doc in docs.data:
+                print(f"{doc.name}: {doc.chunks} chunks")
+
+            # List all accessible documents
+            all_docs = client.list_documents()
+            ```
+        """
+        from albert_client.types import DocumentList
+
+        params = {}
+        if collection_id is not None:
+            params["collection"] = collection_id
+
+        response = self._client._client.get("/documents", params=params)
+        response.raise_for_status()
+
+        return DocumentList(**response.json())
+
+    def get_document(self, document_id: int) -> Document:
+        """Get a specific document by ID.
+
+        Args:
+            document_id: The document ID.
+
+        Returns:
+            Document object with metadata.
+
+        Raises:
+            httpx.HTTPStatusError: If the document doesn't exist or isn't accessible.
+
+        Example:
+            ```python
+            doc = client.get_document(456)
+            print(f"Document: {doc.name}")
+            print(f"Chunks: {doc.chunks}")
+            ```
+        """
+        from albert_client.types import Document
+
+        response = self._client._client.get(f"/documents/{document_id}")
+        response.raise_for_status()
+
+        return Document(**response.json())
+
+    def delete_document(self, document_id: int) -> None:
+        """Delete a document and all its chunks.
+
+        This action is irreversible. The document's embeddings will also be removed.
+
+        Args:
+            document_id: The document ID to delete.
+
+        Raises:
+            httpx.HTTPStatusError: If the deletion fails.
+
+        Example:
+            ```python
+            client.delete_document(456)
+            print("Document deleted")
+            ```
+        """
+        response = self._client._client.delete(f"/documents/{document_id}")
+        response.raise_for_status()
+
+    # Phase 3: Chunks methods
+
+    def list_chunks(self, document_id: int) -> ChunkList:
+        """List all chunks for a specific document.
+
+        Returns the text chunks that were created when the document was uploaded.
+
+        Args:
+            document_id: The document ID.
+
+        Returns:
+            ChunkList containing all chunks for the document.
+
+        Raises:
+            httpx.HTTPStatusError: If the request fails.
+
+        Example:
+            ```python
+            chunks = client.list_chunks(document_id=456)
+            for chunk in chunks.data:
+                print(f"Chunk {chunk.id}: {chunk.content[:100]}...")
+            ```
+        """
+        from albert_client.types import ChunkList
+
+        response = self._client._client.get(f"/chunks/{document_id}")
+        response.raise_for_status()
+
+        return ChunkList(**response.json())
+
+    def get_chunk(self, document_id: int, chunk_id: int) -> Chunk:
+        """Get a specific chunk by document and chunk ID.
+
+        Args:
+            document_id: The document ID.
+            chunk_id: The chunk ID.
+
+        Returns:
+            Chunk object with content and metadata.
+
+        Raises:
+            httpx.HTTPStatusError: If the chunk doesn't exist.
+
+        Example:
+            ```python
+            chunk = client.get_chunk(document_id=456, chunk_id=123)
+            print(chunk.content)
+            print(chunk.metadata)
+            ```
+        """
+        from albert_client.types import Chunk
+
+        response = self._client._client.get(f"/chunks/{document_id}/{chunk_id}")
+        response.raise_for_status()
+
+        return Chunk(**response.json())
+
+    # Phase 4: Usage tracking
+
+    def get_usage(
+        self, start_date: str | None = None, end_date: str | None = None
+    ) -> UsageList:
+        """Get API usage statistics.
+
+        Returns usage data (tokens, cost, carbon) aggregated by date.
+
+        Args:
+            start_date: Filter from this date (ISO format YYYY-MM-DD). Optional.
+            end_date: Filter until this date (ISO format YYYY-MM-DD). Optional.
+
+        Returns:
+            UsageList with usage records per date.
+
+        Raises:
+            httpx.HTTPStatusError: If the request fails.
+
+        Example:
+            ```python
+            # Get all usage
+            usage = client.get_usage()
+            for record in usage.data:
+                print(f"{record.date}: {record.total_tokens} tokens, ${record.cost}")
+
+            # Get usage for date range
+            usage = client.get_usage(start_date="2024-01-01", end_date="2024-01-31")
+            ```
+        """
+        from albert_client.types import UsageList
+
+        params = {}
+        if start_date is not None:
+            params["start_date"] = start_date
+        if end_date is not None:
+            params["end_date"] = end_date
+
+        response = self._client._client.get("/me/usage", params=params)
+        response.raise_for_status()
+
+        return UsageList(**response.json())
+
+    # Phase 4: OCR & Parsing methods
+
+    def ocr(
+        self,
+        document: dict[str, str] | str,
+        model: str | None = None,
+        pages: list[int] | None = None,
+        include_image_base64: bool = False,
+        **kwargs,
+    ) -> OCRResponse:
+        """Perform OCR on a document with advanced options.
+
+        Advanced OCR with support for JSON mode, bounding boxes, and image extraction.
+
+        Args:
+            document: Document to OCR. Can be:
+                - Dict with 'url' key for document URL
+                - Dict with 'image_url' key for image URL
+                - Direct URL string
+            model: Model to use for OCR (optional).
+            pages: Specific pages to process (0-indexed). If None, processes all pages.
+            include_image_base64: Include base64-encoded images in response.
+            **kwargs: Additional OCR options (bbox_annotation_format,
+                document_annotation_format, etc.).
+
+        Returns:
+            OCRResponse with pages, text, and optional bounding boxes.
+
+        Raises:
+            httpx.HTTPStatusError: If the OCR request fails.
+
+        Example:
+            ```python
+            # OCR from URL
+            result = client.ocr(
+                document="https://example.com/doc.pdf",
+                pages=[0, 1, 2],
+                include_image_base64=True
+            )
+            for page in result.pages:
+                print(f"Page {page.page}: {page.text}")
+            ```
+        """
+        from albert_client.types import OCRResponse
+
+        # Build request body
+        body = {}
+
+        # Handle document parameter
+        if isinstance(document, str):
+            body["document"] = {"url": document}
+        else:
+            body["document"] = document
+
+        if model is not None:
+            body["model"] = model
+        if pages is not None:
+            body["pages"] = pages
+        if include_image_base64:
+            body["include_image_base64"] = include_image_base64
+
+        # Add any additional kwargs
+        body.update(kwargs)
+
+        response = self._client._client.post("/ocr", json=body)
+        response.raise_for_status()
+
+        return OCRResponse(**response.json())
+
+    def ocr_beta(
+        self,
+        file_path: str | Path,
+        model: str,
+        dpi: int = 150,
+        prompt: str | None = None,
+    ) -> ParsedDocument:
+        """Perform simple file-based OCR (beta).
+
+        Simpler OCR method that takes a file and returns parsed text.
+
+        Args:
+            file_path: Path to the file to OCR.
+            model: Model to use for OCR (required).
+            dpi: DPI for rendering pages as images (100-600, default: 150).
+            prompt: Custom prompt for OCR extraction (optional).
+
+        Returns:
+            ParsedDocument with OCR results per page.
+
+        Raises:
+            httpx.HTTPStatusError: If the OCR request fails.
+
+        Example:
+            ```python
+            result = client.ocr_beta(
+                file_path="./scanned_doc.pdf",
+                model="gpt-4o-mini",
+                dpi=300
+            )
+            for page in result.data:
+                print(f"Page {page.page}: {page.content}")
+            ```
+        """
+        from pathlib import Path
+
+        from albert_client.types import ParsedDocument
+
+        file_path = Path(file_path)
+
+        # Build form data
+        form_data = {"model": model, "dpi": dpi}
+        if prompt is not None:
+            form_data["prompt"] = prompt
+
+        # Open and upload file
+        with open(file_path, "rb") as f:
+            files = {"file": (file_path.name, f, "application/octet-stream")}
+            response = self._client._client.post(
+                "/ocr-beta", data=form_data, files=files
+            )
+            response.raise_for_status()
+
+        return ParsedDocument(**response.json())
+
+    def parse(
+        self,
+        file_path: str | Path,
+        output_format: ParsedDocumentOutputFormat = "markdown",
+        force_ocr: bool = False,
+        page_range: str = "",
+        paginate_output: bool = False,
+    ) -> ParsedDocument:
+        """Parse a document to markdown, JSON, or HTML.
+
+        Extract and convert document content to structured format.
+
+        Args:
+            file_path: Path to the file to parse.
+            output_format: Output format - "markdown", "json", or "html" (default: "markdown").
+            force_ocr: Force OCR on all pages (default: False).
+            page_range: Page range to convert (e.g., "0,5-10,20"). Empty = all pages.
+            paginate_output: Separate pages with horizontal rules containing page numbers.
+
+        Returns:
+            ParsedDocument with parsed pages.
+
+        Raises:
+            httpx.HTTPStatusError: If the parsing fails.
+
+        Example:
+            ```python
+            # Parse to markdown
+            result = client.parse(
+                file_path="./document.pdf",
+                output_format="markdown",
+                page_range="0-5"
+            )
+            for page in result.data:
+                print(f"Page {page.page}:")
+                print(page.content)
+            ```
+        """
+        from pathlib import Path
+
+        from albert_client.types import ParsedDocument
+
+        file_path = Path(file_path)
+
+        # Build form data
+        form_data = {
+            "output_format": output_format,
+            "force_ocr": force_ocr,
+            "page_range": page_range,
+            "paginate_output": paginate_output,
+        }
+
+        # Open and upload file
+        with open(file_path, "rb") as f:
+            files = {"file": (file_path.name, f, "application/octet-stream")}
+            response = self._client._client.post(
+                "/parse-beta", data=form_data, files=files
+            )
+            response.raise_for_status()
+
+        return ParsedDocument(**response.json())
+
+    # Phase 4: File management
+
+    def upload_file(
+        self, file_path: str | Path, purpose: str | None = None
+    ) -> FileUploadResponse:
+        """Upload a file to Albert API.
+
+        Generic file upload (different from uploading documents to collections).
+
+        Args:
+            file_path: Path to the file to upload.
+            purpose: Purpose of the file upload (optional).
+
+        Returns:
+            FileUploadResponse with file ID and metadata.
+
+        Raises:
+            httpx.HTTPStatusError: If the upload fails.
+
+        Example:
+            ```python
+            result = client.upload_file(
+                file_path="./data.json",
+                purpose="analysis"
+            )
+            print(f"Uploaded file ID: {result.id}")
+            ```
+        """
+        from pathlib import Path
+
+        from albert_client.types import FileUploadResponse
+
+        file_path = Path(file_path)
+
+        # Build form data
+        form_data = {}
+        if purpose is not None:
+            form_data["purpose"] = purpose
+
+        # Open and upload file
+        with open(file_path, "rb") as f:
+            files = {"file": (file_path.name, f, "application/octet-stream")}
+            response = self._client._client.post("/files", data=form_data, files=files)
+            response.raise_for_status()
+
+        return FileUploadResponse(**response.json())
+
+    # Phase 4: Health & Monitoring
+
+    def health_check(self) -> HealthStatus:
+        """Check API health status.
+
+        Returns:
+            HealthStatus with current API status.
+
+        Raises:
+            httpx.HTTPStatusError: If the health check fails.
+
+        Example:
+            ```python
+            health = client.health_check()
+            print(f"API Status: {health.status}")
+            ```
+        """
+        from albert_client.types import HealthStatus
+
+        response = self._client._client.get("/health")
+        response.raise_for_status()
+
+        return HealthStatus(**response.json())
+
+    def get_metrics(self) -> MetricsData:
+        """Get API metrics.
+
+        Returns performance and usage metrics for the API.
+
+        Returns:
+            MetricsData with API metrics.
+
+        Raises:
+            httpx.HTTPStatusError: If the metrics request fails.
+
+        Example:
+            ```python
+            metrics = client.get_metrics()
+            print(f"Requests/sec: {metrics.requests_per_second}")
+            print(f"Avg latency: {metrics.average_latency_ms}ms")
+            ```
+        """
+        from albert_client.types import MetricsData
+
+        response = self._client._client.get("/metrics")
+        response.raise_for_status()
+
+        return MetricsData(**response.json())

--- a/.moon/templates/albert-client/src/albert_client/types/__init__.py
+++ b/.moon/templates/albert-client/src/albert_client/types/__init__.py
@@ -1,0 +1,67 @@
+"""Albert API response types (Phase 2+)."""
+
+from albert_client.types.collections import (
+    Collection,
+    CollectionList,
+    CollectionVisibility,
+    Document,
+    DocumentList,
+)
+from albert_client.types.search import (
+    Chunk,
+    ChunkList,
+    RerankResponse,
+    RerankResult,
+    SearchMethod,
+    SearchResponse,
+    SearchResult,
+    Usage,
+)
+from albert_client.types.tools import (
+    BoundingBox,
+    FileUploadResponse,
+    HealthStatus,
+    MetricsData,
+    OCRPageObject,
+    OCRResponse,
+    OCRText,
+    OCRUsage,
+    ParsedDocument,
+    ParsedDocumentOutputFormat,
+    ParsedDocumentPage,
+    UsageList,
+    UsageRecord,
+)
+
+
+__all__ = [
+    # Search & Rerank
+    "Chunk",
+    "ChunkList",
+    "RerankResult",
+    "RerankResponse",
+    "SearchMethod",
+    "SearchResult",
+    "SearchResponse",
+    "Usage",
+    # Collections & Documents
+    "Collection",
+    "CollectionList",
+    "CollectionVisibility",
+    "Document",
+    "DocumentList",
+    # Tools, Parsing & Monitoring
+    "BoundingBox",
+    "FileUploadResponse",
+    "HealthStatus",
+    "MetricsData",
+    "OCRPageObject",
+    "OCRResponse",
+    "OCRText",
+    "OCRUsage",
+    "ParsedDocument",
+    "ParsedDocumentOutputFormat",
+    "ParsedDocumentPage",
+    "UsageList",
+    "UsageRecord",
+]

--- a/.moon/templates/albert-client/src/albert_client/types/collections.py
+++ b/.moon/templates/albert-client/src/albert_client/types/collections.py
@@ -1,0 +1,56 @@
+"""Collections and documents types for Albert API.
+
+Models for managing RAG collections and document uploads.
+"""
+
+from typing import Literal
+
+from albert_client._models import BaseModel
+
+
+# Collection types
+
+CollectionVisibility = Literal["private", "public"]
+"""Collection visibility: private (owner only) or public (all users)."""
+
+
+class Collection(BaseModel):
+    """A RAG collection for organizing documents."""
+
+    object: Literal["collection"] = "collection"
+    id: int
+    name: str
+    owner: str
+    description: str | None = None
+    visibility: CollectionVisibility | None = None
+    created: int  # Unix timestamp
+    updated: int  # Unix timestamp
+    documents: int = 0  # Number of documents in collection
+
+
+class CollectionList(BaseModel):
+    """Response from listing collections."""
+
+    object: Literal["list"] = "list"
+    data: list[Collection]
+
+
+# Document types
+
+
+class Document(BaseModel):
+    """A document uploaded to a collection."""
+
+    object: Literal["document"] = "document"
+    id: int
+    name: str
+    collection_id: int
+    created: int  # Unix timestamp
+    chunks: int | None = None  # Number of chunks (may be None during upload)
+
+
+class DocumentList(BaseModel):
+    """Response from listing documents."""
+
+    object: Literal["list"] = "list"
+    data: list[Document]

--- a/.moon/templates/albert-client/src/albert_client/types/search.py
+++ b/.moon/templates/albert-client/src/albert_client/types/search.py
@@ -1,0 +1,78 @@
+"""Search and rerank types for Albert API.
+
+Models for hybrid RAG search and BGE reranking endpoints.
+"""
+
+from typing import Any, Literal
+
+from albert_client._models import BaseModel
+
+
+# Search types
+
+
+class Chunk(BaseModel):
+    """A chunk of text from a document in a collection."""
+
+    object: Literal["chunk"] = "chunk"
+    id: int
+    metadata: dict[str, Any]
+    content: str
+
+
+class ChunkList(BaseModel):
+    """Response from listing chunks."""
+
+    object: Literal["list"] = "list"
+    data: list[Chunk]
+
+
+SearchMethod = Literal["hybrid", "semantic", "lexical"]
+"""Search method: hybrid (semantic + lexical), semantic only, or lexical only."""
+
+
+class SearchResult(BaseModel):
+    """A single search result from Albert API."""
+
+    method: SearchMethod
+    score: float
+    chunk: Chunk
+
+
+class Usage(BaseModel):
+    """Usage information for a request."""
+
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    cost: float = 0.0
+    carbon: dict[str, Any] | None = None  # Carbon footprint details
+    requests: int = 0
+
+
+class SearchResponse(BaseModel):
+    """Response from /v1/search endpoint."""
+
+    object: Literal["list"] = "list"
+    data: list[SearchResult]
+    usage: Usage | None = None
+
+
+# Rerank types
+
+
+class RerankResult(BaseModel):
+    """A single reranked document result."""
+
+    relevance_score: float
+    index: int  # Original position in input list
+
+
+class RerankResponse(BaseModel):
+    """Response from /v1/rerank endpoint."""
+
+    object: Literal["list"] = "list"
+    id: str
+    results: list[RerankResult]
+    model: str
+    usage: Usage | None = None

--- a/.moon/templates/albert-client/src/albert_client/types/tools.py
+++ b/.moon/templates/albert-client/src/albert_client/types/tools.py
@@ -1,0 +1,135 @@
+"""Tools, parsing, and monitoring types for Albert API.
+
+Models for OCR, document parsing, file uploads, usage tracking, and health monitoring.
+"""
+
+from typing import Any, Literal
+
+from albert_client._models import BaseModel
+
+
+# Usage tracking types
+
+
+class UsageRecord(BaseModel):
+    """Usage statistics for a specific date."""
+
+    date: str  # ISO date format (YYYY-MM-DD)
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+    cost: float  # USD
+    carbon_footprint_gco2eq: float | None = None
+    requests: int
+
+
+class UsageList(BaseModel):
+    """Response from listing usage statistics."""
+
+    object: Literal["list"] = "list"
+    data: list[UsageRecord]
+
+
+# OCR types
+
+
+class BoundingBox(BaseModel):
+    """Bounding box coordinates for detected text."""
+
+    x: float
+    y: float
+    width: float
+    height: float
+
+
+class OCRText(BaseModel):
+    """Detected text with optional bounding box."""
+
+    text: str
+    bbox: BoundingBox | None = None
+    confidence: float | None = None
+
+
+class OCRPageObject(BaseModel):
+    """OCR results for a single page."""
+
+    page: int
+    text: str | None = None
+    texts: list[OCRText] | None = None
+    images: list[str] | None = None  # Base64 encoded images
+
+
+class OCRUsage(BaseModel):
+    """OCR-specific usage information."""
+
+    pages: int
+    images: int | None = None
+
+
+class OCRResponse(BaseModel):
+    """Response from OCR operation."""
+
+    pages: list[OCRPageObject]
+    document_annotation: str | None = None
+    id: str | None = None
+    model: str | None = None
+    # Can be Usage (from search.py) or OCRUsage - using Any to avoid circular imports
+    usage: Any = None
+    usage_info: OCRUsage | None = None
+
+
+# Parsing types
+
+ParsedDocumentOutputFormat = Literal["markdown", "json", "html"]
+"""Output format for parsed documents."""
+
+
+class ParsedDocumentPage(BaseModel):
+    """A page from a parsed document."""
+
+    page: int
+    content: str
+    metadata: dict[str, Any] | None = None
+
+
+class ParsedDocument(BaseModel):
+    """Response from document parsing."""
+
+    object: Literal["list"] = "list"
+    data: list[ParsedDocumentPage]
+    # Usage information (from search.py) - using Any to avoid circular imports
+    usage: Any = None
+
+
+# File upload types
+
+
+class FileUploadResponse(BaseModel):
+    """Response from file upload."""
+
+    id: str
+    filename: str
+    bytes: int
+    created_at: int  # Unix timestamp
+    purpose: str | None = None
+
+
+# Health & Monitoring types
+
+
+class HealthStatus(BaseModel):
+    """API health status."""
+
+    status: str  # e.g., "ok", "degraded", "down"
+    version: str | None = None
+    timestamp: int | None = None
+
+
+class MetricsData(BaseModel):
+    """API metrics data."""
+
+    requests_total: int | None = None
+    requests_per_second: float | None = None
+    average_latency_ms: float | None = None
+    error_rate: float | None = None
+    uptime_seconds: int | None = None

--- a/.moon/templates/albert-client/template.yml
+++ b/.moon/templates/albert-client/template.yml
@@ -1,0 +1,4 @@
+title: Albert Client
+description: Albert Client package
+destination: packages/albert-client
+variables: {}

--- a/.moon/templates/chainlit-chat/README.md
+++ b/.moon/templates/chainlit-chat/README.md
@@ -1,6 +1,6 @@
 # Chainlit Chat
 
-This is a simple Chainlit-based chat application designed to benchmark the OpenGate LLM (Albert API) using the OpenAI Functions Streaming pattern.
+This is a simple Chainlit-based chat application designed to benchmark the Albert API using the OpenAI-compatible Functions Streaming pattern via the albert-client SDK.
 
 ## Setup
 

--- a/.moon/templates/chainlit-chat/app.py
+++ b/.moon/templates/chainlit-chat/app.py
@@ -5,9 +5,9 @@ import os
 import chainlit as cl
 import engineio
 import engineio.payload
+from albert_client import AsyncAlbertClient
 from context_loader import process_file
 from dotenv import load_dotenv
-from openai import AsyncOpenAI
 
 # Increase the number of packets allowed in a single payload to prevent "Too
 # many packets in payload" errors. This is especially helpful during streaming
@@ -21,7 +21,7 @@ api_key = os.getenv("OPENAI_API_KEY")
 base_url = os.getenv("OPENAI_BASE_URL")
 model = os.getenv("OPENAI_MODEL")
 
-client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+client = AsyncAlbertClient(api_key=api_key, base_url=base_url)
 
 
 # Example dummy function

--- a/.moon/templates/chainlit-chat/app.py
+++ b/.moon/templates/chainlit-chat/app.py
@@ -5,9 +5,11 @@ import os
 import chainlit as cl
 import engineio
 import engineio.payload
-from albert_client import AsyncAlbertClient
 from context_loader import process_file
 from dotenv import load_dotenv
+
+from albert_client import AsyncAlbertClient
+
 
 # Increase the number of packets allowed in a single payload to prevent "Too
 # many packets in payload" errors. This is especially helpful during streaming

--- a/.moon/templates/chainlit-chat/pyproject.toml
+++ b/.moon/templates/chainlit-chat/pyproject.toml
@@ -5,13 +5,13 @@ description = "{{ description }}"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "chainlit>=1.3.0",
     "albert-client",
-    "python-dotenv>=1.0.0",
-    "pyyaml>=6.0.0",
+    "chainlit>=1.3.0",
 {%- if use_pdf %}
     "pdf-context",
 {%- endif %}
+    "python-dotenv>=1.0.0",
+    "pyyaml>=6.0.0",
 ]
 
 [project.scripts]

--- a/.moon/templates/chainlit-chat/pyproject.toml
+++ b/.moon/templates/chainlit-chat/pyproject.toml
@@ -22,12 +22,7 @@ py-modules = ["app", "context_loader"]
 
 [tool.uv.sources]
 albert-client = { workspace = true }
-{%- if use_pdf %}
 pdf-context = { workspace = true }
-{%- endif %}
-{%- if use_chroma %}
-chroma-context = { workspace = true }
-{%- endif %}
 
 [tool.uv]
 package = true

--- a/.moon/templates/chainlit-chat/pyproject.toml
+++ b/.moon/templates/chainlit-chat/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "{{ project_name }}"
-version = "0.6.1" # x-release-please-version
+version = "0.7.0" # x-release-please-version
 description = "{{ description }}"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "chainlit>=1.3.0",
-    "openai>=1.0.0",
+    "albert-client",
     "python-dotenv>=1.0.0",
     "pyyaml>=6.0.0",
 {%- if use_pdf %}
@@ -20,15 +20,14 @@ chainlit-chat = "chainlit.cli:run"
 [tool.setuptools]
 py-modules = ["app", "context_loader"]
 
-{% if use_pdf or use_chroma %}
 [tool.uv.sources]
+albert-client = { workspace = true }
 {%- if use_pdf %}
 pdf-context = { workspace = true }
 {%- endif %}
 {%- if use_chroma %}
 chroma-context = { workspace = true }
 {%- endif %}
-{% endif %}
 
 [tool.uv]
 package = true

--- a/.moon/templates/pdf-context/pyproject.toml
+++ b/.moon/templates/pdf-context/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pdf-context"
-version = "0.6.1" # x-release-please-version
+version = "0.7.0" # x-release-please-version
 description = "PDF text extraction and context formatting for LLM applications"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/.moon/templates/pdf-context/src/pdf_context/__init__.py
+++ b/.moon/templates/pdf-context/src/pdf_context/__init__.py
@@ -19,6 +19,7 @@ Example usage:
 from .extractor import extract_text_from_bytes, extract_text_from_pdf
 from .formatter import format_as_context, process_multiple_files, process_pdf_file
 
+
 __all__ = [
     "extract_text_from_pdf",
     "extract_text_from_bytes",

--- a/.moon/templates/reflex-chat/app/components/navbar.py
+++ b/.moon/templates/reflex-chat/app/components/navbar.py
@@ -13,14 +13,14 @@ def sidebar_chat(chat: str) -> rx.Component:
         rx.hstack(
             rx.button(
                 chat,
-                on_click=lambda: State.set_chat(chat),  # ty:ignore[call-non-callable]
+                on_click=lambda: State.set_chat(chat),
                 width="80%",
                 variant="surface",
             ),
             rx.button(
                 rx.icon(
                     tag="trash",
-                    on_click=State.delete_chat(chat),  # ty:ignore[call-non-callable]
+                    on_click=State.delete_chat(chat),
                     stroke_width=1,
                 ),
                 width="20%",

--- a/.moon/templates/reflex-chat/app/state.py
+++ b/.moon/templates/reflex-chat/app/state.py
@@ -2,10 +2,9 @@ import os
 from typing import Any, TypedDict
 
 import reflex as rx
+from albert_client import AlbertClient, ChatCompletionMessageParam
 from context_loader import process_bytes
 from dotenv import load_dotenv
-from openai import OpenAI
-from openai.types.chat import ChatCompletionMessageParam
 
 # Load .env file
 load_dotenv()
@@ -154,7 +153,7 @@ class State(rx.State):
         if not question:
             return
 
-        async for value in self.openai_process_question(question):  # ty:ignore[call-non-callable]
+        async for value in self.openai_process_question(question):
             yield value
 
     @rx.event
@@ -202,7 +201,7 @@ class State(rx.State):
         messages = messages[:-1]
 
         # Start a new session to answer the question.
-        session = OpenAI(
+        session = AlbertClient(
             base_url=os.getenv("OPENAI_BASE_URL"),
         ).chat.completions.create(
             model=os.getenv("OPENAI_MODEL", "gpt-3.5-turbo"),

--- a/.moon/templates/reflex-chat/app/state.py
+++ b/.moon/templates/reflex-chat/app/state.py
@@ -2,9 +2,11 @@ import os
 from typing import Any, TypedDict
 
 import reflex as rx
-from albert_client import AlbertClient, ChatCompletionMessageParam
 from context_loader import process_bytes
 from dotenv import load_dotenv
+
+from albert_client import AlbertClient, ChatCompletionMessageParam
+
 
 # Load .env file
 load_dotenv()

--- a/.moon/templates/reflex-chat/pyproject.toml
+++ b/.moon/templates/reflex-chat/pyproject.toml
@@ -5,13 +5,13 @@ description = "{{ description }}"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "reflex>=0.7.11",
     "albert-client",
-    "python-dotenv>=1.0.0",
-    "pyyaml>=6.0.0",
 {%- if use_pdf %}
     "pdf-context",
 {%- endif %}
+    "python-dotenv>=1.0.0",
+    "pyyaml>=6.0.0",
+    "reflex>=0.7.11",
 ]
 
 [project.scripts]

--- a/.moon/templates/reflex-chat/pyproject.toml
+++ b/.moon/templates/reflex-chat/pyproject.toml
@@ -25,12 +25,7 @@ py-modules = ["context_loader"]
 
 [tool.uv.sources]
 albert-client = { workspace = true }
-{%- if use_pdf %}
 pdf-context = { workspace = true }
-{%- endif %}
-{%- if use_chroma %}
-chroma-context = { workspace = true }
-{%- endif %}
 
 [tool.uv]
 package = true

--- a/.moon/templates/reflex-chat/pyproject.toml
+++ b/.moon/templates/reflex-chat/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "{{ project_name }}"
-version = "0.6.1" # x-release-please-version
+version = "0.7.0" # x-release-please-version
 description = "{{ description }}"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "reflex>=0.7.11",
-    "openai>=1.78.1",
+    "albert-client",
     "python-dotenv>=1.0.0",
     "pyyaml>=6.0.0",
 {%- if use_pdf %}
@@ -23,15 +23,14 @@ include = ["{{ project_name | replace(from='-', to='_') }}*"]
 [tool.setuptools]
 py-modules = ["context_loader"]
 
-{% if use_pdf or use_chroma %}
 [tool.uv.sources]
+albert-client = { workspace = true }
 {%- if use_pdf %}
 pdf-context = { workspace = true }
 {%- endif %}
 {%- if use_chroma %}
 chroma-context = { workspace = true }
 {%- endif %}
-{% endif %}
 
 [tool.uv]
 package = true

--- a/.moon/templates/reflex-chat/rxconfig.py
+++ b/.moon/templates/reflex-chat/rxconfig.py
@@ -2,10 +2,12 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
+
 # Load environment variables from .env file
 load_dotenv(Path(__file__).parent / ".env")
 
 import reflex as rx  # noqa: E402
+
 
 config = rx.Config(
     app_name="{{ project_name | replace(from='-', to='_') }}",

--- a/apps/chainlit-chat/README.md
+++ b/apps/chainlit-chat/README.md
@@ -1,6 +1,6 @@
 # Chainlit Chat
 
-This is a simple Chainlit-based chat application designed to benchmark the OpenGate LLM (Albert API) using the OpenAI Functions Streaming pattern.
+This is a simple Chainlit-based chat application designed to benchmark the Albert API using the OpenAI-compatible Functions Streaming pattern via the albert-client SDK.
 
 ## Setup
 

--- a/apps/chainlit-chat/app.py
+++ b/apps/chainlit-chat/app.py
@@ -5,9 +5,9 @@ import os
 import chainlit as cl
 import engineio
 import engineio.payload
+from albert_client import AsyncAlbertClient
 from context_loader import process_file
 from dotenv import load_dotenv
-from openai import AsyncOpenAI
 
 # Increase the number of packets allowed in a single payload to prevent "Too
 # many packets in payload" errors. This is especially helpful during streaming
@@ -21,7 +21,7 @@ api_key = os.getenv("OPENAI_API_KEY")
 base_url = os.getenv("OPENAI_BASE_URL")
 model = os.getenv("OPENAI_MODEL")
 
-client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+client = AsyncAlbertClient(api_key=api_key, base_url=base_url)
 
 
 # Example dummy function

--- a/apps/chainlit-chat/app.py
+++ b/apps/chainlit-chat/app.py
@@ -5,9 +5,11 @@ import os
 import chainlit as cl
 import engineio
 import engineio.payload
-from albert_client import AsyncAlbertClient
 from context_loader import process_file
 from dotenv import load_dotenv
+
+from albert_client import AsyncAlbertClient
+
 
 # Increase the number of packets allowed in a single payload to prevent "Too
 # many packets in payload" errors. This is especially helpful during streaming

--- a/apps/chainlit-chat/pyproject.toml
+++ b/apps/chainlit-chat/pyproject.toml
@@ -19,5 +19,5 @@ chainlit-chat = "chainlit.cli:run"
 py-modules = ["app", "context_loader"]
 
 [tool.uv.sources]
-pdf-context = { workspace = true }
 albert-client = { workspace = true }
+pdf-context = { workspace = true }

--- a/apps/chainlit-chat/pyproject.toml
+++ b/apps/chainlit-chat/pyproject.toml
@@ -5,11 +5,11 @@ description = "Chainlit Chat with OpenAI Functions Streaming"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "chainlit>=1.3.0",
     "albert-client",
+    "chainlit>=1.3.0",
+    "pdf-context",
     "python-dotenv>=1.0.0",
     "pyyaml>=6.0.0",
-    "pdf-context",
 ]
 
 [project.scripts]

--- a/apps/chainlit-chat/pyproject.toml
+++ b/apps/chainlit-chat/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "chainlit>=1.3.0",
-    "openai>=1.0.0",
+    "albert-client",
     "python-dotenv>=1.0.0",
     "pyyaml>=6.0.0",
     "pdf-context",
@@ -20,3 +20,4 @@ py-modules = ["app", "context_loader"]
 
 [tool.uv.sources]
 pdf-context = { workspace = true }
+albert-client = { workspace = true }

--- a/apps/cli/pyproject.toml
+++ b/apps/cli/pyproject.toml
@@ -5,18 +5,18 @@ description = "RAG Facile CLI - Generate RAG workspaces for French Government"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "typer>=0.12.0",
-    "rich>=13.0.0",
+    "albert-client",
+    "datasets>=3.0.0",
+    "huggingface-hub>=1.3.0",
+    "letta-client>=0.1.0",
     "libcst>=1.8.6",
+    "pypdf>=5.0.0",
+    "python-dotenv>=1.0.0",
     "pyyaml>=6.0.2",
     "questionary>=2.0.0",
-    "huggingface-hub>=1.3.0",
-    "datasets>=3.0.0",
-    "python-dotenv>=1.0.0",
-    "letta-client>=0.1.0",
     "requests>=2.31.0",
-    "pypdf>=5.0.0",
-    "albert-client",
+    "rich>=13.0.0",
+    "typer>=0.12.0",
 ]
 
 [dependency-groups]

--- a/apps/cli/pyproject.toml
+++ b/apps/cli/pyproject.toml
@@ -40,3 +40,4 @@ packages = ["src/cli"]
 [tool.hatch.build.targets.wheel.force-include]
 "../../.moon/templates" = "cli/templates"
 "../../packages/pdf-context/src/pdf_context" = "cli/pdf_context_src"
+"../../packages/albert-client/src/albert_client" = "cli/albert_client_src"

--- a/apps/cli/pyproject.toml
+++ b/apps/cli/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "letta-client>=0.1.0",
     "requests>=2.31.0",
     "pypdf>=5.0.0",
+    "albert-client",
 ]
 
 [dependency-groups]
@@ -23,6 +24,9 @@ dev = [
     "pytest>=8.0.0",
     "pytest-mock>=3.12.0",
 ]
+
+[tool.uv.sources]
+albert-client = { workspace = true }
 
 [project.scripts]
 rag-facile = "cli.main:app"

--- a/apps/cli/pyproject.toml
+++ b/apps/cli/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "pyyaml>=6.0.2",
     "questionary>=2.0.0",
-    "requests>=2.31.0",
     "rich>=13.0.0",
     "typer>=0.12.0",
 ]

--- a/apps/cli/src/cli/commands/gen_template.py
+++ b/apps/cli/src/cli/commands/gen_template.py
@@ -8,6 +8,7 @@ import typer
 import yaml
 from rich.console import Console
 
+
 app = typer.Typer()
 console = Console()
 

--- a/apps/cli/src/cli/commands/generate_dataset.py
+++ b/apps/cli/src/cli/commands/generate_dataset.py
@@ -15,6 +15,7 @@ import typer
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
+
 console = Console()
 
 # Supported document extensions

--- a/apps/cli/src/cli/commands/providers/albert.py
+++ b/apps/cli/src/cli/commands/providers/albert.py
@@ -10,12 +10,6 @@ from collections.abc import Iterator
 from datetime import datetime, timezone
 from pathlib import Path
 
-try:
-    import requests
-except ImportError as e:
-    raise ImportError(
-        "requests package is required. Install with: uv add requests"
-    ) from e
 
 try:
     from albert_client import AlbertClient
@@ -26,6 +20,7 @@ except ImportError as e:
 
 from .document_preprocessor import DocumentPreprocessor
 from .schema import GeneratedSample
+
 
 logger = logging.getLogger(__name__)
 
@@ -50,8 +45,8 @@ class AlbertApiProvider:
         self.base_url = base_url.rstrip("/")
         self.model = model
 
-        # Initialize Albert client for LLM calls
-        self.llm_client = AlbertClient(api_key=api_key, base_url=self.base_url)
+        # Initialize Albert client for all API operations
+        self.albert_client = AlbertClient(api_key=api_key, base_url=self.base_url)
 
         # Initialize document preprocessor for PDF extraction
         self.preprocessor = DocumentPreprocessor()
@@ -76,66 +71,35 @@ class AlbertApiProvider:
         processed_paths = self.preprocessor.process_documents(document_paths)
         logger.info(f"Preprocessed {len(processed_paths)} documents")
 
-        # Create a collection
+        # Create a collection using SDK
         collection_name = (
             f"data_foundry_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}"
         )
 
-        collection_data = {
-            "name": collection_name,
-            "description": "RAG Facile Data Foundry",
-        }
-        response = requests.post(
-            f"{self.base_url}/collections",
-            json=collection_data,
-            headers={"Authorization": f"Bearer {self.api_key}"},
+        collection = self.albert_client.collections.create(
+            name=collection_name,
+            description="RAG Facile Data Foundry",
         )
-        response.raise_for_status()
-        collection_response = response.json()
-        self.collection_id = collection_response.get("id")
-
-        if not self.collection_id:
-            raise ValueError("Failed to create collection: no ID in response")
+        self.collection_id = collection.id
 
         logger.info(f"Created Albert collection: {self.collection_id}")
 
-        # Upload each processed document
+        # Upload each processed document using SDK
         for i, doc_path in enumerate(processed_paths, 1):
             logger.info(
                 f"Uploading document {i}/{len(processed_paths)}: {Path(doc_path).name}"
             )
-            with open(doc_path, "rb") as f:
-                # Determine MIME type based on file extension
-                mime_types = {
-                    ".pdf": "application/pdf",
-                    ".txt": "text/plain",
-                    ".md": "text/markdown",
-                }
-                ext = Path(doc_path).suffix.lower()
-                mime_type = mime_types.get(ext, "application/octet-stream")
-                logger.debug(
-                    f"  MIME type: {mime_type}, Size: {Path(doc_path).stat().st_size} bytes"
-                )
+            logger.debug(f"  Size: {Path(doc_path).stat().st_size} bytes")
 
-                # Send file and collection in multipart form data
-                files = {
-                    "file": (Path(doc_path).name, f, mime_type),
-                    "collection": (None, str(self.collection_id)),
-                }
-                doc_response = requests.post(
-                    f"{self.base_url}/documents",
-                    files=files,
-                    headers={"Authorization": f"Bearer {self.api_key}"},
+            try:
+                self.albert_client.documents.upload(
+                    file_path=doc_path, collection_id=self.collection_id
                 )
-                if doc_response.status_code != 201:
-                    error_msg = (
-                        f"Failed to upload {doc_path}: "
-                        f"{doc_response.status_code} {doc_response.text}"
-                    )
-                    logger.error(error_msg)
-                    raise RuntimeError(error_msg)
                 logger.debug("  Upload successful")
-                doc_response.raise_for_status()
+            except Exception as e:
+                error_msg = f"Failed to upload {doc_path}: {e}"
+                logger.error(error_msg)
+                raise RuntimeError(error_msg) from e
 
     def generate(self, num_samples: int) -> Iterator[GeneratedSample]:
         """Generate Q/A samples using hybrid search and LLM.
@@ -163,7 +127,7 @@ class AlbertApiProvider:
         total_response = ""
 
         try:
-            stream = self.llm_client.chat.completions.create(
+            stream = self.albert_client.chat.completions.create(
                 model=self.model,
                 messages=[{"role": "user", "content": prompt}],
                 stream=True,
@@ -209,10 +173,7 @@ class AlbertApiProvider:
         """Delete collection from Albert API and clean up temporary files."""
         if self.collection_id:
             try:
-                requests.delete(
-                    f"{self.base_url}/collections/{self.collection_id}",
-                    headers={"Authorization": f"Bearer {self.api_key}"},
-                )
+                self.albert_client.collections.delete(self.collection_id)
             except Exception:
                 pass  # Non-critical
 

--- a/apps/cli/src/cli/commands/providers/albert.py
+++ b/apps/cli/src/cli/commands/providers/albert.py
@@ -18,9 +18,11 @@ except ImportError as e:
     ) from e
 
 try:
-    from openai import OpenAI
+    from albert_client import AlbertClient
 except ImportError as e:
-    raise ImportError("openai package is required. Install with: uv add openai") from e
+    raise ImportError(
+        "albert-client package is required. Install with: uv add albert-client"
+    ) from e
 
 from .document_preprocessor import DocumentPreprocessor
 from .schema import GeneratedSample
@@ -48,8 +50,8 @@ class AlbertApiProvider:
         self.base_url = base_url.rstrip("/")
         self.model = model
 
-        # Initialize OpenAI client for Albert API
-        self.llm_client = OpenAI(api_key=api_key, base_url=self.base_url)
+        # Initialize Albert client for LLM calls
+        self.llm_client = AlbertClient(api_key=api_key, base_url=self.base_url)
 
         # Initialize document preprocessor for PDF extraction
         self.preprocessor = DocumentPreprocessor()

--- a/apps/cli/src/cli/commands/providers/document_preprocessor.py
+++ b/apps/cli/src/cli/commands/providers/document_preprocessor.py
@@ -9,6 +9,7 @@ import tempfile
 from pathlib import Path
 from typing import Optional
 
+
 try:
     from pdf_context import extract_text_from_pdf
 except ImportError:

--- a/apps/cli/src/cli/commands/providers/letta.py
+++ b/apps/cli/src/cli/commands/providers/letta.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from .document_preprocessor import DocumentPreprocessor
 from .schema import GeneratedSample
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/apps/cli/src/cli/commands/setup.py
+++ b/apps/cli/src/cli/commands/setup.py
@@ -686,6 +686,7 @@ def run(
         "sys-config",
         "chainlit-chat",
         "reflex-chat",
+        "albert-client",
         "pdf-context",
         "chroma-context",
     ]:
@@ -760,10 +761,22 @@ OPENAI_MODEL={env_config["openai_model"]}
     env_file.write_text(env_content)
     console.print("[green]✓[/green] Created .env file")
 
+    # 4. Generate albert-client package (always required)
+    console.print()
+    console.print(
+        "[bold green]Step 4:[/bold green] Generating albert-client package..."
+    )
+    albert_cmd = ["moon", "generate", "albert-client", "--defaults"]
+    if force:
+        albert_cmd.append("--force")
+    if not run_command(albert_cmd, "generate albert-client", cwd=target_path):
+        raise typer.Exit(1)
+    console.print("[green]✓[/green] albert-client package generated")
+
     # 5. Generate selected packages
     if selected_modules:
         console.print()
-        console.print("[bold green]Step 4:[/bold green] Generating packages...")
+        console.print("[bold green]Step 5:[/bold green] Generating packages...")
 
         for module in selected_modules:
             module_info = MODULES[module]
@@ -789,14 +802,14 @@ OPENAI_MODEL={env_config["openai_model"]}
 
     # Run uv sync to install dependencies
     console.print()
-    console.print("[bold green]Step 5:[/bold green] Installing dependencies...")
+    console.print("[bold green]Step 6:[/bold green] Installing dependencies...")
     if not run_command(["uv", "sync"], "install dependencies", cwd=target_path):
         console.print("[yellow]Warning: uv sync failed. Run it manually.[/yellow]")
 
     # Start the dev server
     console.print()
     console.print(
-        f"[bold green]Step 6:[/bold green] Starting {frontend_choice} dev server..."
+        f"[bold green]Step 7:[/bold green] Starting {frontend_choice} dev server..."
     )
     console.print()
     console.print(f"[dim]Your app is at: {target_display}[/dim]")

--- a/apps/cli/src/cli/commands/setup.py
+++ b/apps/cli/src/cli/commands/setup.py
@@ -348,9 +348,8 @@ package = true
 
     # For Reflex, we also need to copy the app package directory
     if frontend_choice == "Reflex":
-        # The template uses [project_name | replace(from='-', to='_')] as dir name
-        template_app_dir_name = "[project_name | replace(from='-', to='_')]"
-        template_app_dir = template_dir / template_app_dir_name
+        # The template uses static "app" directory (moon doesn't support filters in paths)
+        template_app_dir = template_dir / "app"
         if template_app_dir.exists():
             snake_name = project_name.replace("-", "_")
             target_app_dir = target_path / snake_name
@@ -359,10 +358,12 @@ package = true
             for src_file in template_app_dir.rglob("*"):
                 if src_file.is_file():
                     rel_path = src_file.relative_to(template_app_dir)
-                    # Rename files/dirs that contain the placeholder
-                    rel_path_str = str(rel_path).replace(
-                        "[project_name | replace(from='-', to='_')]", snake_name
-                    )
+                    rel_path_str = str(rel_path)
+
+                    # Rename app.py to {snake_name}.py (Reflex expects {app_name}/{app_name}.py)
+                    if rel_path_str == "app.py":
+                        rel_path_str = f"{snake_name}.py"
+
                     target_file = target_app_dir / rel_path_str
                     target_file.parent.mkdir(parents=True, exist_ok=True)
                     content = render_template_file(src_file, variables)

--- a/apps/cli/src/cli/commands/setup.py
+++ b/apps/cli/src/cli/commands/setup.py
@@ -10,6 +10,7 @@ import questionary
 import typer
 from rich.console import Console
 
+
 console = Console()
 
 

--- a/apps/cli/src/cli/commands/setup.py
+++ b/apps/cli/src/cli/commands/setup.py
@@ -178,6 +178,24 @@ def get_pdf_context_source() -> Path:
     )
 
 
+def get_albert_client_source() -> Path:
+    """Get the albert-client source directory for inline copying."""
+    # In development mode, use the packages directory
+    repo_root = Path(__file__).resolve().parents[5]
+    local_source = repo_root / "packages" / "albert-client" / "src" / "albert_client"
+    if local_source.exists():
+        return local_source
+
+    # For installed CLI, albert_client is bundled at cli/albert_client_src
+    package_source = Path(__file__).resolve().parent.parent / "albert_client_src"
+    if package_source.exists():
+        return package_source
+
+    raise FileNotFoundError(
+        "albert-client source not found. This is a packaging error - please reinstall the CLI."
+    )
+
+
 def render_template_file(template_path: Path, variables: dict[str, str | bool]) -> str:
     """Render a template file with Tera-style variables.
 
@@ -257,11 +275,12 @@ def generate_standalone(
 
     # Create pyproject.toml for standalone mode
     pdf_dep = '\n    "pypdf>=5.0.0",' if "PDF" in selected_modules else ""
-    setuptools_packages = (
-        'packages = ["pdf_context"]' if "PDF" in selected_modules else ""
-    )
+    setuptools_packages_list = ["albert_client"]
+    if "PDF" in selected_modules:
+        setuptools_packages_list.append("pdf_context")
+    setuptools_packages = f"packages = {setuptools_packages_list}"
 
-    # For standalone, we don't need workspace sources - pdf_context is local
+    # For standalone, albert-client and pdf-context are local modules (not dependencies)
     pyproject_content = f'''[project]
 name = "{project_name}"
 version = "0.1.0"
@@ -270,7 +289,9 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "chainlit>=1.3.0",
+    "httpx>=0.24.0",
     "openai>=1.0.0",
+    "pydantic>=2.0.0",
     "python-dotenv>=1.0.0",
     "pyyaml>=6.0.0",{pdf_dep}
 ]
@@ -292,13 +313,16 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "reflex>=0.7.0",
+    "httpx>=0.24.0",
     "openai>=1.0.0",
+    "pydantic>=2.0.0",
     "python-dotenv>=1.0.0",
     "pyyaml>=6.0.0",{pdf_dep}
 ]
 
-[tool.setuptools.packages.find]
-where = ["."]
+[tool.setuptools]
+py-modules = ["app", "context_loader"]
+{setuptools_packages}
 
 [tool.uv]
 package = true
@@ -359,10 +383,29 @@ package = true
 
     console.print("[green]✓[/green] Project files generated")
 
-    # Step 3: Copy pdf_context as local module if selected
+    # Step 3: Copy albert-client as local module (always required)
+    console.print()
+    console.print("[bold green]Step 3:[/bold green] Adding Albert client module...")
+
+    try:
+        albert_source = get_albert_client_source()
+        target_albert = target_path / "albert_client"
+        if target_albert.exists():
+            shutil.rmtree(target_albert)
+        shutil.copytree(albert_source, target_albert)
+        # Remove __pycache__ if copied
+        pycache = target_albert / "__pycache__"
+        if pycache.exists():
+            shutil.rmtree(pycache)
+        console.print("[green]✓[/green] Albert client module added")
+    except FileNotFoundError as e:
+        console.print(f"[yellow]Warning: {e}[/yellow]")
+        console.print("[yellow]You'll need to install albert-client manually.[/yellow]")
+
+    # Step 4: Copy pdf_context as local module if selected
     if "PDF" in selected_modules:
         console.print()
-        console.print("[bold green]Step 3:[/bold green] Adding PDF context module...")
+        console.print("[bold green]Step 4:[/bold green] Adding PDF context module...")
 
         try:
             pdf_source = get_pdf_context_source()
@@ -381,8 +424,8 @@ package = true
                 "[yellow]You'll need to install pdf-context manually.[/yellow]"
             )
 
-    # Step 4: Create .env file
-    step_num = 4 if "PDF" in selected_modules else 3
+    # Step 5: Create .env file
+    step_num = 5 if "PDF" in selected_modules else 4
     console.print()
     console.print(
         f"[bold green]Step {step_num}:[/bold green] Creating environment file..."

--- a/apps/cli/src/cli/main.py
+++ b/apps/cli/src/cli/main.py
@@ -4,7 +4,8 @@ from typing import Optional
 import typer
 from rich.console import Console
 
-from cli.commands import setup, generate_dataset
+from cli.commands import generate_dataset, setup
+
 
 console = Console()
 

--- a/apps/cli/tests/test_document_preprocessor.py
+++ b/apps/cli/tests/test_document_preprocessor.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+
 from cli.commands.providers.document_preprocessor import DocumentPreprocessor
 
 

--- a/apps/cli/tests/test_generate_dataset.py
+++ b/apps/cli/tests/test_generate_dataset.py
@@ -5,10 +5,12 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from typer.testing import CliRunner
+
 from cli.commands.providers.albert import AlbertApiProvider
 from cli.commands.providers.schema import GeneratedSample, SampleMetadata
 from cli.main import app as main_app
-from typer.testing import CliRunner
+
 
 runner = CliRunner()
 
@@ -17,18 +19,19 @@ class TestAlbertApiProvider:
     """Tests for AlbertApiProvider."""
 
     @pytest.fixture
-    def mock_requests(self, mocker):
-        """Mock the requests library."""
-        mock_req = mocker.patch("cli.commands.providers.albert.requests")
-        return mock_req
-
-    @pytest.fixture
-    def mock_openai(self, mocker):
+    def mock_albert_client(self, mocker):
         """Mock the Albert client."""
         mock_client = mocker.patch("cli.commands.providers.albert.AlbertClient")
+
+        # Setup default mocks for SDK methods
+        mock_instance = mock_client.return_value
+        mock_instance.collections.create.return_value = MagicMock(id="col-123")
+        mock_instance.documents.upload.return_value = MagicMock()
+        mock_instance.collections.delete.return_value = None
+
         return mock_client
 
-    def test_provider_initialization(self, mock_requests, mock_openai):
+    def test_provider_initialization(self, mock_albert_client):
         """Should initialize with API credentials."""
         provider = AlbertApiProvider(
             api_key="test-key", base_url="http://localhost:8000", model="mistral-7b"
@@ -37,10 +40,10 @@ class TestAlbertApiProvider:
         assert provider.api_key == "test-key"
         assert provider.base_url == "http://localhost:8000"
         assert provider.model == "mistral-7b"
-        # OpenAI client should be initialized
-        mock_openai.assert_called_once()
+        # Albert client should be initialized
+        mock_albert_client.assert_called_once()
 
-    def test_base_url_stripping(self, mock_requests, mock_openai):
+    def test_base_url_stripping(self, mock_albert_client):
         """Should strip trailing slash from base_url."""
         provider = AlbertApiProvider(
             api_key="test-key", base_url="http://localhost:8000/", model="mistral-7b"
@@ -48,18 +51,8 @@ class TestAlbertApiProvider:
 
         assert provider.base_url == "http://localhost:8000"
 
-    def test_upload_documents_creates_collection(self, mock_requests, mock_openai):
+    def test_upload_documents_creates_collection(self, mock_albert_client):
         """Should create a collection and upload documents."""
-        # Mock responses for collection creation and document upload
-        collection_response = MagicMock()
-        collection_response.json.return_value = {"id": "col-123"}
-
-        upload_response = MagicMock()
-        upload_response.status_code = 201
-        upload_response.raise_for_status = MagicMock()
-
-        mock_requests.post.side_effect = [collection_response, upload_response]
-
         provider = AlbertApiProvider(
             api_key="test-key", base_url="http://localhost:8000", model="mistral-7b"
         )
@@ -74,15 +67,11 @@ class TestAlbertApiProvider:
             # Should store collection ID
             assert provider.collection_id == "col-123"
 
-            # Should call POST for collection creation
-            calls = mock_requests.post.call_args_list
-            assert len(calls) >= 2  # Collection creation + document upload
+            # Should call SDK methods for collection creation and document upload
+            provider.albert_client.collections.create.assert_called_once()
+            provider.albert_client.documents.upload.assert_called_once()
 
-            # First call should be to create collection
-            first_call = calls[0]
-            assert "/collections" in first_call[0][0]
-
-    def test_generate_requires_collection(self, mock_requests, mock_openai):
+    def test_generate_requires_collection(self, mock_albert_client):
         """Should raise error if generate called without uploaded documents."""
         provider = AlbertApiProvider(
             api_key="test-key", base_url="http://localhost:8000", model="mistral-7b"
@@ -91,19 +80,8 @@ class TestAlbertApiProvider:
         with pytest.raises(RuntimeError, match="No collection ID"):
             list(provider.generate(10))
 
-    def test_cleanup_deletes_collection(self, mock_requests, mock_openai):
+    def test_cleanup_deletes_collection(self, mock_albert_client):
         """Should delete collection on cleanup."""
-        # Mock responses for collection creation and document upload
-        collection_response = MagicMock()
-        collection_response.json.return_value = {"id": "col-123"}
-
-        upload_response = MagicMock()
-        upload_response.status_code = 201
-        upload_response.raise_for_status = MagicMock()
-
-        mock_requests.post.side_effect = [collection_response, upload_response]
-        mock_requests.delete.return_value = MagicMock()
-
         provider = AlbertApiProvider(
             api_key="test-key", base_url="http://localhost:8000", model="mistral-7b"
         )
@@ -116,23 +94,11 @@ class TestAlbertApiProvider:
 
         provider.cleanup()
 
-        # Should call DELETE with collection ID
-        delete_calls = mock_requests.delete.call_args_list
-        assert len(delete_calls) >= 1
-        assert "col-123" in delete_calls[0][0][0]
+        # Should call SDK delete method with collection ID
+        provider.albert_client.collections.delete.assert_called_once_with("col-123")
 
-    def test_generate_streams_samples(self, mock_requests, mock_openai):
+    def test_generate_streams_samples(self, mock_albert_client):
         """Should stream samples from LLM response."""
-        # Mock responses for collection creation and document upload
-        collection_response = MagicMock()
-        collection_response.json.return_value = {"id": "col-123"}
-
-        upload_response = MagicMock()
-        upload_response.status_code = 201
-        upload_response.raise_for_status = MagicMock()
-
-        mock_requests.post.side_effect = [collection_response, upload_response]
-
         # Mock LLM response
         mock_chunk1 = MagicMock()
         mock_chunk1.choices = [MagicMock()]
@@ -144,7 +110,7 @@ class TestAlbertApiProvider:
         mock_chunk2.choices = [MagicMock()]
         mock_chunk2.choices[0].delta.content = None
 
-        mock_openai.return_value.chat.completions.create.return_value = [
+        mock_albert_client.return_value.chat.completions.create.return_value = [
             mock_chunk1,
             mock_chunk2,
         ]
@@ -165,7 +131,7 @@ class TestAlbertApiProvider:
         assert samples[0].user_input == "What is AI?"
         assert samples[0].reference == "AI is artificial intelligence"
 
-    def test_initialization_with_valid_credentials(self, mock_openai):
+    def test_initialization_with_valid_credentials(self, mock_albert_client):
         """Should initialize successfully with valid credentials."""
         provider = AlbertApiProvider(
             api_key="test-key", base_url="http://localhost:8000", model="mistral-7b"
@@ -174,7 +140,7 @@ class TestAlbertApiProvider:
         assert provider.api_key == "test-key"
         assert provider.base_url == "http://localhost:8000"
         assert provider.model == "mistral-7b"
-        mock_openai.assert_called()
+        mock_albert_client.assert_called()
 
 
 class TestGenerateDatasetCommand:

--- a/apps/cli/tests/test_generate_dataset.py
+++ b/apps/cli/tests/test_generate_dataset.py
@@ -24,8 +24,8 @@ class TestAlbertApiProvider:
 
     @pytest.fixture
     def mock_openai(self, mocker):
-        """Mock the OpenAI client."""
-        mock_client = mocker.patch("cli.commands.providers.albert.OpenAI")
+        """Mock the Albert client."""
+        mock_client = mocker.patch("cli.commands.providers.albert.AlbertClient")
         return mock_client
 
     def test_provider_initialization(self, mock_requests, mock_openai):

--- a/apps/cli/tests/test_setup.py
+++ b/apps/cli/tests/test_setup.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from typer.testing import CliRunner
+
 from cli.commands.setup import (
     FRONTENDS,
     MODULES,
@@ -15,7 +17,7 @@ from cli.commands.setup import (
     run_command,
 )
 from cli.main import app as main_app
-from typer.testing import CliRunner
+
 
 runner = CliRunner()
 

--- a/apps/cli/tests/test_setup.py
+++ b/apps/cli/tests/test_setup.py
@@ -460,7 +460,9 @@ class TestGenerateStandalone:
         pyproject = standalone_target / "pyproject.toml"
         content = pyproject.read_text()
         assert "pypdf>=5.0.0" in content
-        assert 'packages = ["pdf_context"]' in content
+        # Both albert_client (always included) and pdf_context should be in packages
+        assert "'albert_client'" in content or '"albert_client"' in content
+        assert "'pdf_context'" in content or '"pdf_context"' in content
 
     def test_modules_yml_includes_pdf_provider(
         self, standalone_target, mock_standalone_deps

--- a/apps/reflex-chat/pyproject.toml
+++ b/apps/reflex-chat/pyproject.toml
@@ -5,11 +5,11 @@ description = "Reflex Chat Application"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "reflex>=0.7.11",
     "albert-client",
+    "pdf-context",
     "python-dotenv>=1.0.0",
     "pyyaml>=6.0.0",
-    "pdf-context",
+    "reflex>=0.7.11",
 ]
 
 [project.scripts]

--- a/apps/reflex-chat/pyproject.toml
+++ b/apps/reflex-chat/pyproject.toml
@@ -22,5 +22,5 @@ include = ["reflex_chat*"]
 py-modules = ["context_loader"]
 
 [tool.uv.sources]
-pdf-context = { workspace = true }
 albert-client = { workspace = true }
+pdf-context = { workspace = true }

--- a/apps/reflex-chat/pyproject.toml
+++ b/apps/reflex-chat/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "reflex>=0.7.11",
-    "openai>=1.78.1",
+    "albert-client",
     "python-dotenv>=1.0.0",
     "pyyaml>=6.0.0",
     "pdf-context",
@@ -23,3 +23,4 @@ py-modules = ["context_loader"]
 
 [tool.uv.sources]
 pdf-context = { workspace = true }
+albert-client = { workspace = true }

--- a/apps/reflex-chat/reflex_chat/state.py
+++ b/apps/reflex-chat/reflex_chat/state.py
@@ -2,9 +2,11 @@ import os
 from typing import Any, TypedDict
 
 import reflex as rx
-from albert_client import AlbertClient, ChatCompletionMessageParam
 from context_loader import process_bytes
 from dotenv import load_dotenv
+
+from albert_client import AlbertClient, ChatCompletionMessageParam
+
 
 # Load .env file
 load_dotenv()

--- a/apps/reflex-chat/reflex_chat/state.py
+++ b/apps/reflex-chat/reflex_chat/state.py
@@ -2,10 +2,9 @@ import os
 from typing import Any, TypedDict
 
 import reflex as rx
+from albert_client import AlbertClient, ChatCompletionMessageParam
 from context_loader import process_bytes
 from dotenv import load_dotenv
-from openai import OpenAI
-from openai.types.chat import ChatCompletionMessageParam
 
 # Load .env file
 load_dotenv()
@@ -202,7 +201,7 @@ class State(rx.State):
         messages = messages[:-1]
 
         # Start a new session to answer the question.
-        session = OpenAI(
+        session = AlbertClient(
             base_url=os.getenv("OPENAI_BASE_URL"),
         ).chat.completions.create(
             model=os.getenv("OPENAI_MODEL", "gpt-3.5-turbo"),

--- a/apps/reflex-chat/rxconfig.py
+++ b/apps/reflex-chat/rxconfig.py
@@ -2,10 +2,12 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
+
 # Load environment variables from .env file
 load_dotenv(Path(__file__).parent / ".env")
 
 import reflex as rx  # noqa: E402
+
 
 config = rx.Config(
     app_name="reflex_chat",

--- a/packages/albert-client/README.md
+++ b/packages/albert-client/README.md
@@ -5,6 +5,7 @@ Official Python SDK for France's [Albert API](https://albert.api.etalab.gouv.fr/
 ## Why Use This SDK?
 
 - **OpenAI-Compatible**: Use the same code you know from OpenAI with French sovereign models
+- **Single Dependency**: The only dependency in RAG Facile that requires the OpenAI SDK - all apps and packages use albert-client
 - **RAG Made Easy**: Built-in hybrid search, reranking, and collections management
 - **Type-Safe**: Full autocomplete and type checking in your IDE
 - **Production-Ready**: Async support, comprehensive error handling, battle-tested

--- a/packages/albert-client/pyproject.toml
+++ b/packages/albert-client/pyproject.toml
@@ -35,19 +35,6 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/albert_client"]
 
-[tool.ruff]
-extend-exclude = []
-line-length = 100
-target-version = "py311"
-
-[tool.ruff.lint]
-select = ["E", "F", "I", "UP"]
-ignore = []
-
-[tool.ruff.format]
-quote-style = "double"
-indent-style = "space"
-
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"

--- a/packages/albert-client/src/albert_client/__init__.py
+++ b/packages/albert-client/src/albert_client/__init__.py
@@ -5,10 +5,10 @@ French government-specific features like RAG search, collections management,
 and carbon footprint tracking.
 """
 
-# Re-export commonly used OpenAI types for convenience
-# Apps can use these types without importing openai directly
+# Third-party imports
 from openai.types.chat import ChatCompletionMessageParam
 
+# Local imports
 from albert_client._async_client import AsyncAlbertClient
 from albert_client._version import __version__
 from albert_client.client import AlbertClient

--- a/packages/albert-client/src/albert_client/__init__.py
+++ b/packages/albert-client/src/albert_client/__init__.py
@@ -41,6 +41,7 @@ from albert_client.types import (
     UsageRecord,
 )
 
+
 __all__ = [
     # Clients
     "AlbertClient",

--- a/packages/albert-client/src/albert_client/__init__.py
+++ b/packages/albert-client/src/albert_client/__init__.py
@@ -5,6 +5,10 @@ French government-specific features like RAG search, collections management,
 and carbon footprint tracking.
 """
 
+# Re-export commonly used OpenAI types for convenience
+# Apps can use these types without importing openai directly
+from openai.types.chat import ChatCompletionMessageParam
+
 from albert_client._async_client import AsyncAlbertClient
 from albert_client._version import __version__
 from albert_client.client import AlbertClient
@@ -41,6 +45,8 @@ __all__ = [
     # Clients
     "AlbertClient",
     "AsyncAlbertClient",
+    # OpenAI type re-exports
+    "ChatCompletionMessageParam",
     # Search & Rerank types
     "Chunk",
     "ChunkList",

--- a/packages/albert-client/src/albert_client/_async_client.py
+++ b/packages/albert-client/src/albert_client/_async_client.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from openai import AsyncOpenAI
 
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -363,7 +364,9 @@ class AsyncAlbertClient:
         if visibility is not None:
             body["visibility"] = visibility
 
-        response = await self._client._client.patch(f"/collections/{collection_id}", json=body)
+        response = await self._client._client.patch(
+            f"/collections/{collection_id}", json=body
+        )
         response.raise_for_status()
 
         return Collection(**response.json())
@@ -435,7 +438,9 @@ class AsyncAlbertClient:
 
         with open(file_path, "rb") as f:
             files = {"file": (file_path.name, f, "application/octet-stream")}
-            response = await self._client._client.post("/documents", data=form_data, files=files)
+            response = await self._client._client.post(
+                "/documents", data=form_data, files=files
+            )
             response.raise_for_status()
 
         return Document(**response.json())
@@ -665,7 +670,9 @@ class AsyncAlbertClient:
 
         with open(file_path, "rb") as f:
             files = {"file": (file_path.name, f, "application/octet-stream")}
-            response = await self._client._client.post("/ocr-beta", data=form_data, files=files)
+            response = await self._client._client.post(
+                "/ocr-beta", data=form_data, files=files
+            )
             response.raise_for_status()
 
         return ParsedDocument(**response.json())
@@ -710,7 +717,9 @@ class AsyncAlbertClient:
 
         with open(file_path, "rb") as f:
             files = {"file": (file_path.name, f, "application/octet-stream")}
-            response = await self._client._client.post("/parse-beta", data=form_data, files=files)
+            response = await self._client._client.post(
+                "/parse-beta", data=form_data, files=files
+            )
             response.raise_for_status()
 
         return ParsedDocument(**response.json())
@@ -746,7 +755,9 @@ class AsyncAlbertClient:
 
         with open(file_path, "rb") as f:
             files = {"file": (file_path.name, f, "application/octet-stream")}
-            response = await self._client._client.post("/files", data=form_data, files=files)
+            response = await self._client._client.post(
+                "/files", data=form_data, files=files
+            )
             response.raise_for_status()
 
         return FileUploadResponse(**response.json())

--- a/packages/albert-client/src/albert_client/_async_client.py
+++ b/packages/albert-client/src/albert_client/_async_client.py
@@ -66,18 +66,20 @@ class AsyncAlbertClient:
         """Initialize async Albert client.
 
         Args:
-            api_key: Albert API key. If not provided, reads from ALBERT_API_KEY env var.
+            api_key: Albert API key. If not provided, reads from ALBERT_API_KEY or OPENAI_API_KEY env var.
             base_url: Base URL for Albert API (includes /v1 suffix).
             **kwargs: Additional arguments passed to AsyncOpenAI client.
         """
-        # Get API key from env if not provided
+        # Get API key from env if not provided (check both ALBERT_API_KEY and OPENAI_API_KEY)
         if api_key is None:
-            api_key = os.environ.get("ALBERT_API_KEY")
+            api_key = os.environ.get("ALBERT_API_KEY") or os.environ.get(
+                "OPENAI_API_KEY"
+            )
 
         if not api_key:
             raise ValueError(
                 "Albert API key is required. Provide via api_key parameter or "
-                "ALBERT_API_KEY environment variable."
+                "ALBERT_API_KEY/OPENAI_API_KEY environment variable."
             )
 
         # Initialize wrapped AsyncOpenAI client

--- a/packages/albert-client/src/albert_client/_async_client.py
+++ b/packages/albert-client/src/albert_client/_async_client.py
@@ -59,7 +59,7 @@ class AsyncAlbertClient:
     def __init__(
         self,
         api_key: str | None = None,
-        base_url: str = "https://albert.api.etalab.gouv.fr/v1",
+        base_url: str | None = "https://albert.api.etalab.gouv.fr/v1",
         **kwargs,
     ):
         """Initialize async Albert client.

--- a/packages/albert-client/src/albert_client/client.py
+++ b/packages/albert-client/src/albert_client/client.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from openai import OpenAI
 
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -375,7 +376,9 @@ class AlbertClient:
         if visibility is not None:
             body["visibility"] = visibility
 
-        response = self._client._client.patch(f"/collections/{collection_id}", json=body)
+        response = self._client._client.patch(
+            f"/collections/{collection_id}", json=body
+        )
         response.raise_for_status()
 
         return Collection(**response.json())
@@ -457,7 +460,9 @@ class AlbertClient:
         # Open and upload file
         with open(file_path, "rb") as f:
             files = {"file": (file_path.name, f, "application/octet-stream")}
-            response = self._client._client.post("/documents", data=form_data, files=files)
+            response = self._client._client.post(
+                "/documents", data=form_data, files=files
+            )
             response.raise_for_status()
 
         return Document(**response.json())
@@ -601,7 +606,9 @@ class AlbertClient:
 
     # Phase 4: Usage tracking
 
-    def get_usage(self, start_date: str | None = None, end_date: str | None = None) -> UsageList:
+    def get_usage(
+        self, start_date: str | None = None, end_date: str | None = None
+    ) -> UsageList:
         """Get API usage statistics.
 
         Returns usage data (tokens, cost, carbon) aggregated by date.
@@ -757,7 +764,9 @@ class AlbertClient:
         # Open and upload file
         with open(file_path, "rb") as f:
             files = {"file": (file_path.name, f, "application/octet-stream")}
-            response = self._client._client.post("/ocr-beta", data=form_data, files=files)
+            response = self._client._client.post(
+                "/ocr-beta", data=form_data, files=files
+            )
             response.raise_for_status()
 
         return ParsedDocument(**response.json())
@@ -817,14 +826,18 @@ class AlbertClient:
         # Open and upload file
         with open(file_path, "rb") as f:
             files = {"file": (file_path.name, f, "application/octet-stream")}
-            response = self._client._client.post("/parse-beta", data=form_data, files=files)
+            response = self._client._client.post(
+                "/parse-beta", data=form_data, files=files
+            )
             response.raise_for_status()
 
         return ParsedDocument(**response.json())
 
     # Phase 4: File management
 
-    def upload_file(self, file_path: str | Path, purpose: str | None = None) -> FileUploadResponse:
+    def upload_file(
+        self, file_path: str | Path, purpose: str | None = None
+    ) -> FileUploadResponse:
         """Upload a file to Albert API.
 
         Generic file upload (different from uploading documents to collections).

--- a/packages/albert-client/src/albert_client/client.py
+++ b/packages/albert-client/src/albert_client/client.py
@@ -72,18 +72,20 @@ class AlbertClient:
         """Initialize Albert client.
 
         Args:
-            api_key: Albert API key. If not provided, reads from ALBERT_API_KEY env var.
+            api_key: Albert API key. If not provided, reads from ALBERT_API_KEY or OPENAI_API_KEY env var.
             base_url: Base URL for Albert API (includes /v1 suffix).
             **kwargs: Additional arguments passed to OpenAI client (timeout, max_retries, etc.).
         """
-        # Get API key from env if not provided
+        # Get API key from env if not provided (check both ALBERT_API_KEY and OPENAI_API_KEY)
         if api_key is None:
-            api_key = os.environ.get("ALBERT_API_KEY")
+            api_key = os.environ.get("ALBERT_API_KEY") or os.environ.get(
+                "OPENAI_API_KEY"
+            )
 
         if not api_key:
             raise ValueError(
                 "Albert API key is required. Provide via api_key parameter or "
-                "ALBERT_API_KEY environment variable."
+                "ALBERT_API_KEY/OPENAI_API_KEY environment variable."
             )
 
         # Initialize wrapped OpenAI client

--- a/packages/albert-client/src/albert_client/client.py
+++ b/packages/albert-client/src/albert_client/client.py
@@ -65,7 +65,7 @@ class AlbertClient:
     def __init__(
         self,
         api_key: str | None = None,
-        base_url: str = "https://albert.api.etalab.gouv.fr/v1",
+        base_url: str | None = "https://albert.api.etalab.gouv.fr/v1",
         **kwargs,
     ):
         """Initialize Albert client.

--- a/packages/albert-client/src/albert_client/resources/__init__.py
+++ b/packages/albert-client/src/albert_client/resources/__init__.py
@@ -1,1 +1,0 @@
-"""Albert API resource implementations (Phase 3+)."""

--- a/packages/albert-client/src/albert_client/types/__init__.py
+++ b/packages/albert-client/src/albert_client/types/__init__.py
@@ -33,6 +33,7 @@ from albert_client.types.tools import (
     UsageRecord,
 )
 
+
 __all__ = [
     # Search & Rerank
     "Chunk",

--- a/packages/albert-client/src/albert_client/types/collections.py
+++ b/packages/albert-client/src/albert_client/types/collections.py
@@ -7,6 +7,7 @@ from typing import Literal
 
 from albert_client._models import BaseModel
 
+
 # Collection types
 
 CollectionVisibility = Literal["private", "public"]

--- a/packages/albert-client/src/albert_client/types/search.py
+++ b/packages/albert-client/src/albert_client/types/search.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 
 from albert_client._models import BaseModel
 
+
 # Search types
 
 

--- a/packages/albert-client/src/albert_client/types/tools.py
+++ b/packages/albert-client/src/albert_client/types/tools.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 
 from albert_client._models import BaseModel
 
+
 # Usage tracking types
 
 

--- a/packages/albert-client/tests/test_async_client.py
+++ b/packages/albert-client/tests/test_async_client.py
@@ -24,6 +24,24 @@ class TestAsyncClientInitialization:
         client = AsyncAlbertClient(base_url=base_url)
         assert client.api_key == api_key
 
+    def test_init_with_openai_api_key_fallback(self, base_url, monkeypatch):
+        """Test initialization with OPENAI_API_KEY env var (fallback)."""
+        api_key = "openai_from_env"
+        monkeypatch.setenv("OPENAI_API_KEY", api_key)
+
+        client = AsyncAlbertClient(base_url=base_url)
+        assert client.api_key == api_key
+
+    def test_init_albert_api_key_takes_precedence(self, base_url, monkeypatch):
+        """Test that ALBERT_API_KEY takes precedence over OPENAI_API_KEY."""
+        albert_key = "albert_key"
+        openai_key = "openai_key"
+        monkeypatch.setenv("ALBERT_API_KEY", albert_key)
+        monkeypatch.setenv("OPENAI_API_KEY", openai_key)
+
+        client = AsyncAlbertClient(base_url=base_url)
+        assert client.api_key == albert_key
+
     def test_init_without_api_key_raises_error(self, base_url):
         """Test that missing API key raises ValueError."""
         with pytest.raises(ValueError, match="Albert API key is required"):

--- a/packages/albert-client/tests/test_async_collections_documents.py
+++ b/packages/albert-client/tests/test_async_collections_documents.py
@@ -99,7 +99,9 @@ class TestAsyncCollections:
     async def test_list_collections(self, client, base_url, mock_collection):
         """Test async list collections."""
         respx.get(f"{base_url.rstrip('/')}/collections").mock(
-            return_value=Response(200, json={"object": "list", "data": [mock_collection]})
+            return_value=Response(
+                200, json={"object": "list", "data": [mock_collection]}
+            )
         )
 
         result = await client.list_collections()
@@ -136,12 +138,16 @@ class TestAsyncCollections:
     @respx.mock
     async def test_delete_collection(self, client, base_url):
         """Test async delete collection."""
-        respx.delete(f"{base_url.rstrip('/')}/collections/123").mock(return_value=Response(204))
+        respx.delete(f"{base_url.rstrip('/')}/collections/123").mock(
+            return_value=Response(204)
+        )
 
         await client.delete_collection(123)
 
     @respx.mock
-    async def test_collections_context_manager(self, api_key, base_url, mock_collection):
+    async def test_collections_context_manager(
+        self, api_key, base_url, mock_collection
+    ):
         """Test async collections with context manager."""
         respx.post(f"{base_url.rstrip('/')}/collections").mock(
             return_value=Response(200, json=mock_collection)
@@ -208,19 +214,25 @@ class TestAsyncDocuments:
     @respx.mock
     async def test_delete_document(self, client, base_url):
         """Test async delete document."""
-        respx.delete(f"{base_url.rstrip('/')}/documents/456").mock(return_value=Response(204))
+        respx.delete(f"{base_url.rstrip('/')}/documents/456").mock(
+            return_value=Response(204)
+        )
 
         await client.delete_document(456)
 
     @respx.mock
-    async def test_documents_context_manager(self, api_key, base_url, mock_document, temp_file):
+    async def test_documents_context_manager(
+        self, api_key, base_url, mock_document, temp_file
+    ):
         """Test async documents with context manager."""
         respx.post(f"{base_url.rstrip('/')}/documents").mock(
             return_value=Response(200, json=mock_document)
         )
 
         async with AsyncAlbertClient(api_key=api_key, base_url=base_url) as client:
-            result = await client.upload_document(file_path=temp_file, collection_id=123)
+            result = await client.upload_document(
+                file_path=temp_file, collection_id=123
+            )
             assert isinstance(result, Document)
 
 

--- a/packages/albert-client/tests/test_async_rerank.py
+++ b/packages/albert-client/tests/test_async_rerank.py
@@ -153,7 +153,9 @@ class TestAsyncRerank:
         )
 
         with pytest.raises(Exception):  # httpx.HTTPStatusError
-            await client.rerank(query="test", documents=sample_documents, model="nonexistent-model")
+            await client.rerank(
+                query="test", documents=sample_documents, model="nonexistent-model"
+            )
 
     @respx.mock
     async def test_async_rerank_scores_descending(
@@ -164,7 +166,9 @@ class TestAsyncRerank:
             return_value=Response(200, json=mock_rerank_response)
         )
 
-        result = await client.rerank(query="test", documents=sample_documents, model="test-model")
+        result = await client.rerank(
+            query="test", documents=sample_documents, model="test-model"
+        )
 
         # Verify scores are in descending order
         scores = [r.relevance_score for r in result.results]

--- a/packages/albert-client/tests/test_async_search.py
+++ b/packages/albert-client/tests/test_async_search.py
@@ -52,7 +52,9 @@ class TestAsyncSearch:
         )
 
         # Make async request
-        result = await client.search(prompt="Loi Énergie Climat", collections=["col_123"])
+        result = await client.search(
+            prompt="Loi Énergie Climat", collections=["col_123"]
+        )
 
         # Verify result type
         assert isinstance(result, SearchResponse)
@@ -72,7 +74,9 @@ class TestAsyncSearch:
         assert "énergie" in chunk.content.lower()
 
     @respx.mock
-    async def test_async_search_with_parameters(self, client, base_url, mock_search_response):
+    async def test_async_search_with_parameters(
+        self, client, base_url, mock_search_response
+    ):
         """Test async search with optional parameters."""
         respx.post(f"{base_url.rstrip('/')}/search").mock(
             return_value=Response(200, json=mock_search_response)
@@ -90,7 +94,9 @@ class TestAsyncSearch:
         assert len(result.data) == 1
 
     @respx.mock
-    async def test_async_search_context_manager(self, api_key, base_url, mock_search_response):
+    async def test_async_search_context_manager(
+        self, api_key, base_url, mock_search_response
+    ):
         """Test async search with context manager."""
         respx.post(f"{base_url.rstrip('/')}/search").mock(
             return_value=Response(200, json=mock_search_response)
@@ -118,7 +124,9 @@ class TestAsyncSearch:
     async def test_async_search_http_error(self, client, base_url):
         """Test async search with HTTP error response."""
         respx.post(f"{base_url.rstrip('/')}/search").mock(
-            return_value=Response(404, json={"error": {"message": "Collection not found"}})
+            return_value=Response(
+                404, json={"error": {"message": "Collection not found"}}
+            )
         )
 
         with pytest.raises(Exception):  # httpx.HTTPStatusError
@@ -130,7 +138,9 @@ class TestAsyncSearchMethods:
 
     @respx.mock
     @pytest.mark.parametrize("method", ["hybrid", "semantic", "lexical"])
-    async def test_async_search_methods(self, client, base_url, method, mock_search_response):
+    async def test_async_search_methods(
+        self, client, base_url, method, mock_search_response
+    ):
         """Test all three async search methods."""
         # Update response to match method
         mock_search_response["data"][0]["method"] = method

--- a/packages/albert-client/tests/test_async_tools.py
+++ b/packages/albert-client/tests/test_async_tools.py
@@ -79,7 +79,9 @@ class TestAsyncUsageTracking:
 
         result = await client.get_usage(start_date="2024-01-01", end_date="2024-01-31")
 
-        assert mock_route.calls.last.request.url.params.get("start_date") == "2024-01-01"
+        assert (
+            mock_route.calls.last.request.url.params.get("start_date") == "2024-01-01"
+        )
         assert isinstance(result, UsageList)
 
     @respx.mock
@@ -108,7 +110,9 @@ class TestAsyncOCR:
             "model": "doctr",
         }
 
-        respx.post(f"{base_url.rstrip('/')}/ocr").mock(return_value=Response(200, json=mock_ocr))
+        respx.post(f"{base_url.rstrip('/')}/ocr").mock(
+            return_value=Response(200, json=mock_ocr)
+        )
 
         result = await client.ocr(document="https://example.com/doc.pdf")
 
@@ -120,7 +124,9 @@ class TestAsyncOCR:
         """Test async OCR with options."""
         mock_ocr = {"pages": [{"page": 0, "text": "Page 1"}], "model": "doctr"}
 
-        respx.post(f"{base_url.rstrip('/')}/ocr").mock(return_value=Response(200, json=mock_ocr))
+        respx.post(f"{base_url.rstrip('/')}/ocr").mock(
+            return_value=Response(200, json=mock_ocr)
+        )
 
         result = await client.ocr(
             document="https://example.com/doc.pdf",

--- a/packages/albert-client/tests/test_chunks.py
+++ b/packages/albert-client/tests/test_chunks.py
@@ -76,7 +76,9 @@ class TestListChunks:
     def test_list_chunks_http_error(self, client, base_url):
         """Test list chunks with HTTP error."""
         respx.get(f"{base_url.rstrip('/')}/chunks/999").mock(
-            return_value=Response(404, json={"error": {"message": "Document not found"}})
+            return_value=Response(
+                404, json={"error": {"message": "Document not found"}}
+            )
         )
 
         with pytest.raises(Exception):  # httpx.HTTPStatusError

--- a/packages/albert-client/tests/test_client.py
+++ b/packages/albert-client/tests/test_client.py
@@ -24,6 +24,24 @@ class TestClientInitialization:
         client = AlbertClient(base_url=base_url)
         assert client.api_key == api_key
 
+    def test_init_with_openai_api_key_fallback(self, base_url, monkeypatch):
+        """Test initialization with OPENAI_API_KEY env var (fallback)."""
+        api_key = "openai_from_env"
+        monkeypatch.setenv("OPENAI_API_KEY", api_key)
+
+        client = AlbertClient(base_url=base_url)
+        assert client.api_key == api_key
+
+    def test_init_albert_api_key_takes_precedence(self, base_url, monkeypatch):
+        """Test that ALBERT_API_KEY takes precedence over OPENAI_API_KEY."""
+        albert_key = "albert_key"
+        openai_key = "openai_key"
+        monkeypatch.setenv("ALBERT_API_KEY", albert_key)
+        monkeypatch.setenv("OPENAI_API_KEY", openai_key)
+
+        client = AlbertClient(base_url=base_url)
+        assert client.api_key == albert_key
+
     def test_init_without_api_key_raises_error(self, base_url):
         """Test that missing API key raises ValueError."""
         with pytest.raises(ValueError, match="Albert API key is required"):

--- a/packages/albert-client/tests/test_collections.py
+++ b/packages/albert-client/tests/test_collections.py
@@ -64,7 +64,9 @@ class TestCreateCollection:
         assert result.visibility == "private"
 
     @respx.mock
-    def test_create_collection_with_all_parameters(self, client, base_url, mock_collection):
+    def test_create_collection_with_all_parameters(
+        self, client, base_url, mock_collection
+    ):
         """Test creating collection with all parameters."""
         mock_route = respx.post(f"{base_url.rstrip('/')}/collections").mock(
             return_value=Response(200, json=mock_collection)
@@ -89,7 +91,9 @@ class TestCreateCollection:
     def test_create_collection_http_error(self, client, base_url):
         """Test create collection with HTTP error."""
         respx.post(f"{base_url.rstrip('/')}/collections").mock(
-            return_value=Response(400, json={"error": {"message": "Invalid collection name"}})
+            return_value=Response(
+                400, json={"error": {"message": "Invalid collection name"}}
+            )
         )
 
         with pytest.raises(Exception):  # httpx.HTTPStatusError
@@ -215,7 +219,9 @@ class TestDeleteCollection:
     @respx.mock
     def test_delete_collection(self, client, base_url):
         """Test deleting a collection."""
-        respx.delete(f"{base_url.rstrip('/')}/collections/123").mock(return_value=Response(204))
+        respx.delete(f"{base_url.rstrip('/')}/collections/123").mock(
+            return_value=Response(204)
+        )
 
         # Should not raise
         client.delete_collection(123)

--- a/packages/albert-client/tests/test_documents.py
+++ b/packages/albert-client/tests/test_documents.py
@@ -73,7 +73,9 @@ class TestUploadDocument:
         assert result.chunks == 10
 
     @respx.mock
-    def test_upload_document_with_parameters(self, client, base_url, mock_document, temp_file):
+    def test_upload_document_with_parameters(
+        self, client, base_url, mock_document, temp_file
+    ):
         """Test uploading document with custom parameters."""
         respx.post(f"{base_url.rstrip('/')}/documents").mock(
             return_value=Response(200, json=mock_document)
@@ -94,7 +96,9 @@ class TestUploadDocument:
     def test_upload_document_http_error(self, client, base_url, temp_file):
         """Test upload document with HTTP error."""
         respx.post(f"{base_url.rstrip('/')}/documents").mock(
-            return_value=Response(400, json={"error": {"message": "Invalid collection"}})
+            return_value=Response(
+                400, json={"error": {"message": "Invalid collection"}}
+            )
         )
 
         with pytest.raises(Exception):  # httpx.HTTPStatusError
@@ -181,7 +185,9 @@ class TestDeleteDocument:
     @respx.mock
     def test_delete_document(self, client, base_url):
         """Test deleting a document."""
-        respx.delete(f"{base_url.rstrip('/')}/documents/456").mock(return_value=Response(204))
+        respx.delete(f"{base_url.rstrip('/')}/documents/456").mock(
+            return_value=Response(204)
+        )
 
         # Should not raise
         client.delete_document(456)

--- a/packages/albert-client/tests/test_rerank.py
+++ b/packages/albert-client/tests/test_rerank.py
@@ -54,7 +54,9 @@ class TestRerank:
     """Test rerank method."""
 
     @respx.mock
-    def test_rerank_basic(self, client, base_url, mock_rerank_response, sample_documents):
+    def test_rerank_basic(
+        self, client, base_url, mock_rerank_response, sample_documents
+    ):
         """Test basic rerank request."""
         # Mock the rerank endpoint
         respx.post(f"{base_url.rstrip('/')}/rerank").mock(
@@ -86,7 +88,9 @@ class TestRerank:
         assert result.usage.cost == 0.005
 
     @respx.mock
-    def test_rerank_with_top_n(self, client, base_url, mock_rerank_response, sample_documents):
+    def test_rerank_with_top_n(
+        self, client, base_url, mock_rerank_response, sample_documents
+    ):
         """Test rerank with top_n parameter."""
         # Return only top 2 results
         limited_response = mock_rerank_response.copy()
@@ -147,7 +151,9 @@ class TestRerank:
             return_value=Response(200, json=response_no_usage)
         )
 
-        result = client.rerank(query="test", documents=sample_documents, model="test-model")
+        result = client.rerank(
+            query="test", documents=sample_documents, model="test-model"
+        )
 
         assert isinstance(result, RerankResponse)
         assert result.usage is None
@@ -160,7 +166,9 @@ class TestRerank:
         )
 
         with pytest.raises(Exception):  # httpx.HTTPStatusError
-            client.rerank(query="test", documents=sample_documents, model="nonexistent-model")
+            client.rerank(
+                query="test", documents=sample_documents, model="nonexistent-model"
+            )
 
     @respx.mock
     def test_rerank_pydantic_helpers(
@@ -254,20 +262,26 @@ class TestRerankScores:
             return_value=Response(200, json=mock_rerank_response)
         )
 
-        result = client.rerank(query="test", documents=sample_documents, model="test-model")
+        result = client.rerank(
+            query="test", documents=sample_documents, model="test-model"
+        )
 
         # Verify scores are in descending order
         scores = [r.relevance_score for r in result.results]
         assert scores == sorted(scores, reverse=True)
 
     @respx.mock
-    def test_rerank_score_range(self, client, base_url, mock_rerank_response, sample_documents):
+    def test_rerank_score_range(
+        self, client, base_url, mock_rerank_response, sample_documents
+    ):
         """Test that rerank scores are valid floats."""
         respx.post(f"{base_url.rstrip('/')}/rerank").mock(
             return_value=Response(200, json=mock_rerank_response)
         )
 
-        result = client.rerank(query="test", documents=sample_documents, model="test-model")
+        result = client.rerank(
+            query="test", documents=sample_documents, model="test-model"
+        )
 
         # Verify all scores are valid floats
         for rerank_result in result.results:

--- a/packages/albert-client/tests/test_search.py
+++ b/packages/albert-client/tests/test_search.py
@@ -176,7 +176,9 @@ class TestSearch:
     def test_search_http_error(self, client, base_url):
         """Test search with HTTP error response."""
         respx.post(f"{base_url.rstrip('/')}/search").mock(
-            return_value=Response(404, json={"error": {"message": "Collection not found"}})
+            return_value=Response(
+                404, json={"error": {"message": "Collection not found"}}
+            )
         )
 
         with pytest.raises(Exception):  # httpx.HTTPStatusError

--- a/packages/albert-client/tests/test_tools.py
+++ b/packages/albert-client/tests/test_tools.py
@@ -93,7 +93,9 @@ class TestUsageTracking:
         result = client.get_usage(start_date="2024-01-01", end_date="2024-01-31")
 
         # Verify query params
-        assert mock_route.calls.last.request.url.params.get("start_date") == "2024-01-01"
+        assert (
+            mock_route.calls.last.request.url.params.get("start_date") == "2024-01-01"
+        )
         assert mock_route.calls.last.request.url.params.get("end_date") == "2024-01-31"
 
         assert isinstance(result, UsageList)
@@ -162,7 +164,9 @@ class TestOCR:
             return_value=Response(200, json=mock_ocr_response)
         )
 
-        result = client.ocr(document="https://example.com/doc.pdf", pages=[0, 1, 2], model="doctr")
+        result = client.ocr(
+            document="https://example.com/doc.pdf", pages=[0, 1, 2], model="doctr"
+        )
 
         # Verify request body
         request_body = mock_route.calls.last.request.content.decode()
@@ -205,7 +209,9 @@ class TestParsing:
         }
 
     @respx.mock
-    def test_parse_default_markdown(self, client, base_url, temp_file, mock_parsed_document):
+    def test_parse_default_markdown(
+        self, client, base_url, temp_file, mock_parsed_document
+    ):
         """Test parsing document to markdown."""
         respx.post(f"{base_url.rstrip('/')}/parse-beta").mock(
             return_value=Response(200, json=mock_parsed_document)
@@ -218,7 +224,9 @@ class TestParsing:
         assert result.data[0].content.startswith("# Page 1")
 
     @respx.mock
-    def test_parse_with_options(self, client, base_url, temp_file, mock_parsed_document):
+    def test_parse_with_options(
+        self, client, base_url, temp_file, mock_parsed_document
+    ):
         """Test parsing with custom options."""
         mock_route = respx.post(f"{base_url.rstrip('/')}/parse-beta").mock(
             return_value=Response(200, json=mock_parsed_document)

--- a/packages/pdf-context/src/pdf_context/__init__.py
+++ b/packages/pdf-context/src/pdf_context/__init__.py
@@ -19,6 +19,7 @@ Example usage:
 from .extractor import extract_text_from_bytes, extract_text_from_pdf
 from .formatter import format_as_context, process_multiple_files, process_pdf_file
 
+
 __all__ = [
     "extract_text_from_pdf",
     "extract_text_from_bytes",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,5 +49,12 @@ extend-exclude = [".moon/templates"]
 [tool.ruff.lint]
 exclude = [".moon/templates"]
 
+[tool.ruff.lint.isort]
+# Define our first-party packages (local imports)
+known-first-party = ["albert_client", "cli", "pdf_context", "chainlit_chat", "reflex_chat"]
+# Ensure proper PEP 8 section ordering with blank lines between groups
+section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
+lines-after-imports = 2  # PEP 8: 2 blank lines before top-level definitions
+
 [tool.ruff.format]
 exclude = [".moon/templates"]

--- a/tools/generate_templates.py
+++ b/tools/generate_templates.py
@@ -35,6 +35,9 @@ ARTIFACTS = [
     ".web",
     ".states",
     ".chainlit",
+    "tests",
+    ".pytest_cache",
+    ".ruff_cache",
 ]
 
 
@@ -534,6 +537,7 @@ def main():
             "sys-config",
             "chainlit-chat",
             "reflex-chat",
+            "albert-client",
             "pdf-context",
             "chroma-context",
         ],
@@ -559,6 +563,7 @@ def main():
             "sys-config",
             "chainlit-chat",
             "reflex-chat",
+            "albert-client",
             "pdf-context",
             "chroma-context",
         ]
@@ -573,6 +578,10 @@ def main():
             generate_app_template("chainlit-chat", REPO_ROOT / "apps" / "chainlit-chat")
         elif template == "reflex-chat":
             generate_app_template("reflex-chat", REPO_ROOT / "apps" / "reflex-chat")
+        elif template == "albert-client":
+            generate_package_template(
+                "albert-client", REPO_ROOT / "packages" / "albert-client"
+            )
         elif template == "pdf-context":
             generate_package_template(
                 "pdf-context", REPO_ROOT / "packages" / "pdf-context"

--- a/tools/generate_templates.py
+++ b/tools/generate_templates.py
@@ -17,6 +17,7 @@ import libcst as cst
 import yaml
 from rich.console import Console
 
+
 console = Console()
 
 # Repository root (tools/ is at repo/tools/)

--- a/uv.lock
+++ b/uv.lock
@@ -2381,7 +2381,6 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "questionary" },
-    { name = "requests" },
     { name = "rich" },
     { name = "typer" },
 ]
@@ -2403,7 +2402,6 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "questionary", specifier = ">=2.0.0" },
-    { name = "requests", specifier = ">=2.31.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "typer", specifier = ">=0.12.0" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -321,8 +321,8 @@ name = "chainlit-chat"
 version = "0.7.0"
 source = { editable = "apps/chainlit-chat" }
 dependencies = [
+    { name = "albert-client" },
     { name = "chainlit" },
-    { name = "openai" },
     { name = "pdf-context" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
@@ -330,8 +330,8 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "albert-client", editable = "packages/albert-client" },
     { name = "chainlit", specifier = ">=1.3.0" },
-    { name = "openai", specifier = ">=1.0.0" },
     { name = "pdf-context", editable = "packages/pdf-context" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
@@ -2372,6 +2372,7 @@ name = "rag-facile-cli"
 version = "0.7.0"
 source = { editable = "apps/cli" }
 dependencies = [
+    { name = "albert-client" },
     { name = "datasets" },
     { name = "huggingface-hub" },
     { name = "letta-client" },
@@ -2393,6 +2394,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "albert-client", editable = "packages/albert-client" },
     { name = "datasets", specifier = ">=3.0.0" },
     { name = "huggingface-hub", specifier = ">=1.3.0" },
     { name = "letta-client", specifier = ">=0.1.0" },
@@ -2467,7 +2469,7 @@ name = "reflex-chat"
 version = "0.7.0"
 source = { editable = "apps/reflex-chat" }
 dependencies = [
-    { name = "openai" },
+    { name = "albert-client" },
     { name = "pdf-context" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
@@ -2476,7 +2478,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "openai", specifier = ">=1.78.1" },
+    { name = "albert-client", editable = "packages/albert-client" },
     { name = "pdf-context", editable = "packages/pdf-context" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },


### PR DESCRIPTION
## Summary

Establishes `albert-client` as the single OpenAI SDK dependency across the entire codebase. This improves architectural consistency and creates a clear dependency boundary.

## Changes

**albert-client Package:**
- Added `ChatCompletionMessageParam` type re-export for consuming apps
- Made `base_url` parameter accept `str | None` for flexibility

**Applications:**
- **chainlit-chat**: Migrated to `AsyncAlbertClient`
- **reflex-chat**: Migrated to `AlbertClient` with type imports from albert_client
- **CLI albert provider**: Migrated to `AlbertClient`

**Templates:**
- Regenerated all moon templates with albert-client dependencies
- Fixed `[tool.uv.sources]` structure for consistency

**Documentation:**
- Updated app READMEs to reference albert-client
- Updated albert-client README to highlight it as sole OpenAI dependency

## Architecture

The codebase now has a clear dependency boundary:
```
OpenAI SDK ← albert-client ← [apps, CLI, templates]
```

All OpenAI SDK interactions are centralized in `albert-client`, which wraps the OpenAI client using the composition pattern.

## Quality Checks

- ✅ Ruff format: All files formatted
- ✅ Ruff lint: All issues resolved
- ✅ Type checking (ty): All checks passed
- ✅ Tests: **79/80 passing** (1 pre-existing Letta test failure unrelated to changes)

## Test Plan

See comment below for comprehensive local testing guide.

---

*Posted by LettaCode* 🐙