### PR TITLE
fix: update extra-files to match renamed packages and sync versions

### DIFF
--- a/.moon/templates/rag-core/pyproject.toml
+++ b/.moon/templates/rag-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rag-core"
-version = "0.8.0" # x-release-please-version
+version = "0.10.0" # x-release-please-version
 description = "Core library for RAG Facile - configuration, utils, and shared models"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/.moon/templates/retrieval-basic/pyproject.toml
+++ b/.moon/templates/retrieval-basic/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "retrieval-basic"
-version = "0.8.0" # x-release-please-version
+version = "0.10.0" # x-release-please-version
 description = "Basic retrieval components - PDF text extraction and context formatting"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/rag-core/pyproject.toml
+++ b/packages/rag-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rag-core"
-version = "0.8.0" # x-release-please-version
+version = "0.10.0" # x-release-please-version
 description = "Core library for RAG Facile - configuration, utils, and shared models"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/retrieval-basic/pyproject.toml
+++ b/packages/retrieval-basic/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "retrieval-basic"
-version = "0.8.0" # x-release-please-version
+version = "0.10.0" # x-release-please-version
 description = "Basic retrieval components - PDF text extraction and context formatting"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -18,8 +18,8 @@
 				"apps/cli/pyproject.toml",
 				"apps/chainlit-chat/pyproject.toml",
 				"apps/reflex-chat/pyproject.toml",
-				"packages/pdf-context/pyproject.toml",
-				"packages/rag-config/pyproject.toml"
+				"packages/rag-core/pyproject.toml",
+				"packages/retrieval-basic/pyproject.toml"
 			]
 		}
 	}

--- a/uv.lock
+++ b/uv.lock
@@ -2327,7 +2327,7 @@ wheels = [
 
 [[package]]
 name = "rag-core"
-version = "0.8.0"
+version = "0.10.0"
 source = { editable = "packages/rag-core" }
 dependencies = [
     { name = "pydantic" },
@@ -2552,7 +2552,7 @@ wheels = [
 
 [[package]]
 name = "retrieval-basic"
-version = "0.8.0"
+version = "0.10.0"
 source = { editable = "packages/retrieval-basic" }
 dependencies = [
     { name = "pypdf" },


### PR DESCRIPTION
## Summary

- **Fixes stale `extra-files` in `release-please-config.json`** — `packages/pdf-context` and `packages/rag-config` no longer exist (renamed during component-first refactoring). Updated to `packages/rag-core` and `packages/retrieval-basic`.
- **Syncs package versions to `0.10.0`** — `rag-core` and `retrieval-basic` were stuck at `0.8.0`, now aligned with the monorepo version.

## Test plan

- [ ] Verify `release-please-config.json` extra-files point to existing packages
- [ ] Verify `rag-core` and `retrieval-basic` versions match root (`0.10.0`)
- [ ] After merge, confirm release-please no longer warns about missing files

👾 Generated with [Letta Code](https://letta.com)