### PR TITLE
refactor!: consolidate citation config and unify schema terminology

### DIFF
--- a/.moon/templates/rag-core/README.md
+++ b/.moon/templates/rag-core/README.md
@@ -65,7 +65,7 @@ config = get_config()
 # Use in your RAG pipeline
 search_results = client.search(
     query=user_query,
-    method=config.retrieval.method,
+    method=config.retrieval.strategy,
     top_k=config.retrieval.top_k,
 )
 

--- a/.moon/templates/rag-core/presets/accurate.toml
+++ b/.moon/templates/rag-core/presets/accurate.toml
@@ -37,7 +37,7 @@ batch_size = 16  # Smaller batches for stability
 normalization = "L2"
 
 [storage]
-backend = "albert-collections"
+provider = "albert-collections"
 collection_naming = "workspace"
 distance_metric = "cosine"
 
@@ -47,7 +47,7 @@ expand_enabled = true  # Find more relevant results
 spell_check = true  # Fix typos
 
 [retrieval]
-method = "hybrid"  # Best of both worlds
+strategy = "hybrid"  # Best of both worlds
 top_k = 20  # More candidates for reranking
 score_threshold = 0.5  # Only high-quality results
 
@@ -65,9 +65,7 @@ max_tokens = 8192  # Large context window
 deduplicate = true
 ordering = "by-score"
 
-[context.formatting]
-include_citations = true
-citation_style = "inline"
+
 
 [generation]
 model = "openweight-large"  # Best generation model
@@ -81,12 +79,16 @@ If you're unsure about any information, explicitly state it."""
 
 [hallucination]
 enabled = true  # Critical for accuracy
-method = "citation-check"
+strategy = "citation-check"
 threshold = 0.9  # Strict threshold
 fallback = "warn"
 
 [formatting]
 output_format = "markdown"
-include_sources = true
 include_confidence = true  # Show confidence scores
 language = "fr"
+
+[formatting.citations]
+enabled = true
+style = "inline"
+include_sources = true

--- a/.moon/templates/rag-core/presets/balanced.toml
+++ b/.moon/templates/rag-core/presets/balanced.toml
@@ -52,7 +52,7 @@ normalization = "L2"
 # VECTOR STORAGE / INDEX
 # ==============================================================================
 [storage]
-backend = "albert-collections"
+provider = "albert-collections"
 collection_naming = "workspace"
 distance_metric = "cosine"
 
@@ -68,7 +68,7 @@ spell_check = false
 # RETRIEVAL
 # ==============================================================================
 [retrieval]
-method = "hybrid"
+strategy = "hybrid"
 top_k = 10
 score_threshold = 0.0
 
@@ -92,9 +92,7 @@ max_tokens = 4096
 deduplicate = true
 ordering = "by-score"
 
-[context.formatting]
-include_citations = true
-citation_style = "inline"
+
 
 # ==============================================================================
 # RESPONSE GENERATION
@@ -113,7 +111,7 @@ Always cite your sources using [1], [2], etc."""
 # ==============================================================================
 [hallucination]
 enabled = false
-method = "citation-check"
+strategy = "citation-check"
 threshold = 0.8
 fallback = "warn"
 
@@ -122,6 +120,10 @@ fallback = "warn"
 # ==============================================================================
 [formatting]
 output_format = "markdown"
-include_sources = true
 include_confidence = false
 language = "fr"
+
+[formatting.citations]
+enabled = true
+style = "inline"
+include_sources = true

--- a/.moon/templates/rag-core/presets/fast.toml
+++ b/.moon/templates/rag-core/presets/fast.toml
@@ -37,7 +37,7 @@ batch_size = 64  # Larger batches for speed
 normalization = "L2"
 
 [storage]
-backend = "albert-collections"
+provider = "albert-collections"
 collection_naming = "workspace"
 distance_metric = "cosine"
 
@@ -47,7 +47,7 @@ expand_enabled = false
 spell_check = false
 
 [retrieval]
-method = "semantic"  # Skip lexical component for speed
+strategy = "semantic"  # Skip lexical component for speed
 top_k = 5  # Fewer results
 score_threshold = 0.0
 
@@ -65,9 +65,7 @@ max_tokens = 2048  # Smaller context
 deduplicate = false  # Skip for speed
 ordering = "by-score"
 
-[context.formatting]
-include_citations = true
-citation_style = "inline"
+
 
 [generation]
 model = "openweight-small"  # Fastest model
@@ -78,12 +76,16 @@ system_prompt = """You are a helpful assistant. Answer concisely based on the co
 
 [hallucination]
 enabled = false
-method = "citation-check"
+strategy = "citation-check"
 threshold = 0.8
 fallback = "warn"
 
 [formatting]
 output_format = "markdown"
-include_sources = false  # Skip for speed
 include_confidence = false
 language = "fr"
+
+[formatting.citations]
+enabled = true
+style = "inline"
+include_sources = false  # Skip for speed

--- a/.moon/templates/rag-core/presets/hr.toml
+++ b/.moon/templates/rag-core/presets/hr.toml
@@ -37,7 +37,7 @@ batch_size = 32
 normalization = "L2"
 
 [storage]
-backend = "albert-collections"
+provider = "albert-collections"
 collection_naming = "workspace"
 distance_metric = "cosine"
 
@@ -47,7 +47,7 @@ expand_enabled = true  # Find related policies
 spell_check = true  # Friendly to typos
 
 [retrieval]
-method = "hybrid"  # Balance semantic understanding with keyword matching
+strategy = "hybrid"  # Balance semantic understanding with keyword matching
 top_k = 12
 score_threshold = 0.3  # Lower threshold for broader policy coverage
 
@@ -65,9 +65,7 @@ max_tokens = 4096
 deduplicate = true
 ordering = "by-score"
 
-[context.formatting]
-include_citations = true
-citation_style = "inline"  # Clear policy attribution
+
 
 [generation]
 model = "openweight-medium"  # Good for conversational HR responses
