### PR TITLE
chore: exclude albert-client from automated release management

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,3 @@
 {
-	"packages/albert-client": "0.4.0",
 	".": "0.11.1"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,13 +3,6 @@
 	"release-type": "python",
 	"changelog-path": "CHANGELOG.md",
 	"packages": {
-		"packages/albert-client": {
-			"release-type": "python",
-			"component": "albert-client",
-			"include-component-in-tag": true,
-			"changelog-path": "CHANGELOG.md",
-			"version-file": "pyproject.toml"
-		},
 		".": {
 			"release-type": "python",
 			"changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
## Problem

PR #95 is attempting to bump `albert-client` from 0.4.0 to 0.5.0 based on conventional commits. However, `albert-client` versioning should **only** be driven by Albert API OpenAPI spec changes, not by our commit history.

When we make fixes to the albert-client code (like the Collection model fix in PR #96), these are implementation details that shouldn't trigger automatic version bumps.

## Solution

Remove `albert-client` from release-please management entirely. The package will be versioned and released manually when the Albert API spec changes.

### Changes

- Removed `packages/albert-client` entry from `release-please-config.json`
- Removed `packages/albert-client` entry from `.release-please-manifest.json`

### Manual Release Process (for future Albert API updates)

When the Albert API spec changes (e.g., v0.4.0 → v0.5.0):

1. Update version in `packages/albert-client/pyproject.toml`
2. Update `packages/albert-client/CHANGELOG.md` (optional)
3. Create tag: `git tag -a albert-client-v0.x.0 -m "albert-client v0.x.0"`
4. Push tag: `git push origin albert-client-v0.x.0`
5. Create GitHub release: `gh release create albert-client-v0.x.0 --title "albert-client v0.x.0" --notes "Tracks Albert API v0.x.0"`

## Next Steps

After this PR merges:
- PR #95 will need to be updated (release-please should regenerate without albert-client)
- Or we may need to close #95 and let release-please create a fresh PR

## Related

- Closes issue with automated albert-client version bumps
- Affects PR #95

👾 Generated with [Letta Code](https://letta.com)