### PR TITLE
feat: add ingestion package with pluggable provider interface

### DIFF
--- a/.moon/templates/rag-core/presets/accurate.toml
+++ b/.moon/templates/rag-core/presets/accurate.toml
@@ -12,6 +12,7 @@ target_samples = 100  # More samples for better coverage
 output_format = "jsonl"
 
 [ingestion]
+provider = "albert"
 file_types = [".pdf", ".md", ".txt"]
 
 [ingestion.ocr]

--- a/.moon/templates/rag-core/presets/balanced.toml
+++ b/.moon/templates/rag-core/presets/balanced.toml
@@ -18,6 +18,7 @@ output_format = "jsonl"
 # DOCUMENT INGESTION
 # ==============================================================================
 [ingestion]
+provider = "local"
 file_types = [".pdf", ".md", ".txt"]
 
 [ingestion.ocr]

--- a/.moon/templates/rag-core/presets/fast.toml
+++ b/.moon/templates/rag-core/presets/fast.toml
@@ -12,6 +12,7 @@ target_samples = 25  # Fewer samples for faster generation
 output_format = "jsonl"
 
 [ingestion]
+provider = "local"
 file_types = [".pdf", ".md", ".txt"]
 
 [ingestion.ocr]

--- a/.moon/templates/rag-core/presets/hr.toml
+++ b/.moon/templates/rag-core/presets/hr.toml
@@ -12,6 +12,7 @@ target_samples = 50
 output_format = "jsonl"
 
 [ingestion]
+provider = "local"
 file_types = [".pdf", ".md", ".txt"]
 
 [ingestion.ocr]

--- a/.moon/templates/rag-core/presets/legal.toml
+++ b/.moon/templates/rag-core/presets/legal.toml
@@ -12,6 +12,7 @@ target_samples = 75
 output_format = "jsonl"
 
 [ingestion]
+provider = "albert"
 file_types = [".pdf", ".md", ".txt"]
 
 [ingestion.ocr]

--- a/.moon/templates/rag-core/src/rag_core/schema.py
+++ b/.moon/templates/rag-core/src/rag_core/schema.py
@@ -104,6 +104,10 @@ class ParsingConfig(BaseModel):
 class IngestionConfig(BaseModel):
     """Configuration for document ingestion and pre-processing."""
 