@@ -82,12 +80,16 @@ If a policy doesn't cover the question, suggest who to contact (e.g., "Contact H
 
 [hallucination]
 enabled = true  # Important for policy accuracy
-method = "citation-check"
+strategy = "citation-check"
 threshold = 0.85
 fallback = "warn"  # Warn but allow response with disclaimer
 
 [formatting]
 output_format = "markdown"
-include_sources = true  # Show which policies were consulted
 include_confidence = false  # Keep responses simple
 language = "fr"
+
+[formatting.citations]
+enabled = true
+style = "inline"  # Clear policy attribution
+include_sources = true  # Show which policies were consulted

--- a/.moon/templates/rag-core/presets/legal.toml
+++ b/.moon/templates/rag-core/presets/legal.toml
@@ -37,7 +37,7 @@ batch_size = 16
 normalization = "L2"
 
 [storage]
-backend = "albert-collections"
+provider = "albert-collections"
 collection_naming = "workspace"
 distance_metric = "cosine"
 
@@ -47,7 +47,7 @@ expand_enabled = false  # Legal terms are precise
 spell_check = true  # Catch typos but preserve legal terms
 
 [retrieval]
-method = "hybrid"  # Lexical important for exact legal terms
+strategy = "hybrid"  # Lexical important for exact legal terms
 top_k = 15
 score_threshold = 0.6  # Higher threshold for relevance
 
@@ -65,9 +65,7 @@ max_tokens = 6144  # Large context for legal reasoning
 deduplicate = true
 ordering = "by-document"  # Preserve document order for legal context
 
-[context.formatting]
-include_citations = true  # Mandatory for legal
-citation_style = "footnote"  # Formal citation style
+
 
 [generation]
 model = "openweight-large"  # Best for legal reasoning
