### PR TITLE
fix: use date-sorted release badge to avoid shields.io semver bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RAG Facile
 
-[![Release](https://img.shields.io/github/v/release/etalab-ia/rag-facile?style=flat-square)](https://github.com/etalab-ia/rag-facile/releases)
+[![Release](https://img.shields.io/github/v/release/etalab-ia/rag-facile?sort=date&style=flat-square)](https://github.com/etalab-ia/rag-facile/releases)
 [![License](https://img.shields.io/github/license/etalab-ia/rag-facile?style=flat-square)](LICENSE)
 
 ```


### PR DESCRIPTION
## Summary
- Adds `sort=date` to the shields.io release badge URL
- shields.io's default `sort=semver` endpoint is intermittently returning "invalid" for GitHub release badges (confirmed not specific to our repo — even `astral-sh/ruff` is affected)
- `sort=date` is more reliable and semantically correct (we always want the most recent release)

## Test plan
- [x] Verified `sort=date` returns correct version (`v0.11.1`) via `curl`
- [x] Confirmed the issue affects other repos too (not related to our v1.0.0 rollback)

👾 Generated with [Letta Code](https://letta.com)