### PR TITLE
fix: add GIT_WORK_TREE workaround for moon in bare repo worktrees

### DIFF
--- a/justfile
+++ b/justfile
@@ -5,7 +5,7 @@ set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
 
 # Workaround for moon not supporting bare repo worktrees (moonrepo/moon#2162).
 # Fixed in moon v2 — remove this once upgraded.
-export GIT_WORK_TREE := `pwd`
+export GIT_WORK_TREE := justfile_directory()
 
 # Display available commands
 default:

--- a/justfile
+++ b/justfile
@@ -3,6 +3,10 @@
 # Use PowerShell on Windows, sh on Unix
 set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
 
+# Workaround for moon not supporting bare repo worktrees (moonrepo/moon#2162).
+# Fixed in moon v2 — remove this once upgraded.
+export GIT_WORK_TREE := `pwd`
+
 # Display available commands
 default:
     @just --list


### PR DESCRIPTION
## Summary
- Moon v1 doesn't support the bare repo worktree pattern ([moonrepo/moon#2162](https://github.com/moonrepo/moon/issues/2162))
- All `moon run` commands fail with `fatal: this operation must be run in a work tree` because moon traverses up to the bare repo root and runs git there
- Fix: export `GIT_WORK_TREE` in the justfile so all moon commands run against the correct worktree
- Temporary — the [fix is merged](https://github.com/moonrepo/moon/pull/2332) in moon v2, remove once upgraded

## Test plan
- [x] `just format` works in bare repo worktree
- [x] `just lint` works
- [x] `just check` (format-check + lint + type-check) all pass
- [x] `just run chainlit-chat` works
- [x] Tests: 100/101 passing (1 pre-existing failure)

👾 Generated with [Letta Code](https://letta.com)