@@ -83,12 +81,16 @@ Never make assumptions or provide information not supported by the context."""
 
 [hallucination]
 enabled = true  # Essential for legal applications
-method = "citation-check"  # Every claim must cite source
+strategy = "citation-check"  # Every claim must cite source
 threshold = 0.95  # Very strict
 fallback = "reject"  # Reject hallucinated responses
 
 [formatting]
 output_format = "markdown"
-include_sources = true  # Show all sources consulted
 include_confidence = true  # Transparency about certainty
 language = "fr"
+
+[formatting.citations]
+enabled = true  # Mandatory for legal
+style = "footnote"  # Formal citation style
+include_sources = true  # Show all sources consulted

--- a/.moon/templates/rag-core/src/rag_core/__init__.py
+++ b/.moon/templates/rag-core/src/rag_core/__init__.py
@@ -32,6 +32,7 @@ from .runtime import get_config, has_config_file, reload_config
 from .schema import (
     PIPELINE_STAGES,
     ChunkingConfig,
+    CitationsConfig,
     ContextConfig,
     EmbeddingConfig,
     EvalConfig,
@@ -69,6 +70,7 @@ __all__ = [
     "GenerationConfig",
     "HallucinationConfig",
     "FormattingConfig",
+    "CitationsConfig",
     # Pipeline metadata
     "PIPELINE_STAGES",
     "PipelineStage",

--- a/.moon/templates/rag-core/src/rag_core/loader.py
+++ b/.moon/templates/rag-core/src/rag_core/loader.py
@@ -240,10 +240,10 @@ def get_env_override_docs() -> str:
     sections = [
         ("eval", ["provider", "target_samples"]),
         ("embedding", ["model", "batch_size"]),
-        ("retrieval", ["method", "top_k", "score_threshold"]),
+        ("retrieval", ["strategy", "top_k", "score_threshold"]),
         ("reranking", ["enabled", "model", "top_n"]),
         ("generation", ["model", "temperature", "max_tokens"]),
-        ("hallucination", ["enabled", "method"]),
+        ("hallucination", ["enabled", "strategy"]),
     ]
 
     docs = ["# Environment Variable Overrides\n"]

--- a/.moon/templates/rag-core/src/rag_core/schema.py
+++ b/.moon/templates/rag-core/src/rag_core/schema.py
@@ -180,9 +180,9 @@ class EmbeddingConfig(BaseModel):
 class StorageConfig(BaseModel):
     """Configuration for vector storage."""
 
-    backend: Literal["albert-collections", "local-sqlite"] = Field(
+    provider: Literal["albert-collections", "local-sqlite"] = Field(
         default="albert-collections",
-        description="Vector store backend",
+        description="Vector store provider",
     )
     collection_naming: Literal["workspace", "app", "custom"] = Field(
         default="workspace",
@@ -235,9 +235,9 @@ class HybridRetrievalConfig(BaseModel):
 class RetrievalConfig(BaseModel):
     """Configuration for retrieval."""
 
-    method: Literal["hybrid", "semantic", "lexical"] = Field(
+    strategy: Literal["hybrid", "semantic", "lexical"] = Field(
         default="hybrid",
-        description="Retrieval method",
+        description="Retrieval strategy",
     )
     top_k: int = Field(
         default=10,
@@ -286,19 +286,6 @@ class RerankingConfig(BaseModel):
 # ==============================================================================
 
 
-class ContextFormattingConfig(BaseModel):
-    """Context formatting settings."""
-
-    include_citations: bool = Field(
-        default=True,
-        description="Include source citations in context",
-    )
-    citation_style: Literal["inline", "footnote"] = Field(
-        default="inline",
-        description="Citation style",
-    )
-
-
 class ContextConfig(BaseModel):
     """Configuration for context selection."""
 
@@ -319,10 +306,6 @@ class ContextConfig(BaseModel):
     ordering: Literal["by-score", "by-document", "by-date"] = Field(
         default="by-score",
         description="Ordering of context chunks",
-    )
-    formatting: ContextFormattingConfig = Field(
-        default_factory=ContextFormattingConfig,
-        description="Context formatting settings",
     )
 
 
@@ -376,9 +359,9 @@ class HallucinationConfig(BaseModel):
         default=False,
         description="Enable hallucination detection",
     )
-    method: Literal["entailment", "fact-check", "citation-check"] = Field(
+    strategy: Literal["entailment", "fact-check", "citation-check"] = Field(
         default="citation-check",
-        description="Detection method",
+        description="Detection strategy",
     )
     threshold: float = Field(
         default=0.8,
@@ -397,16 +380,29 @@ class HallucinationConfig(BaseModel):
 # ==============================================================================
 
 
+class CitationsConfig(BaseModel):
+    """Citation settings for context markers and source attribution."""
+
+    enabled: bool = Field(
+        default=True,
+        description="Include source citations ([1], [2], ...) in context",
+    )
+    style: Literal["inline", "footnote"] = Field(
+        default="inline",
+        description="Citation style (inline or footnote)",
+    )
+    include_sources: bool = Field(
+        default=True,
+        description="Append source list (URLs, document names) to the response",
+    )
+
+
 class FormattingConfig(BaseModel):
     """Configuration for answer formatting."""
 
     output_format: Literal["markdown", "html", "plain-text"] = Field(
         default="markdown",
         description="Output format",
-    )
-    include_sources: bool = Field(
-        default=True,
-        description="Include retrieved sources in response",
     )
     include_confidence: bool = Field(
         default=False,
@@ -415,6 +411,10 @@ class FormattingConfig(BaseModel):
     language: Literal["fr", "en"] = Field(
         default="fr",
         description="Response language",
+    )
+    citations: CitationsConfig = Field(
+        default_factory=CitationsConfig,
+        description="Citation and source attribution settings",
     )
 
 
@@ -503,7 +503,7 @@ class RAGConfig(BaseModel):
                         "max_tokens": 1024,
                     },
                     "retrieval": {
-                        "method": "hybrid",
+                        "strategy": "hybrid",
                         "top_k": 10,
                         "hybrid": {"alpha": 0.5},
                     },

--- a/.moon/templates/retrieval/src/retrieval/__init__.py
+++ b/.moon/templates/retrieval/src/retrieval/__init__.py
@@ -6,7 +6,7 @@ This package provides document retrieval capabilities with two backends:
 
 Backend selection is driven by `ragfacile.toml`:
     [storage]
-    backend = "albert-collections"  # or "local-sqlite"
+    provider = "albert-collections"  # or "local-sqlite"
 
 Example usage with factory:
     from retrieval import get_provider
@@ -41,8 +41,8 @@ def get_provider(config: Any | None = None) -> Any:
 
         config = get_config()
 
-    # Determine backend from storage.backend config field
-    backend = config.storage.backend
+    # Determine backend from storage.provider config field
+    backend = config.storage.provider
 
     if backend == "albert-collections":
         # Albert RAG: full pipeline with ingestion + search + reranking

--- a/.moon/templates/retrieval/src/retrieval/albert.py
+++ b/.moon/templates/retrieval/src/retrieval/albert.py
@@ -150,7 +150,7 @@ def retrieve(
         query: Search query text.
         collection_ids: Collections to search in.
         top_k: Number of search results (defaults to config.retrieval.top_k).
-        method: Search method (defaults to config.retrieval.method).
+        method: Search method (defaults to config.retrieval.strategy).
         score_threshold: Min score (defaults to config.retrieval.score_threshold).
         rerank: Whether to rerank (defaults to config.reranking.enabled).
         rerank_model: Reranker model (defaults to config.reranking.model).
@@ -163,7 +163,7 @@ def retrieve(
 
     # Apply config defaults
     top_k = top_k if top_k is not None else config.retrieval.top_k
-    method = method if method is not None else config.retrieval.method
+    method = method if method is not None else config.retrieval.strategy
     score_threshold = (
         score_threshold
         if score_threshold is not None

--- a/.moon/templates/retrieval/src/retrieval/formatter.py
+++ b/.moon/templates/retrieval/src/retrieval/formatter.py
@@ -51,12 +51,12 @@ def format_context(
     include_citations = (
         include_citations
         if include_citations is not None
-        else config.context.formatting.include_citations
+        else config.formatting.citations.enabled
     )
     citation_style = (
         citation_style
         if citation_style is not None
-        else config.context.formatting.citation_style
+        else config.formatting.citations.style
     )
 
     lines: list[str] = ["", "--- Retrieved context ---"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,11 +108,11 @@ RAG Facile uses a **unified retrieval package** (`packages/retrieval/`) with two
 - **basic** — Local PDF extraction via pypdf (lightweight, offline)
 - **albert** — Full RAG via Albert API (ingestion, search, reranking)
 
-Backend selection is automatic based on `storage.backend` config:
+Backend selection is automatic based on `storage.provider` config:
 ```toml
 [storage]
-backend = "albert-collections"  # Uses Albert RAG
-# backend = "local-sqlite"      # Uses basic context injection
+provider = "albert-collections"  # Uses Albert RAG
+# provider = "local-sqlite"      # Uses basic context injection
 ```
 
 Both backends implement the same interface through the factory pattern:

--- a/apps/cli/src/cli/commands/config/preset.py
+++ b/apps/cli/src/cli/commands/config/preset.py
@@ -76,7 +76,7 @@ def show(
         settings = [
             ("Generation Model", config.generation.model),
             ("Temperature", config.generation.temperature),
-            ("Retrieval Method", config.retrieval.method),
+            ("Retrieval Strategy", config.retrieval.strategy),
             ("Retrieval Top K", config.retrieval.top_k),
             ("Reranking Enabled", config.reranking.enabled),
             (

--- a/apps/cli/src/cli/commands/setup.py
+++ b/apps/cli/src/cli/commands/setup.py
@@ -380,16 +380,15 @@ def generate_config_file(
             streaming=True,
             system_prompt=preset_config["system_prompt"],
         ),
-        retrieval=RetrievalConfig(method="hybrid"),
+        retrieval=RetrievalConfig(strategy="hybrid"),
         eval=EvalConfig(provider="albert", target_samples=50),
         ingestion=IngestionConfig(
             ocr=OCRConfig(enabled=True, dpi=300),
         ),
         chunking=ChunkingConfig(strategy="semantic", chunk_size=512, chunk_overlap=50),
-        storage=StorageConfig(backend=storage_backend),
+        storage=StorageConfig(provider=storage_backend),
         formatting=FormattingConfig(
             output_format="markdown",
-            include_sources=True,
             include_confidence=False,
             language=preset_config["language"],
         ),

--- a/apps/cli/src/cli/templates/ragfacile.toml
+++ b/apps/cli/src/cli/templates/ragfacile.toml
@@ -37,7 +37,7 @@ batch_size = 32
 normalization = "L2"
 
 [storage]
-backend = "albert-collections"
+provider = "albert-collections"
 collection_naming = "workspace"
 distance_metric = "cosine"
 
@@ -47,7 +47,7 @@ expand_enabled = false
 spell_check = false
 
 [retrieval]
-method = "hybrid"
+strategy = "hybrid"
 top_k = 10
 score_threshold = 0.0
 
@@ -65,9 +65,7 @@ max_tokens = 4096
 deduplicate = true
 ordering = "by-score"
 
-[context.formatting]
-include_citations = true
-citation_style = "inline"
+
 
 [generation]
 model = "openweight-medium"
@@ -78,12 +76,16 @@ system_prompt = "You are a helpful assistant for the French government.\nAnswer 
 
 [hallucination]
 enabled = false
-method = "citation-check"
+strategy = "citation-check"
 threshold = 0.8
 fallback = "warn"
 
 [formatting]
 output_format = "markdown"
-include_sources = true
 include_confidence = false
 language = "fr"
+
+[formatting.citations]
+enabled = true
+style = "inline"
+include_sources = true

--- a/docs/reference/ragfacile-toml.md
+++ b/docs/reference/ragfacile-toml.md
@@ -116,7 +116,7 @@ normalization = "L2"              # "L2" or "none"
 # VECTOR STORAGE
 # ==========================================================
 [storage]
-backend = "albert-collections"  # "albert-collections", "local-sqlite"
+provider = "albert-collections"  # "albert-collections", "local-sqlite"
 collection_naming = "workspace" # "workspace", "app", or "custom"
 distance_metric = "cosine"      # "cosine", "euclidean", "dot-product"
 
@@ -132,7 +132,7 @@ spell_check = false             # Fix typos in queries
 # RETRIEVAL
 # ==========================================================
 [retrieval]
-method = "hybrid"               # "hybrid", "semantic", "lexical"
+strategy = "hybrid"               # "hybrid", "semantic", "lexical"
 top_k = 10                      # Number of chunks to retrieve (1–100)
 score_threshold = 0.0           # Minimum relevance score (0.0–1.0)
 
@@ -156,10 +156,6 @@ max_tokens = 4096               # Token budget for context (512–32768)
 deduplicate = true              # Remove duplicate/similar chunks
 ordering = "by-score"           # "by-score", "by-document", "by-date"
 
-[context.formatting]
-include_citations = true        # Add source indices ([1], [2], ...)
-citation_style = "inline"       # "inline" or "footnote"
-
 # ==========================================================
 # RESPONSE GENERATION
 # ==========================================================
@@ -177,7 +173,7 @@ Always cite your sources using [1], [2], etc."""
 # ==========================================================
 [hallucination]
 enabled = false                 # Enable hallucination detection