+    provider: Literal["local", "albert"] = Field(
+        default="local",
+        description="Document parsing provider (local pypdf or Albert API)",
+    )
     file_types: list[str] = Field(
         default=[".pdf", ".md", ".txt"],
         description="Supported file extensions",

--- a/apps/cli/src/cli/templates/ragfacile.toml
+++ b/apps/cli/src/cli/templates/ragfacile.toml
@@ -8,6 +8,7 @@ target_samples = 50
 output_format = "jsonl"
 
 [ingestion]
+provider = "local"
 file_types = [
     ".pdf",
     ".md",

--- a/packages/ingestion/README.md
+++ b/packages/ingestion/README.md
@@ -1,0 +1,25 @@
+# ingestion
+
+Document ingestion package for RAG Facile. Parses and extracts text from files (PDF, Markdown, HTML) using pluggable providers.
+
+## Providers
+
+- **local** — Local PDF parsing using pypdf (no external API required)
+- **albert** — Server-side parsing via Albert API with OCR and multi-format support
+
+## Usage
+
+```python
+from ingestion import get_provider
+
+provider = get_provider()  # reads ragfacile.toml
+text = provider.extract_text("document.pdf")
+context = provider.process_file("document.pdf")
+```
+
+The provider is configured in `ragfacile.toml`:
+
+```toml
+[ingestion]
+provider = "local"  # or "albert"
+```

--- a/packages/ingestion/pyproject.toml
+++ b/packages/ingestion/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "ingestion"
+version = "1.0.0" # x-release-please-version
+description = "Document ingestion - parse and extract text from files (PDF, Markdown, HTML)"
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = [
+    "albert-client",
+    "rag-core",
+]
+
+[tool.uv.sources]
+albert-client = { workspace = true }
+rag-core = { workspace = true }
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/ingestion"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/packages/ingestion/src/ingestion/__init__.py
+++ b/packages/ingestion/src/ingestion/__init__.py
@@ -1,0 +1,65 @@
+"""Ingestion - Document parsing with pluggable providers.
+
+Extract text from documents (PDF, Markdown, HTML) using either local
+parsing (pypdf) or server-side parsing (Albert API).
+
+The provider is selected via ``ragfacile.toml``:
+
+    [ingestion]
+    provider = "local"   # or "albert"
+
+Example usage::
+
+    from ingestion import get_provider
+
+    provider = get_provider()
+    text = provider.extract_text("document.pdf")
+    context = provider.process_file("document.pdf", filename="My Doc")
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ingestion._base import IngestionProvider
+
+
+def get_provider(config: Any | None = None) -> IngestionProvider:
+    """Get the configured ingestion provider.
+
+    Reads ``ragfacile.toml`` to determine which backend to use.
+
+    Args:
+        config: Optional RAGConfig instance. If None, loads from ragfacile.toml.
+
+    Returns:
+        An :class:`IngestionProvider` instance for the configured backend.
+
+    Raises:
+        ValueError: If the configured provider is not recognized.
+    """
+    if config is None:
+        from rag_core import get_config
+
+        config = get_config()
+
+    backend = config.ingestion.provider
+
+    if backend == "local":
+        from ingestion.local import LocalProvider
+
+        return LocalProvider()
+
+    if backend == "albert":
+        from ingestion.albert import AlbertProvider
+
+        return AlbertProvider()
+
+    msg = f"Unknown ingestion provider: {backend!r}. Expected 'local' or 'albert'."
+    raise ValueError(msg)
+
+
+__all__ = [
+    "IngestionProvider",
+    "get_provider",
+]

--- a/packages/ingestion/src/ingestion/__init__.py
+++ b/packages/ingestion/src/ingestion/__init__.py
@@ -45,18 +45,18 @@ def get_provider(config: Any | None = None) -> IngestionProvider:
 
     backend = config.ingestion.provider
 
-    if backend == "local":
-        from ingestion.local import LocalProvider
+    match backend:
+        case "local":
+            from ingestion.local import LocalProvider
 
-        return LocalProvider()
+            return LocalProvider()
+        case "albert":
+            from ingestion.albert import AlbertProvider
 
-    if backend == "albert":
-        from ingestion.albert import AlbertProvider
-
-        return AlbertProvider()
-
-    msg = f"Unknown ingestion provider: {backend!r}. Expected 'local' or 'albert'."
-    raise ValueError(msg)
+            return AlbertProvider()
+        case _:
+            msg = f"Unknown ingestion provider: {backend!r}. Expected 'local' or 'albert'."
+            raise ValueError(msg)
 
 
 __all__ = [

--- a/packages/ingestion/src/ingestion/_base.py
+++ b/packages/ingestion/src/ingestion/_base.py
@@ -1,0 +1,128 @@
+"""Base interface for document ingestion providers.
+
+Defines the :class:`IngestionProvider` ABC that all backends must implement.
+Shared logic (context formatting, file/bytes processing) lives here so
+concrete providers only need to implement text extraction.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+
+class IngestionProvider(ABC):
+    """Abstract base class for document ingestion providers.
+
+    Subclasses must implement:
+      - :attr:`supported_extensions` — file extensions this provider handles
+      - :attr:`accepted_mime_types` — MIME type map for file picker dialogs
+      - :meth:`extract_text` — extract text from a file path
+      - :meth:`extract_text_from_bytes` — extract text from raw bytes
+
+    Shared methods provided by this base class:
+      - :meth:`format_as_context` — wrap text with source delimiters
+      - :meth:`process_file` — extract + format in one call
+      - :meth:`process_bytes` — extract from bytes + format in one call
+    """
+
+    @property
+    @abstractmethod
+    def supported_extensions(self) -> list[str]:
+        """File extensions this provider can parse (e.g., ``[".pdf"]``)."""
+
+    @property
+    @abstractmethod
+    def accepted_mime_types(self) -> dict[str, list[str]]:
+        """MIME types for file picker dialogs.
+
+        Returns:
+            Dict mapping MIME types to extensions, e.g.
+            ``{"application/pdf": [".pdf"]}``.
+        """
+
+    @abstractmethod
+    def extract_text(self, path: str | Path) -> str:
+        """Extract text content from a document file.
+
+        Args:
+            path: Path to the document.
+
+        Returns:
+            Extracted text content.
+
+        Raises:
+            FileNotFoundError: If the file doesn't exist.
+        """
+
+    @abstractmethod
+    def extract_text_from_bytes(
+        self,
+        data: bytes,
+        *,
+        suffix: str = ".pdf",
+    ) -> str:
+        """Extract text content from raw file bytes.
+
+        Args:
+            data: Raw file content.
+            suffix: File extension hint (e.g., ``".pdf"``).
+
+        Returns:
+            Extracted text content.
+        """
+
+    def format_as_context(self, text: str, filename: str) -> str:
+        """Format extracted text with source delimiters for context injection.
+
+        Args:
+            text: The extracted text content.
+            filename: Display name of the source file.
+
+        Returns:
+            Text wrapped with file delimiters.
+        """
+        return (
+            f"\n\n--- Content of attached file '{filename}' ---\n"
+            f"{text}\n"
+            f"--- End of file ---\n"
+        )
+
+    def process_file(
+        self,
+        path: str | Path,
+        filename: str | None = None,
+    ) -> str:
+        """Extract text from a file and format it for context injection.
+
+        Convenience method combining :meth:`extract_text` and
+        :meth:`format_as_context`.
+
+        Args:
+            path: Path to the document.
+            filename: Optional display name. Defaults to the file's basename.
+
+        Returns:
+            Formatted text ready for context injection.
+        """
+        path = Path(path)
+        display_name = filename or path.name
+        text = self.extract_text(path)
+        return self.format_as_context(text, display_name)
+
+    def process_bytes(self, data: bytes, filename: str) -> str:
+        """Extract text from bytes and format it for context injection.
+
+        Convenience method combining :meth:`extract_text_from_bytes` and
+        :meth:`format_as_context`.
+
+        Args:
+            data: Raw file content.
+            filename: Display name (also used to infer file type).
+
+        Returns:
+            Formatted text ready for context injection.
+        """
+        suffix = Path(filename).suffix or ".pdf"
+        text = self.extract_text_from_bytes(data, suffix=suffix)
+        return self.format_as_context(text, filename)

--- a/packages/ingestion/src/ingestion/albert.py
+++ b/packages/ingestion/src/ingestion/albert.py
@@ -1,0 +1,151 @@
+"""Albert API document ingestion provider.
+
+Uses Albert's server-side parse API for high-quality document parsing
+with OCR support. Supports PDF, Markdown, HTML, and JSON files.
+Falls back to local pypdf for PDF files when the API returns a server error.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import TYPE_CHECKING
+
+from ingestion._base import IngestionProvider
+
+
+if TYPE_CHECKING:
+    from albert import AlbertClient
+
+
+logger = logging.getLogger(__name__)
+
+
+class AlbertProvider(IngestionProvider):
+    """Albert API document parsing.
+
+    Parses documents via Albert's ``/parse-beta`` endpoint, which provides
+    high-quality OCR and markdown conversion for multiple file formats.
+
+    Falls back to local pypdf for PDF files when the API is unavailable.
+
+    Args:
+        client: Optional pre-configured Albert client.
+            If None, creates one from environment variables.
+    """
+
+    def __init__(self, client: AlbertClient | None = None) -> None:
+        self._client = client
+
+    @property
+    def supported_extensions(self) -> list[str]:
+        return [".pdf", ".json", ".md", ".html"]
+
+    @property
+    def accepted_mime_types(self) -> dict[str, list[str]]:
+        return {
+            "application/pdf": [".pdf"],
+            "application/json": [".json"],
+            "text/markdown": [".md"],
+            "text/html": [".html", ".htm"],
+        }
+
+    @property
+    def client(self) -> AlbertClient:
+        """Lazily create the Albert client on first use."""
+        if self._client is None:
+            from albert import AlbertClient
+
+            self._client = AlbertClient()
+        return self._client
+
+    def _parse_and_combine(self, file_path: Path, *, force_ocr: bool = False) -> str:
+        """Parse a file via Albert API and combine page contents."""
+        parsed = self.client.parse(file_path=file_path, force_ocr=force_ocr)
+
+        text_parts: list[str] = []
+        for page in parsed.data:
+            if page.content:
+                text_parts.append(page.content)
+
+        return "\n".join(text_parts)
+
+    def extract_text(self, path: str | Path) -> str:
+        """Extract text from a document using Albert's parse API.
+
+        For PDF files, falls back to local pypdf if the API returns
+        a server error (5xx).
+
+        Args:
+            path: Path to the document file.
+
+        Returns:
+            Extracted text content as markdown.
+
+        Raises:
+            FileNotFoundError: If the file doesn't exist.
+        """
+        import httpx
+
+        path = Path(path)
+
+        if not path.exists():
+            raise FileNotFoundError(f"File not found: {path}")
+
+        try:
+            return self._parse_and_combine(path)
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code >= 500 and path.suffix.lower() == ".pdf":
+                logger.warning(
+                    "Albert parse API returned %s for '%s', "
+                    "falling back to local pypdf",
+                    e.response.status_code,
+                    path.name,
+                )
+                from rag_core.pdf import extract_text_from_pdf
+
+                return extract_text_from_pdf(path)
+            raise
+
+    def extract_text_from_bytes(
+        self,
+        data: bytes,
+        *,
+        suffix: str = ".pdf",
+    ) -> str:
+        """Extract text from file bytes using Albert's parse API.
+
+        For PDF bytes, falls back to local pypdf if the API returns
+        a server error (5xx).
+
+        Args:
+            data: Raw file content.
+            suffix: File extension hint (e.g., ``".pdf"``).
+
+        Returns:
+            Extracted text content as markdown.
+        """
+        import httpx
+
+        # Albert parse API requires a file path, so write to a temp file.
+        # delete=False for Windows compatibility (prevents read-while-open).
+        tmp = NamedTemporaryFile(suffix=suffix, delete=False)
+        try:
+            tmp.write(data)
+            tmp.flush()
+            tmp.close()
+            try:
+                return self._parse_and_combine(Path(tmp.name))
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code >= 500 and suffix.lower() == ".pdf":
+                    logger.warning(
+                        "Albert parse API returned %s, falling back to local pypdf",
+                        e.response.status_code,
+                    )
+                    from rag_core.pdf import extract_text_from_bytes as _local
+
+                    return _local(data)
+                raise
+        finally:
+            Path(tmp.name).unlink(missing_ok=True)

--- a/packages/ingestion/src/ingestion/albert.py
+++ b/packages/ingestion/src/ingestion/albert.py
@@ -64,12 +64,7 @@ class AlbertProvider(IngestionProvider):
         """Parse a file via Albert API and combine page contents."""
         parsed = self.client.parse(file_path=file_path, force_ocr=force_ocr)
 
-        text_parts: list[str] = []
-        for page in parsed.data:
-            if page.content:
-                text_parts.append(page.content)
-
-        return "\n".join(text_parts)
+        return "\n".join(page.content for page in parsed.data if page.content)
 
     def extract_text(self, path: str | Path) -> str:
         """Extract text from a document using Albert's parse API.
@@ -130,22 +125,21 @@ class AlbertProvider(IngestionProvider):
 
         # Albert parse API requires a file path, so write to a temp file.
         # delete=False for Windows compatibility (prevents read-while-open).
-        tmp = NamedTemporaryFile(suffix=suffix, delete=False)
-        try:
+        with NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+            tmp_path = Path(tmp.name)
             tmp.write(data)
-            tmp.flush()
-            tmp.close()
-            try:
-                return self._parse_and_combine(Path(tmp.name))
-            except httpx.HTTPStatusError as e:
-                if e.response.status_code >= 500 and suffix.lower() == ".pdf":
-                    logger.warning(
-                        "Albert parse API returned %s, falling back to local pypdf",
-                        e.response.status_code,
-                    )
-                    from rag_core.pdf import extract_text_from_bytes as _local
 
-                    return _local(data)
-                raise
+        try:
+            return self._parse_and_combine(tmp_path)
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code >= 500 and suffix.lower() == ".pdf":
+                logger.warning(
+                    "Albert parse API returned %s, falling back to local pypdf",
+                    e.response.status_code,
+                )
+                from rag_core.pdf import extract_text_from_bytes as _local
+
+                return _local(data)
+            raise
         finally:
-            Path(tmp.name).unlink(missing_ok=True)
+            tmp_path.unlink(missing_ok=True)

--- a/packages/ingestion/src/ingestion/local.py
+++ b/packages/ingestion/src/ingestion/local.py
@@ -1,0 +1,66 @@
+"""Local document ingestion provider using pypdf.
+
+Extracts text from PDF files locally without any external API calls.
+Suitable for offline use or when server-side parsing is unavailable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rag_core.pdf import extract_text_from_bytes as _pdf_from_bytes
+from rag_core.pdf import extract_text_from_pdf as _pdf_from_path
+
+from ingestion._base import IngestionProvider
+
+
+class LocalProvider(IngestionProvider):
+    """Local PDF parsing using pypdf.
+
+    Only supports PDF files. For multi-format parsing (HTML, Markdown, JSON),
+    use the Albert provider instead.
+    """
+
+    @property
+    def supported_extensions(self) -> list[str]:
+        return [".pdf"]
+
+    @property
+    def accepted_mime_types(self) -> dict[str, list[str]]:
+        return {"application/pdf": [".pdf"]}
+
+    def extract_text(self, path: str | Path) -> str:
+        """Extract text from a PDF file using pypdf.
+
+        Args:
+            path: Path to the PDF file.
+
+        Returns:
+            Extracted text content.
+
+        Raises:
+            FileNotFoundError: If the file doesn't exist.
+            ValueError: If the file is not a PDF.
+            pypdf.errors.PdfReadError: If the PDF is corrupted.
+        """
+        return _pdf_from_path(path)
+
+    def extract_text_from_bytes(
+        self,
+        data: bytes,
+        *,
+        suffix: str = ".pdf",
+    ) -> str:
+        """Extract text from PDF bytes using pypdf.
+
+        Args:
+            data: Raw PDF file content.
+            suffix: File extension hint (only ``".pdf"`` supported).
+
+        Returns:
+            Extracted text content.
+
+        Raises:
+            pypdf.errors.PdfReadError: If the PDF is corrupted.
+        """
+        return _pdf_from_bytes(data)

--- a/packages/ingestion/tests/test_ingestion.py
+++ b/packages/ingestion/tests/test_ingestion.py
@@ -1,0 +1,115 @@
+"""Tests for the ingestion package."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from ingestion import IngestionProvider, get_provider
+from ingestion._base import IngestionProvider as BaseClass
+from ingestion.local import LocalProvider
+
+
+# ---------------------------------------------------------------------------
+# ABC contract
+# ---------------------------------------------------------------------------
+
+
+def test_ingestion_provider_is_abstract():
+    """IngestionProvider cannot be instantiated directly."""
+    with pytest.raises(TypeError):
+        IngestionProvider()  # type: ignore[abstract]
+
+
+def test_local_provider_implements_interface():
+    """LocalProvider satisfies the IngestionProvider interface."""
+    provider = LocalProvider()
+    assert isinstance(provider, BaseClass)
+
+
+# ---------------------------------------------------------------------------
+# LocalProvider
+# ---------------------------------------------------------------------------
+
+
+class TestLocalProvider:
+    """Tests for LocalProvider (pypdf backend)."""
+
+    def test_supported_extensions(self):
+        provider = LocalProvider()
+        assert provider.supported_extensions == [".pdf"]
+
+    def test_accepted_mime_types(self):
+        provider = LocalProvider()
+        assert "application/pdf" in provider.accepted_mime_types
+
+    def test_extract_text_file_not_found(self):
+        provider = LocalProvider()
+        with pytest.raises(FileNotFoundError):
+            provider.extract_text("/nonexistent/file.pdf")
+
+    def test_extract_text_not_pdf(self, tmp_path: Path):
+        provider = LocalProvider()
+        txt_file = tmp_path / "test.txt"
+        txt_file.write_text("hello")
+        with pytest.raises(ValueError, match="Expected a PDF"):
+            provider.extract_text(txt_file)
+
+    def test_format_as_context(self):
+        provider = LocalProvider()
+        result = provider.format_as_context("some text", "doc.pdf")
+        assert "doc.pdf" in result
+        assert "some text" in result
+        assert "--- Content of attached file" in result
+        assert "--- End of file ---" in result
+
+    def test_process_file_formats_output(self, tmp_path: Path, monkeypatch):
+        """process_file calls extract_text and wraps with delimiters."""
+        provider = LocalProvider()
+        monkeypatch.setattr(provider, "extract_text", lambda _path: "extracted content")
+        result = provider.process_file(tmp_path / "report.pdf")
+        assert "report.pdf" in result
+        assert "extracted content" in result
+
+    def test_process_bytes_formats_output(self, monkeypatch):
+        """process_bytes calls extract_text_from_bytes and wraps with delimiters."""
+        provider = LocalProvider()
+        monkeypatch.setattr(
+            provider,
+            "extract_text_from_bytes",
+            lambda _data, suffix=".pdf": "bytes content",
+        )
+        result = provider.process_bytes(b"fake-pdf", "upload.pdf")
+        assert "upload.pdf" in result
+        assert "bytes content" in result
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+class TestGetProvider:
+    """Tests for the get_provider factory function."""
+
+    def test_local_provider(self):
+        config = MagicMock()
+        config.ingestion.provider = "local"
+        provider = get_provider(config)
+        assert isinstance(provider, LocalProvider)
+
+    def test_albert_provider(self):
+        from ingestion.albert import AlbertProvider
+
+        config = MagicMock()
+        config.ingestion.provider = "albert"
+        provider = get_provider(config)
+        assert isinstance(provider, AlbertProvider)
+
+    def test_unknown_provider_raises(self):
+        config = MagicMock()
+        config.ingestion.provider = "unknown"
+        with pytest.raises(ValueError, match="Unknown ingestion provider"):
+            get_provider(config)

--- a/packages/rag-core/presets/accurate.toml
+++ b/packages/rag-core/presets/accurate.toml
@@ -12,6 +12,7 @@ target_samples = 100  # More samples for better coverage
 output_format = "jsonl"
 
 [ingestion]
+provider = "albert"
 file_types = [".pdf", ".md", ".txt"]
 
 [ingestion.ocr]

--- a/packages/rag-core/presets/balanced.toml
+++ b/packages/rag-core/presets/balanced.toml
@@ -18,6 +18,7 @@ output_format = "jsonl"
 # DOCUMENT INGESTION
 # ==============================================================================
 [ingestion]
+provider = "local"
 file_types = [".pdf", ".md", ".txt"]
 
 [ingestion.ocr]

--- a/packages/rag-core/presets/fast.toml
+++ b/packages/rag-core/presets/fast.toml
@@ -12,6 +12,7 @@ target_samples = 25  # Fewer samples for faster generation
 output_format = "jsonl"
 
 [ingestion]
+provider = "local"
 file_types = [".pdf", ".md", ".txt"]
 
 [ingestion.ocr]

--- a/packages/rag-core/presets/hr.toml
+++ b/packages/rag-core/presets/hr.toml
@@ -12,6 +12,7 @@ target_samples = 50
 output_format = "jsonl"
 
 [ingestion]
+provider = "local"
 file_types = [".pdf", ".md", ".txt"]
 
 [ingestion.ocr]

--- a/packages/rag-core/presets/legal.toml
+++ b/packages/rag-core/presets/legal.toml
@@ -12,6 +12,7 @@ target_samples = 75
 output_format = "jsonl"
 
 [ingestion]
+provider = "albert"
 file_types = [".pdf", ".md", ".txt"]
 
 [ingestion.ocr]

--- a/packages/rag-core/src/rag_core/schema.py
+++ b/packages/rag-core/src/rag_core/schema.py
@@ -104,6 +104,10 @@ class ParsingConfig(BaseModel):
 class IngestionConfig(BaseModel):
     """Configuration for document ingestion and pre-processing."""
 
+    provider: Literal["local", "albert"] = Field(
+        default="local",
+        description="Document parsing provider (local pypdf or Albert API)",
+    )
     file_types: list[str] = Field(
         default=[".pdf", ".md", ".txt"],
         description="Supported file extensions",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.13, <3.14"
 dependencies = [
     "albert-client",
     "chainlit-chat",
+    "ingestion",
     "rag-core",
     "retrieval",
     "rag-facile-cli",
@@ -16,6 +17,7 @@ dependencies = [
 [tool.uv.sources]
 albert-client = { workspace = true }
 chainlit-chat = { workspace = true }
+ingestion = { workspace = true }
 rag-core = { workspace = true }
 retrieval = { workspace = true }
 rag-facile-cli = { workspace = true }
@@ -57,7 +59,7 @@ exclude = [".moon/templates"]
 
 [tool.ruff.lint.isort]
 # Define our first-party packages (local imports)
-known-first-party = ["albert", "chainlit_chat", "cli", "rag_core", "retrieval", "reflex_chat"]
+known-first-party = ["albert", "chainlit_chat", "cli", "ingestion", "rag_core", "retrieval", "reflex_chat"]
 # Ensure proper PEP 8 section ordering with blank lines between groups
 section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
 lines-after-imports = 2  # PEP 8: 2 blank lines before top-level definitions

--- a/ragfacile.toml
+++ b/ragfacile.toml
@@ -8,6 +8,7 @@ target_samples = 50
 output_format = "jsonl"
 
 [ingestion]
+provider = "local"
 file_types = [
     ".pdf",
     ".md",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -18,6 +18,7 @@
 				"apps/cli/pyproject.toml",
 				"apps/chainlit-chat/pyproject.toml",
 				"apps/reflex-chat/pyproject.toml",
+				"packages/ingestion/pyproject.toml",
 				"packages/rag-core/pyproject.toml",
 				"packages/retrieval/pyproject.toml"
 			]

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,7 @@ resolution-markers = [
 members = [
     "albert-client",
     "chainlit-chat",
+    "ingestion",
     "rag-core",
     "rag-facile",
     "rag-facile-cli",
@@ -324,7 +325,7 @@ wheels = [
 
 [[package]]
 name = "chainlit-chat"
-version = "0.10.1"
+version = "1.0.0"
 source = { editable = "apps/chainlit-chat" }
 dependencies = [
     { name = "albert-client" },
@@ -831,6 +832,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e1/7e/691d061b7329bc8d54edbf0ec22fbfb2afe61facb681f9aaa9bff7a27d04/inflection-0.5.1.tar.gz", hash = "sha256:1a29730d366e996aaacffb2f1f1cb9593dc38e2ddd30c91250c6dde09ea9b417", size = 15091, upload-time = "2020-08-22T08:16:29.139Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/91/aa6bde563e0085a02a435aa99b49ef75b0a4b062635e606dab23ce18d720/inflection-0.5.1-py2.py3-none-any.whl", hash = "sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2", size = 9454, upload-time = "2020-08-22T08:16:27.816Z" },
+]
+
+[[package]]
+name = "ingestion"
+version = "1.0.0"
+source = { editable = "packages/ingestion" }
+dependencies = [
+    { name = "albert-client" },
+    { name = "rag-core" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "albert-client", editable = "packages/albert-client" },
+    { name = "rag-core", editable = "packages/rag-core" },
 ]
 
 [[package]]
@@ -2327,7 +2343,7 @@ wheels = [
 
 [[package]]
 name = "rag-core"
-version = "0.10.1"
+version = "1.0.0"
 source = { editable = "packages/rag-core" }
 dependencies = [
     { name = "pydantic" },
@@ -2344,11 +2360,12 @@ requires-dist = [
 
 [[package]]
 name = "rag-facile"
-version = "0.10.1"
+version = "1.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "albert-client" },
     { name = "chainlit-chat" },
+    { name = "ingestion" },
     { name = "rag-core" },
     { name = "rag-facile-cli" },
     { name = "reflex-chat" },
@@ -2371,6 +2388,7 @@ dev = [
 requires-dist = [
     { name = "albert-client", editable = "packages/albert-client" },
     { name = "chainlit-chat", editable = "apps/chainlit-chat" },
+    { name = "ingestion", editable = "packages/ingestion" },
     { name = "rag-core", editable = "packages/rag-core" },
     { name = "rag-facile-cli", editable = "apps/cli" },
     { name = "reflex-chat", editable = "apps/reflex-chat" },
@@ -2391,7 +2409,7 @@ dev = [
 
 [[package]]
 name = "rag-facile-cli"
-version = "0.10.1"
+version = "1.0.0"
 source = { editable = "apps/cli" }
 dependencies = [
     { name = "albert-client" },
@@ -2490,7 +2508,7 @@ wheels = [
 
 [[package]]
 name = "reflex-chat"
-version = "0.10.1"
+version = "1.0.0"
 source = { editable = "apps/reflex-chat" }
 dependencies = [
     { name = "albert-client" },
@@ -2556,7 +2574,7 @@ wheels = [
 
 [[package]]
 name = "retrieval"
-version = "0.10.1"
+version = "1.0.0"
 source = { editable = "packages/retrieval" }
 dependencies = [
     { name = "albert-client" },


### PR DESCRIPTION
## Summary

- New `packages/ingestion/` package with an ABC-based provider interface (`IngestionProvider`) for document text extraction
- **`LocalProvider`** — local PDF parsing using pypdf (no API required)
- **`AlbertProvider`** — server-side parsing via Albert API with pypdf fallback on 5xx errors
- Factory `get_provider()` reads `ingestion.provider` from `ragfacile.toml` to select backend
- Added `provider: Literal["local", "albert"]` field to `IngestionConfig` schema
- Updated all 5 presets (`accurate` and `legal` use `"albert"`, others use `"local"`), `ragfacile.toml`, and CLI template
- Registered in workspace, release-please `extra-files`, and ruff isort config

### Package structure

```
packages/ingestion/
├── src/ingestion/
│   ├── __init__.py     # get_provider() factory
│   ├── _base.py        # IngestionProvider ABC
│   ├── local.py        # LocalProvider (pypdf)
│   └── albert.py       # AlbertProvider (Albert parse API)
└── tests/
    └── test_ingestion.py   # 12 tests
```

### Interface

Subclasses implement `extract_text()`, `extract_text_from_bytes()`, `supported_extensions`, `accepted_mime_types`. The ABC provides shared `format_as_context()`, `process_file()`, and `process_bytes()`.

This is the first pipeline-phase package. Subsequent phases (chunking, embedding, etc.) will follow the same pattern. Rewiring `retrieval` and `context_loader` to delegate to this package is tracked separately in #86 and #87.

## Test plan

- [x] 12 new tests pass (ABC contract, LocalProvider, factory)
- [x] 65 existing tests pass (rag-core + retrieval) — no regressions
- [x] All presets load correctly (`test_presets.py`)
- [x] ruff check + format clean
- [x] Pre-commit hooks pass (ruff, ruff-format, ty, regenerate-templates)

👾 Generated with [Letta Code](https://letta.com)