### PR TITLE
feat: automate template synchronization on release

### DIFF
--- a/.github/workflows/sync-templates-on-release.yml
+++ b/.github/workflows/sync-templates-on-release.yml
@@ -1,0 +1,43 @@
+name: Sync Templates on Release
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize]
+
+jobs:
+  sync-templates:
+    if: startsWith(github.head_ref, 'release-please--branches--main')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Setup proto
+        uses: moonrepo/setup-proto@v1
+        with:
+          proto-version: latest
+
+      - name: Setup uv
+        run: proto install uv
+
+      - name: Install dependencies
+        run: uv sync --project tools
+
+      - name: Regenerate templates
+        run: uv run --project tools python tools/generate_templates.py --all --force
+
+      - name: Commit and push changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: synchronize templates with new version"
+          commit_user_name: "github-actions[bot]"
+          commit_user_email: "github-actions[bot]@users.noreply.github.com"
+          commit_author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+          file_pattern: ".moon/templates/**"


### PR DESCRIPTION
This PR adds a GitHub Action that automatically regenerates moon templates whenever a release PR is opened or updated by release-please.

This ensures that version bumps in 'pyproject.toml' files are correctly propagated to the generated templates without manual intervention.

🚀 Generated with [Gemini CLI](https://github.com/google/gemini-cli)