-method = "citation-check"       # "citation-check", "fact-check", "entailment"
+strategy = "citation-check"     # "citation-check", "fact-check", "entailment"
 threshold = 0.8                 # Confidence threshold (0.0–1.0)
 fallback = "warn"               # "warn", "reject", "regenerate"
 
@@ -186,9 +182,13 @@ fallback = "warn"               # "warn", "reject", "regenerate"
 # ==========================================================
 [formatting]
 output_format = "markdown"      # "markdown", "html", "plain-text"
-include_sources = true          # Append source list to response
 include_confidence = false      # Show confidence scores
 language = "fr"                 # "fr" or "en"
+
+[formatting.citations]
+enabled = true                  # Add source citations ([1], [2], ...)
+style = "inline"                # "inline" or "footnote"
+include_sources = true          # Append source list to response
 ```
 
 ## Presets
@@ -209,7 +209,7 @@ rag-facile config preset apply legal    # Apply a preset
 | **Chunking strategy** | semantic | fixed-size | semantic | paragraph | semantic |
 | **Chunk size** | 512 | 512 | 768 | 768 | 512 |
 | **Embedding model** | openweight-embeddings | openweight-embeddings | openweight-embeddings | openweight-embeddings | openweight-embeddings |
-| **Retrieval method** | hybrid | semantic | hybrid | hybrid | hybrid |
+| **Retrieval strategy** | hybrid | semantic | hybrid | hybrid | hybrid |
 | **top_k** | 10 | 5 | 20 | 15 | 12 |
 | **Reranking** | on | **off** | on | on | on |
 | **Generation model** | medium | small | large | large | medium |

--- a/packages/rag-core/README.md
+++ b/packages/rag-core/README.md
@@ -65,7 +65,7 @@ config = get_config()
 # Use in your RAG pipeline
 search_results = client.search(
     query=user_query,
-    method=config.retrieval.method,
+    method=config.retrieval.strategy,
     top_k=config.retrieval.top_k,
 )
 

--- a/packages/rag-core/presets/accurate.toml
+++ b/packages/rag-core/presets/accurate.toml
@@ -37,7 +37,7 @@ batch_size = 16  # Smaller batches for stability
 normalization = "L2"
 
 [storage]
-backend = "albert-collections"
+provider = "albert-collections"
 collection_naming = "workspace"
 distance_metric = "cosine"
 
@@ -47,7 +47,7 @@ expand_enabled = true  # Find more relevant results
 spell_check = true  # Fix typos
 
 [retrieval]
-method = "hybrid"  # Best of both worlds
+strategy = "hybrid"  # Best of both worlds
 top_k = 20  # More candidates for reranking
 score_threshold = 0.5  # Only high-quality results
 
@@ -65,9 +65,7 @@ max_tokens = 8192  # Large context window
 deduplicate = true
 ordering = "by-score"
 
-[context.formatting]
-include_citations = true
-citation_style = "inline"
+
 
 [generation]
 model = "openweight-large"  # Best generation model
@@ -81,12 +79,16 @@ If you're unsure about any information, explicitly state it."""
 
 [hallucination]
 enabled = true  # Critical for accuracy
-method = "citation-check"
+strategy = "citation-check"
 threshold = 0.9  # Strict threshold
 fallback = "warn"
 
 [formatting]
 output_format = "markdown"
-include_sources = true
 include_confidence = true  # Show confidence scores
 language = "fr"
+
+[formatting.citations]
+enabled = true
+style = "inline"
+include_sources = true

--- a/packages/rag-core/presets/balanced.toml
+++ b/packages/rag-core/presets/balanced.toml
@@ -52,7 +52,7 @@ normalization = "L2"
 # VECTOR STORAGE / INDEX
 # ==============================================================================
 [storage]
-backend = "albert-collections"
+provider = "albert-collections"
 collection_naming = "workspace"
 distance_metric = "cosine"
 
@@ -68,7 +68,7 @@ spell_check = false
 # RETRIEVAL
 # ==============================================================================
 [retrieval]
-method = "hybrid"
+strategy = "hybrid"
 top_k = 10
 score_threshold = 0.0
 
@@ -92,9 +92,7 @@ max_tokens = 4096
 deduplicate = true
 ordering = "by-score"
 
-[context.formatting]
-include_citations = true
-citation_style = "inline"
+
 
 # ==============================================================================
 # RESPONSE GENERATION
@@ -113,7 +111,7 @@ Always cite your sources using [1], [2], etc."""
 # ==============================================================================
 [hallucination]
 enabled = false
-method = "citation-check"
+strategy = "citation-check"
 threshold = 0.8
 fallback = "warn"
 
@@ -122,6 +120,10 @@ fallback = "warn"
 # ==============================================================================
 [formatting]
 output_format = "markdown"
-include_sources = true
 include_confidence = false
 language = "fr"
+
+[formatting.citations]
+enabled = true
+style = "inline"
+include_sources = true

--- a/packages/rag-core/presets/fast.toml
+++ b/packages/rag-core/presets/fast.toml
@@ -37,7 +37,7 @@ batch_size = 64  # Larger batches for speed
 normalization = "L2"
 
 [storage]
-backend = "albert-collections"
+provider = "albert-collections"
 collection_naming = "workspace"
 distance_metric = "cosine"
 
@@ -47,7 +47,7 @@ expand_enabled = false
 spell_check = false
 
 [retrieval]
-method = "semantic"  # Skip lexical component for speed
+strategy = "semantic"  # Skip lexical component for speed
 top_k = 5  # Fewer results
 score_threshold = 0.0
 
@@ -65,9 +65,7 @@ max_tokens = 2048  # Smaller context
 deduplicate = false  # Skip for speed
 ordering = "by-score"
 
-[context.formatting]
-include_citations = true
-citation_style = "inline"
+
 
 [generation]
 model = "openweight-small"  # Fastest model
@@ -78,12 +76,16 @@ system_prompt = """You are a helpful assistant. Answer concisely based on the co
 
 [hallucination]
 enabled = false
-method = "citation-check"
+strategy = "citation-check"
 threshold = 0.8
 fallback = "warn"
 
 [formatting]
 output_format = "markdown"
-include_sources = false  # Skip for speed
 include_confidence = false
 language = "fr"
+
+[formatting.citations]
+enabled = true
+style = "inline"
+include_sources = false  # Skip for speed

--- a/packages/rag-core/presets/hr.toml
+++ b/packages/rag-core/presets/hr.toml
@@ -37,7 +37,7 @@ batch_size = 32
 normalization = "L2"
 
 [storage]
-backend = "albert-collections"
+provider = "albert-collections"
 collection_naming = "workspace"
 distance_metric = "cosine"
 
@@ -47,7 +47,7 @@ expand_enabled = true  # Find related policies
 spell_check = true  # Friendly to typos
 
 [retrieval]
-method = "hybrid"  # Balance semantic understanding with keyword matching
+strategy = "hybrid"  # Balance semantic understanding with keyword matching
 top_k = 12
 score_threshold = 0.3  # Lower threshold for broader policy coverage
 
@@ -65,9 +65,7 @@ max_tokens = 4096
 deduplicate = true
 ordering = "by-score"
 
-[context.formatting]
-include_citations = true
-citation_style = "inline"  # Clear policy attribution
+
 
 [generation]
 model = "openweight-medium"  # Good for conversational HR responses
@@ -82,12 +80,16 @@ If a policy doesn't cover the question, suggest who to contact (e.g., "Contact H
 
 [hallucination]
 enabled = true  # Important for policy accuracy
-method = "citation-check"
+strategy = "citation-check"
 threshold = 0.85
 fallback = "warn"  # Warn but allow response with disclaimer
 
 [formatting]
 output_format = "markdown"
-include_sources = true  # Show which policies were consulted
 include_confidence = false  # Keep responses simple
 language = "fr"
+
+[formatting.citations]
+enabled = true
+style = "inline"  # Clear policy attribution
+include_sources = true  # Show which policies were consulted

--- a/packages/rag-core/presets/legal.toml
+++ b/packages/rag-core/presets/legal.toml
@@ -37,7 +37,7 @@ batch_size = 16
 normalization = "L2"
 
 [storage]
-backend = "albert-collections"
+provider = "albert-collections"
 collection_naming = "workspace"
 distance_metric = "cosine"
 
@@ -47,7 +47,7 @@ expand_enabled = false  # Legal terms are precise
 spell_check = true  # Catch typos but preserve legal terms
 
 [retrieval]
-method = "hybrid"  # Lexical important for exact legal terms
+strategy = "hybrid"  # Lexical important for exact legal terms
 top_k = 15
 score_threshold = 0.6  # Higher threshold for relevance
 
@@ -65,9 +65,7 @@ max_tokens = 6144  # Large context for legal reasoning
 deduplicate = true
 ordering = "by-document"  # Preserve document order for legal context
 
-[context.formatting]
-include_citations = true  # Mandatory for legal
-citation_style = "footnote"  # Formal citation style
+
 
 [generation]
 model = "openweight-large"  # Best for legal reasoning
@@ -83,12 +81,16 @@ Never make assumptions or provide information not supported by the context."""
 
 [hallucination]
 enabled = true  # Essential for legal applications
-method = "citation-check"  # Every claim must cite source
+strategy = "citation-check"  # Every claim must cite source
 threshold = 0.95  # Very strict
 fallback = "reject"  # Reject hallucinated responses
 
 [formatting]
 output_format = "markdown"
-include_sources = true  # Show all sources consulted
 include_confidence = true  # Transparency about certainty
 language = "fr"
+
+[formatting.citations]
+enabled = true  # Mandatory for legal
+style = "footnote"  # Formal citation style
+include_sources = true  # Show all sources consulted

--- a/packages/rag-core/src/rag_core/__init__.py
+++ b/packages/rag-core/src/rag_core/__init__.py
@@ -32,6 +32,7 @@ from .runtime import get_config, has_config_file, reload_config
 from .schema import (
     PIPELINE_STAGES,
     ChunkingConfig,
+    CitationsConfig,
     ContextConfig,
     EmbeddingConfig,
     EvalConfig,
@@ -69,6 +70,7 @@ __all__ = [
     "GenerationConfig",
     "HallucinationConfig",
     "FormattingConfig",
+    "CitationsConfig",
     # Pipeline metadata
     "PIPELINE_STAGES",
     "PipelineStage",

--- a/packages/rag-core/src/rag_core/loader.py
+++ b/packages/rag-core/src/rag_core/loader.py
@@ -240,10 +240,10 @@ def get_env_override_docs() -> str:
     sections = [
         ("eval", ["provider", "target_samples"]),
         ("embedding", ["model", "batch_size"]),
-        ("retrieval", ["method", "top_k", "score_threshold"]),
+        ("retrieval", ["strategy", "top_k", "score_threshold"]),
         ("reranking", ["enabled", "model", "top_n"]),
         ("generation", ["model", "temperature", "max_tokens"]),
-        ("hallucination", ["enabled", "method"]),
+        ("hallucination", ["enabled", "strategy"]),
     ]
 
     docs = ["# Environment Variable Overrides\n"]

--- a/packages/rag-core/src/rag_core/schema.py
+++ b/packages/rag-core/src/rag_core/schema.py
@@ -180,9 +180,9 @@ class EmbeddingConfig(BaseModel):
 class StorageConfig(BaseModel):
     """Configuration for vector storage."""
 
-    backend: Literal["albert-collections", "local-sqlite"] = Field(
+    provider: Literal["albert-collections", "local-sqlite"] = Field(
         default="albert-collections",
-        description="Vector store backend",
+        description="Vector store provider",
     )
     collection_naming: Literal["workspace", "app", "custom"] = Field(
         default="workspace",
@@ -235,9 +235,9 @@ class HybridRetrievalConfig(BaseModel):
 class RetrievalConfig(BaseModel):
     """Configuration for retrieval."""
 
-    method: Literal["hybrid", "semantic", "lexical"] = Field(
+    strategy: Literal["hybrid", "semantic", "lexical"] = Field(
         default="hybrid",
-        description="Retrieval method",
+        description="Retrieval strategy",
     )
     top_k: int = Field(
         default=10,
@@ -286,19 +286,6 @@ class RerankingConfig(BaseModel):
 # ==============================================================================
 
 
-class ContextFormattingConfig(BaseModel):
-    """Context formatting settings."""
-
-    include_citations: bool = Field(
-        default=True,
-        description="Include source citations in context",
-    )
-    citation_style: Literal["inline", "footnote"] = Field(
-        default="inline",
-        description="Citation style",
-    )
-
-
 class ContextConfig(BaseModel):
     """Configuration for context selection."""
 
@@ -319,10 +306,6 @@ class ContextConfig(BaseModel):
     ordering: Literal["by-score", "by-document", "by-date"] = Field(
         default="by-score",
         description="Ordering of context chunks",
-    )
-    formatting: ContextFormattingConfig = Field(
-        default_factory=ContextFormattingConfig,
-        description="Context formatting settings",
     )
 
 
@@ -376,9 +359,9 @@ class HallucinationConfig(BaseModel):
         default=False,
         description="Enable hallucination detection",
     )
-    method: Literal["entailment", "fact-check", "citation-check"] = Field(
+    strategy: Literal["entailment", "fact-check", "citation-check"] = Field(
         default="citation-check",
-        description="Detection method",
+        description="Detection strategy",
     )
     threshold: float = Field(
         default=0.8,
@@ -397,16 +380,29 @@ class HallucinationConfig(BaseModel):
 # ==============================================================================
 
 
+class CitationsConfig(BaseModel):
+    """Citation settings for context markers and source attribution."""
+
+    enabled: bool = Field(
+        default=True,
+        description="Include source citations ([1], [2], ...) in context",
+    )
+    style: Literal["inline", "footnote"] = Field(
+        default="inline",
+        description="Citation style (inline or footnote)",
+    )
+    include_sources: bool = Field(
+        default=True,
+        description="Append source list (URLs, document names) to the response",
+    )
+
+
 class FormattingConfig(BaseModel):
     """Configuration for answer formatting."""
 
     output_format: Literal["markdown", "html", "plain-text"] = Field(
         default="markdown",
         description="Output format",
-    )
-    include_sources: bool = Field(
-        default=True,
-        description="Include retrieved sources in response",
     )
     include_confidence: bool = Field(
         default=False,
@@ -415,6 +411,10 @@ class FormattingConfig(BaseModel):
     language: Literal["fr", "en"] = Field(
         default="fr",
         description="Response language",
+    )
+    citations: CitationsConfig = Field(
+        default_factory=CitationsConfig,
+        description="Citation and source attribution settings",
     )
 
 
@@ -503,7 +503,7 @@ class RAGConfig(BaseModel):
                         "max_tokens": 1024,
                     },
                     "retrieval": {
-                        "method": "hybrid",
+                        "strategy": "hybrid",
                         "top_k": 10,
                         "hybrid": {"alpha": 0.5},
                     },

--- a/packages/rag-core/tests/test_loader.py
+++ b/packages/rag-core/tests/test_loader.py
@@ -165,11 +165,11 @@ model = "openweight-medium"  # Default model
 temperature = 0.7
 
 [retrieval]
-method = "hybrid"
+strategy = "hybrid"
 top_k = 10
 """)
 
     # Load - should work despite comments
     config = load_config(config_file)
     assert config.generation.model == "openweight-medium"
-    assert config.retrieval.method == "hybrid"
+    assert config.retrieval.strategy == "hybrid"

--- a/packages/rag-core/tests/test_presets.py
+++ b/packages/rag-core/tests/test_presets.py
@@ -32,7 +32,7 @@ def test_load_balanced_preset():
 
     assert config.meta.preset == "balanced"
     assert config.generation.model == "openweight-medium"
-    assert config.retrieval.method == "hybrid"
+    assert config.retrieval.strategy == "hybrid"
     assert config.reranking.enabled is True
 
 
@@ -66,7 +66,7 @@ def test_load_legal_preset():
     assert config.hallucination.enabled is True
     assert config.hallucination.threshold == 0.95  # Very strict
     assert config.hallucination.fallback == "reject"
-    assert config.context.formatting.citation_style == "footnote"
+    assert config.formatting.citations.style == "footnote"
 
 
 def test_load_hr_preset():

--- a/packages/rag-core/tests/test_schema.py
+++ b/packages/rag-core/tests/test_schema.py
@@ -36,14 +36,14 @@ def test_embedding_config_validation():
 def test_retrieval_config_validation():
     """Test retrieval configuration validation."""
     # Valid config
-    config = RetrievalConfig(method="hybrid", top_k=10)
-    assert config.method == "hybrid"
+    config = RetrievalConfig(strategy="hybrid", top_k=10)
+    assert config.strategy == "hybrid"
     assert config.hybrid.alpha == 0.5  # Default
 
-    # Invalid method
+    # Invalid strategy
     with pytest.raises(ValidationError) as exc_info:
-        RetrievalConfig(method="invalid")  # type: ignore[arg-type]
-    assert "method" in str(exc_info.value)
+        RetrievalConfig(strategy="invalid")  # type: ignore[arg-type]
+    assert "strategy" in str(exc_info.value)
 
     # Invalid top_k (too large)
     with pytest.raises(ValidationError) as exc_info:
@@ -91,7 +91,7 @@ def test_nested_config_validation():
 
     # Access nested values
     assert config.retrieval.hybrid.alpha == 0.5
-    assert config.context.formatting.include_citations is True
+    assert config.formatting.citations.enabled is True
     assert config.ingestion.ocr.enabled is True
 
     # Modify nested values
@@ -118,7 +118,7 @@ def test_config_from_dict():
             "temperature": 0.5,
         },
         "retrieval": {
-            "method": "semantic",
+            "strategy": "semantic",
             "top_k": 15,
         },
     }
@@ -126,7 +126,7 @@ def test_config_from_dict():
     config = RAGConfig(**config_dict)  # type: ignore[arg-type]
     assert config.generation.model == "openweight-large"
     assert config.generation.temperature == 0.5
-    assert config.retrieval.method == "semantic"
+    assert config.retrieval.strategy == "semantic"
     assert config.retrieval.top_k == 15
 
 

--- a/packages/retrieval/src/retrieval/__init__.py
+++ b/packages/retrieval/src/retrieval/__init__.py
@@ -6,7 +6,7 @@ This package provides document retrieval capabilities with two backends:
 
 Backend selection is driven by `ragfacile.toml`:
     [storage]
-    backend = "albert-collections"  # or "local-sqlite"
+    provider = "albert-collections"  # or "local-sqlite"
 
 Example usage with factory:
     from retrieval import get_provider
@@ -41,8 +41,8 @@ def get_provider(config: Any | None = None) -> Any:
 
         config = get_config()
 
-    # Determine backend from storage.backend config field
-    backend = config.storage.backend
+    # Determine backend from storage.provider config field
+    backend = config.storage.provider
 
     if backend == "albert-collections":
         # Albert RAG: full pipeline with ingestion + search + reranking

--- a/packages/retrieval/src/retrieval/albert.py
+++ b/packages/retrieval/src/retrieval/albert.py
@@ -150,7 +150,7 @@ def retrieve(
         query: Search query text.
         collection_ids: Collections to search in.
         top_k: Number of search results (defaults to config.retrieval.top_k).
-        method: Search method (defaults to config.retrieval.method).
+        method: Search method (defaults to config.retrieval.strategy).
         score_threshold: Min score (defaults to config.retrieval.score_threshold).
         rerank: Whether to rerank (defaults to config.reranking.enabled).
         rerank_model: Reranker model (defaults to config.reranking.model).
@@ -163,7 +163,7 @@ def retrieve(
 
     # Apply config defaults
     top_k = top_k if top_k is not None else config.retrieval.top_k
-    method = method if method is not None else config.retrieval.method
+    method = method if method is not None else config.retrieval.strategy
     score_threshold = (
         score_threshold
         if score_threshold is not None

--- a/packages/retrieval/src/retrieval/formatter.py
+++ b/packages/retrieval/src/retrieval/formatter.py
@@ -51,12 +51,12 @@ def format_context(
     include_citations = (
         include_citations
         if include_citations is not None
-        else config.context.formatting.include_citations
+        else config.formatting.citations.enabled
     )
     citation_style = (
         citation_style
         if citation_style is not None
-        else config.context.formatting.citation_style
+        else config.formatting.citations.style
     )
 
     lines: list[str] = ["", "--- Retrieved context ---"]

--- a/packages/retrieval/tests/conftest.py
+++ b/packages/retrieval/tests/conftest.py
@@ -5,8 +5,8 @@ import pytest
 from albert import AlbertClient
 from rag_core.schema import (
     ChunkingConfig,
-    ContextConfig,
-    ContextFormattingConfig,
+    CitationsConfig,
+    FormattingConfig,
     RAGConfig,
     RerankingConfig,
     RetrievalConfig,
@@ -43,12 +43,10 @@ def mock_config(monkeypatch):
     """Patch rag_core.get_config() with test values."""
     config = RAGConfig(
         chunking=ChunkingConfig(chunk_size=512, chunk_overlap=50),
-        retrieval=RetrievalConfig(method="hybrid", top_k=10, score_threshold=0.0),
+        retrieval=RetrievalConfig(strategy="hybrid", top_k=10, score_threshold=0.0),
         reranking=RerankingConfig(enabled=True, model="openweight-rerank", top_n=3),
-        context=ContextConfig(
-            formatting=ContextFormattingConfig(
-                include_citations=True, citation_style="inline"
-            )
+        formatting=FormattingConfig(
+            citations=CitationsConfig(enabled=True, style="inline")
         ),
     )
     monkeypatch.setattr("retrieval.ingestion.get_config", lambda: config)

--- a/packages/retrieval/tests/test_retriever.py
+++ b/packages/retrieval/tests/test_retriever.py
@@ -220,7 +220,7 @@ class TestRetrieve:
 
         # Verify search was called with config defaults
         request_body = mock_route.calls.last.request.content.decode()
-        assert '"hybrid"' in request_body  # config.retrieval.method
+        assert '"hybrid"' in request_body  # config.retrieval.strategy
         assert '"limit":10' in request_body or '"limit": 10' in request_body
 
     @respx.mock

--- a/ragfacile.toml
+++ b/ragfacile.toml
@@ -1,0 +1,89 @@
+[meta]
+schema_version = "1.0.0"
+preset = "balanced"
+
+[eval]
+provider = "albert"
+target_samples = 50
+output_format = "jsonl"
+
+[ingestion]
+file_types = [
+    ".pdf",
+    ".md",
+    ".txt",
+]
+
+[ingestion.ocr]
+enabled = true
+dpi = 300
+extract_images = false
+include_bounding_boxes = false
+
+[ingestion.parsing]
+output_format = "markdown"
+preserve_structure = true
+include_page_numbers = true
+
+[chunking]
+strategy = "semantic"
+chunk_size = 512
+chunk_overlap = 50
+preserve_metadata = true
+
+[embedding]
+model = "openweight-embeddings"
+batch_size = 32
+normalization = "L2"
+
+[storage]
+provider = "albert-collections"
+collection_naming = "workspace"
+distance_metric = "cosine"
+
+[query]
+rewrite_enabled = false
+expand_enabled = false
+spell_check = false
+
+[retrieval]
+strategy = "hybrid"
+top_k = 10
+score_threshold = 0.0
+
+[retrieval.hybrid]
+alpha = 0.5
+
+[reranking]
+enabled = true
+model = "openweight-rerank"
+top_n = 3
+
+[context]
+strategy = "token-budget"
+max_tokens = 4096
+deduplicate = true
+ordering = "by-score"
+
+[generation]
+model = "openweight-medium"
+temperature = 0.7
+max_tokens = 1024
+streaming = true
+system_prompt = "You are a helpful assistant for the French government.\nAnswer questions based on the provided context.\nAlways cite your sources using [1], [2], etc."
+
+[hallucination]
+enabled = false
+strategy = "citation-check"
+threshold = 0.8
+fallback = "warn"
+
+[formatting]
+output_format = "markdown"
+include_confidence = false
+language = "fr"
+
+[formatting.citations]
+enabled = true
+style = "inline"
+include_sources = true


### PR DESCRIPTION
## Summary

- **Consolidate citation/source config** (#82): Removed overlapping `[context.formatting]` section and merged `include_citations`, `citation_style`, and `include_sources` into a single `[formatting.citations]` section — one place for all citation settings
- **Unify terminology** (#83): Renamed `storage.backend` → `storage.provider`, `retrieval.method` → `retrieval.strategy`, `hallucination.method` → `hallucination.strategy` for consistent naming across all pipeline stages
- Updated all 5 presets, CLI template, app code, tests (65 pass), and documentation (22 files total)

### Before
```toml
[context.formatting]
include_citations = true
citation_style = "inline"

[formatting]
include_sources = true

[storage]
backend = "albert-collections"

[retrieval]
method = "hybrid"

[hallucination]
method = "citation-check"
```

### After
```toml
[formatting.citations]
enabled = true
style = "inline"
include_sources = true

[storage]
provider = "albert-collections"

[retrieval]
strategy = "hybrid"

[hallucination]
strategy = "citation-check"
```

Closes #82, closes #83

## Test plan

- [x] `ruff check .` — all checks pass
- [x] `ruff format --check .` — 76 files already formatted
- [x] `ty` — type checker pass (via pre-commit)
- [x] `pytest packages/rag-core/tests/` — 38/38 pass
- [x] `pytest packages/retrieval/tests/` — 27/27 pass
- [x] `pytest apps/cli/tests/` — 77/78 pass (1 pre-existing failure unrelated to this PR)
- [x] Verify `rag-facile config show` displays correctly with new field names
- [x] Verify `rag-facile config preset apply <name>` works with updated presets

👾 Generated with [Letta Code](https://letta.com)