### PR TITLE
docs: fix install instructions for macOS/zsh compatibility

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,9 @@
 Install proto (version manager):
 ```bash
 curl -fsSL https://moonrepo.dev/install/proto.sh | bash
-source ~/.bashrc  # or restart your terminal
 ```
+
+Then **restart your terminal** (or `source ~/.zshrc` on macOS, `source ~/.bashrc` on Linux).
 
 Install required tools via proto:
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Install proto (version manager):
 curl -fsSL https://moonrepo.dev/install/proto.sh | bash
 ```
 
-Then **restart your terminal** (or `source ~/.zshrc` on macOS, `source ~/.bashrc` on Linux).
+Then **restart your terminal** (or run the `source` command shown by the installer).
 
 Install required tools via proto:
 ```bash

--- a/README.md
+++ b/README.md
@@ -23,18 +23,19 @@ Build a RAG application for the French government in under 5 minutes, powered by
 
 One command installs the entire toolchain and the `rag-facile` CLI:
 
+Linux / macOS / WSL:
+
 ```bash
-# Linux / macOS / WSL
 curl -fsSL https://raw.githubusercontent.com/etalab-ia/rag-facile/main/install.sh | bash
-source ~/.bashrc  # or restart your terminal
 ```
 
+Windows (PowerShell):
+
 ```powershell
-# Windows (PowerShell)
 irm https://raw.githubusercontent.com/etalab-ia/rag-facile/main/install.ps1 | iex
 ```
 
-Verify it worked:
+Then **restart your terminal** (or run the `source` command shown by the installer) and verify it worked:
 
 ```bash
 rag-facile --help
@@ -52,13 +53,15 @@ The CLI will guide you through choosing a project structure, a configuration pre
 
 Re-run the installer to get the latest version:
 
+Linux / macOS / WSL:
+
 ```bash
-# Linux / macOS / WSL
 curl -fsSL https://raw.githubusercontent.com/etalab-ia/rag-facile/main/install.sh | bash
 ```
 
+Windows (PowerShell):
+
 ```powershell
-# Windows (PowerShell)
 irm https://raw.githubusercontent.com/etalab-ia/rag-facile/main/install.ps1 | iex
 ```
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -10,8 +10,9 @@ One command installs the entire toolchain (proto, moon, uv) and the CLI:
 
 ```bash
 bash <(curl -fsSL https://raw.githubusercontent.com/etalab-ia/rag-facile/main/install.sh)
-source ~/.bashrc  # or restart your terminal
 ```
+
+Then **restart your terminal** (or run the `source` command shown by the installer).
 
 ### Option 2: Manual Installation
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -18,8 +18,9 @@ The installer sets up the full toolchain automatically: [proto](https://moonrepo
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/etalab-ia/rag-facile/main/install.sh | bash
-source ~/.bashrc  # or restart your terminal
 ```
+
+Then **restart your terminal** (or run the `source` command shown by the installer).
 
 > **Note**: On Ubuntu/Debian, the installer will automatically install prerequisites (git, curl, xz-utils, unzip) if needed.
 


### PR DESCRIPTION
## Summary

- **Move comments outside code blocks** so the copy button only copies runnable commands (zsh chokes on comments pasted as part of multi-line input)
- **Replace hardcoded `source ~/.bashrc`** with shell-agnostic guidance — macOS defaults to zsh (`~/.zshrc`), not bash, so users without a `.bashrc` get an error
- The installer already detects the correct shell profile dynamically, so docs now say "restart your terminal or run the `source` command shown by the installer"

**Files changed**: `README.md`, `CONTRIBUTING.md`, `apps/cli/README.md`, `docs/guides/getting-started.md`

**Not changed** (intentionally): Windows Git Bash references (`docs/guides/windows-setup.md`, `install.sh`) where `.bashrc` is correct, and the Docker Ubuntu testing block in `CONTRIBUTING.md` where bash is the shell.

## Test plan

- [x] Verify README renders correctly on GitHub (code blocks, bold text)
- [x] Copy-paste the install command from the README into zsh — no comment gets copied
- [x] Verify `docs/guides/getting-started.md` renders correctly

👾 Generated with [Letta Code](https://letta.com)