### PR TITLE
feat: add --expert flag to setup command and rename PDF pipeline to Local

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@ rag-facile/
 ### Command Structure
 **Current commands** (alphabetically ordered):
 - `generate-dataset` - Generate synthetic Q/A evaluation datasets
-- `setup <name>` - Setup a new RAG Facile workspace
+- `setup <name> [--expert]` - Setup a new RAG Facile workspace (--expert shows project structure and pipeline options)
 - `version` - Show CLI version
 
 **Key Pattern**: Alphabetical ordering is important - check help output order when adding commands

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ rag-facile --help
 rag-facile setup my-rag-app
 ```
 
-The CLI will guide you through choosing a project structure, a configuration preset, and a frontend. After setup, it installs dependencies and starts the dev server — your app opens in the browser, ready to use.
+The CLI will guide you through choosing a configuration preset and a frontend. After setup, it installs dependencies and starts the dev server — your app opens in the browser, ready to use. Use `--expert` for advanced options like project structure and pipeline selection.
 
 ## Upgrade
 

--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -9,146 +9,124 @@
 
 ---
 
-## 🏗️ Scenario A: Standalone with PDF Retrieval (retrieval-basic)
-*Focus: Testing the "Lambda Developer" path with local PDF extraction.*
+## 🏗️ Scenario A: Standalone with Albert RAG (Default)
+*Focus: Testing the default "Lambda Developer" path — no `--expert` flag needed.*
 
 ### Step 1: Run the Installer
 
 **macOS/Linux:**
 ```bash
-export RAG_FACILE_BRANCH="feat/retrieval-albert"
-curl -sSL "https://raw.githubusercontent.com/etalab-ia/rag-facile/refs/heads/${RAG_FACILE_BRANCH}/install.sh" | bash
+curl -fsSL https://raw.githubusercontent.com/etalab-ia/rag-facile/main/install.sh | bash
 ```
 
 **Windows (PowerShell):**
 ```powershell
-$env:RAG_FACILE_BRANCH = "feat/retrieval-albert"
-irm "https://raw.githubusercontent.com/etalab-ia/rag-facile/refs/heads/$env:RAG_FACILE_BRANCH/install.ps1" | iex
+irm https://raw.githubusercontent.com/etalab-ia/rag-facile/main/install.ps1 | iex
 ```
-
-> **Important**: Use double quotes `"` in the curl URL so the shell expands `${RAG_FACILE_BRANCH}`. Single quotes will prevent variable expansion and cause a 404 error.
 
 ### Step 2: Verify CLI Installation
 ```bash
 rag-facile --version
-# Should output: rag-facile v0.10.1
 ```
 
-### Step 3: Run Setup (Standalone with PDF)
+### Step 3: Run Setup (Default Mode)
 ```bash
 mkdir -p ~/tmp/rf-testing && cd ~/tmp/rf-testing
-rag-facile setup my-pdf-app
+rag-facile setup my-rag-app
 ```
 
 **Interactive Prompts** — Select:
-- **Structure**: "Simple (recommended for getting started)"
 - **Preset**: "balanced"
 - **Frontend**: "Chainlit"
-- **Retrieval module**: "PDF - Local text extraction (offline, simple)"
-- **API Key**: Provide your Albert API key (or dummy value for testing)
+- **API Key**: Provide your Albert API key
 - **Confirm**: "Yes"
 
+> **Note**: No structure or pipeline prompts appear — the default is standalone + Albert RAG.
+
 ### Step 4: Verify Generated Files
-Navigate to `my-pdf-app/` and check:
+Navigate to `my-rag-app/` and check:
 - [ ] `albert/` directory exists
 - [ ] `rag_core/` directory exists
-- [ ] `retrieval_basic/` directory exists
-- [ ] `pyproject.toml` contains: `packages = ["albert", "rag_core", "retrieval_basic"]`
+- [ ] `pipelines/` directory exists
+- [ ] `ingestion/` directory exists
+- [ ] `retrieval/` directory exists
+- [ ] `reranking/` directory exists
+- [ ] `context/` directory exists
+- [ ] `storage/` directory exists
+- [ ] `pyproject.toml` contains all pipeline packages in `packages = [...]`
 - [ ] `.env` file contains `OPENAI_API_KEY` and `OPENAI_BASE_URL`
+- [ ] `ragfacile.toml` exists with `provider = "albert-collections"` in `[storage]`
 - [ ] `.envrc` file exists (direnv configuration)
-- [ ] `modules.yml` contains `pdf: retrieval_basic`
-
-**Enable direnv** (optional but recommended):
-```bash
-direnv allow  # Trust the .envrc file
-```
 
 ### Step 5: Run the App
 ```bash
-cd my-pdf-app
-just sync
+cd my-rag-app
 just run
 ```
 
 **Expected**: Chainlit opens in browser at `http://localhost:8000`
 
-### Step 6: Test PDF Upload
-- [ ] Upload a `.pdf` file — should extract text and include in chat context
-- [ ] Uploading a `.docx` or other non-PDF file — should show "Unsupported file type"
-
----
-
-## 🔬 Scenario B: Standalone with Albert RAG (retrieval-albert)
-*Focus: Testing the Albert API-powered retrieval path with multi-format support.*
-
-### Step 1: Run Setup (Standalone with Albert RAG)
-```bash
-cd ~/tmp/rf-testing
-rag-facile setup my-albert-app
-```
-
-**Interactive Prompts** — Select:
-- **Structure**: "Simple (recommended for getting started)"
-- **Preset**: "balanced"
-- **Frontend**: "Chainlit"
-- **Retrieval module**: "Albert RAG - Server-side parsing, search & reranking"
-- **API Key**: Provide your Albert API key (required for Albert RAG)
-- **Confirm**: "Yes"
-
-### Step 2: Verify Generated Files
-Navigate to `my-albert-app/` and check:
-- [ ] `albert/` directory exists
-- [ ] `rag_core/` directory exists
-- [ ] `retrieval_albert/` directory exists (NOT `retrieval_basic/`)
-- [ ] `pyproject.toml` contains: `packages = ["albert", "rag_core", "retrieval_albert"]`
-- [ ] `.env` file contains `OPENAI_API_KEY` and `OPENAI_BASE_URL`
-- [ ] `modules.yml` contains `pdf: retrieval_albert`
-
-### Step 3: Run the App
-```bash
-cd my-albert-app
-just sync
-just run
-```
-
-**Expected**: Chainlit opens in browser at `http://localhost:8000`
-
-### Step 4: Test Multi-Format File Upload
+### Step 6: Test File Upload
 Albert RAG supports the following formats via Albert's parse API:
 - [ ] Upload a `.pdf` file — should parse via Albert API and include in chat
 - [ ] Upload a `.json` file — should parse and include in chat
 - [ ] Upload a `.md` (Markdown) file — should parse and include in chat
 - [ ] Upload an `.html` file — should parse and include in chat
-- [ ] Upload an unsupported format (e.g., `.docx`, `.xlsx`, `.txt`) — should show "Unsupported file type" or fall back to local extraction
 
 **Note**: If Albert's parse API returns a 500 error (server issue), the app automatically falls back to local pypdf extraction for PDF files.
 
-### Step 5: Verify the Retrieval Module API
-```python
-# In a Python shell within the project
-from retrieval_albert import SUPPORTED_EXTENSIONS, process_file, extract_text
+---
 
-# Check supported extensions
-print(SUPPORTED_EXTENSIONS)
-# Should be: ['.pdf', '.json', '.md', '.html']
+## 🔬 Scenario B: Standalone with Local Pipeline (`--expert`)
+*Focus: Testing the offline Local pipeline path using the `--expert` flag.*
+
+### Step 1: Run Setup (Expert Mode, Local Pipeline)
+```bash
+cd ~/tmp/rf-testing
+rag-facile setup my-local-app --expert
 ```
+
+**Interactive Prompts** — Select:
+- **Structure**: "Simple (recommended for getting started)"
+- **Preset**: "balanced"
+- **Frontend**: "Chainlit"
+- **Pipeline**: "Local - Local text extraction (offline, simple)"
+- **API Key**: Provide your Albert API key (or dummy value for testing)
+- **Confirm**: "Yes"
+
+### Step 2: Verify Generated Files
+Navigate to `my-local-app/` and check:
+- [ ] Same pipeline package directories as Scenario A
+- [ ] `ragfacile.toml` exists with `provider = "local-sqlite"` in `[storage]`
+- [ ] `.env` file contains `OPENAI_API_KEY` and `OPENAI_BASE_URL`
+
+### Step 3: Run the App
+```bash
+cd my-local-app
+just run
+```
+
+**Expected**: Chainlit opens in browser at `http://localhost:8000`
+
+### Step 4: Test PDF Upload
+- [ ] Upload a `.pdf` file — should extract text locally and include in chat context
 
 ---
 
-## 🏢 Scenario C: Monorepo Installation
+## 🏢 Scenario C: Monorepo (`--expert`)
 *Focus: Testing the "Advanced Developer" path with a Moonrepo workspace.*
 
-### Step 1: Run Setup (Monorepo)
+### Step 1: Run Setup (Expert Mode, Monorepo)
 ```bash
 cd ~/tmp/rf-testing
-rag-facile setup rf-monorepo
+rag-facile setup rf-monorepo --expert
 ```
 
 **Interactive Prompts** — Select:
 - **Structure**: "Monorepo (for multi-app projects)"
 - **Preset**: "accurate"
 - **Frontend**: "Reflex"
-- **Retrieval module**: "Albert RAG - Server-side parsing, search & reranking"
+- **Pipeline**: "Albert RAG - Server-side parsing, search & reranking (recommended)"
 - **API Key**: Provide your Albert API key (or dummy value)
 - **Confirm**: "Yes"
 
@@ -160,19 +138,12 @@ cd rf-monorepo
 Check that these directories exist:
 - [ ] `.moon/templates/rag-core/`
 - [ ] `.moon/templates/albert-client/`
-- [ ] `.moon/templates/retrieval-albert/`
+- [ ] `.moon/templates/retrieval/`
 - [ ] `packages/rag-core/src/rag_core/`
 - [ ] `packages/albert-client/src/albert/`
-- [ ] `packages/retrieval-albert/src/retrieval_albert/`
+- [ ] `packages/retrieval/src/retrieval/`
 
-### Step 3: Verify Imports
-Open `apps/reflex-chat/reflex_chat/state.py` and verify:
-```python
-from rag_core import get_config
-from albert import AlbertClient
-```
-
-### Step 4: Enable direnv and Run Workspace Sync
+### Step 3: Enable direnv and Run Workspace Sync
 **Enable direnv** (optional but recommended):
 ```bash
 direnv allow  # Trust the .envrc file
@@ -185,14 +156,14 @@ just sync
 
 **Expected**: Dependencies installed, pre-commit hooks configured, and `.env` automatically loaded by direnv
 
-### Step 5: Run Type Checking
+### Step 4: Run Type Checking
 ```bash
 just type-check
 ```
 
 **Expected**: All checks pass
 
-### Step 6: Run the App
+### Step 5: Run the App
 ```bash
 just run reflex-chat
 ```
@@ -336,36 +307,31 @@ export PATH="$HOME/.local/bin:$PATH"
 Keep track of your testing:
 
 ```markdown
-### Standalone Test — PDF Retrieval (Chainlit)
+### Default Standalone Test — Albert RAG (Chainlit)
 - [ ] Installation successful
 - [ ] rag-facile --version works
-- [ ] Setup shows retrieval module choice (PDF vs Albert RAG)
-- [ ] Setup creates correct directory structure
-- [ ] retrieval_basic/ included when PDF selected
-- [ ] App runs: `just run` starts Chainlit server
-- [ ] PDF upload works
-- [ ] Non-PDF files correctly rejected
-- [ ] Config commands work
-- [ ] modules.yml contains `pdf: retrieval_basic`
-
-### Standalone Test — Albert RAG (Chainlit)
-- [ ] Setup creates correct directory structure
-- [ ] retrieval_albert/ included when Albert RAG selected
+- [ ] Default setup (no --expert) skips structure and pipeline prompts
+- [ ] Setup creates correct directory structure (flat, no apps/ or .moon/)
+- [ ] All pipeline packages present (albert/, rag_core/, pipelines/, etc.)
+- [ ] ragfacile.toml has provider = "albert-collections"
 - [ ] App runs: `just run` starts Chainlit server
 - [ ] PDF upload works (via Albert parse API)
-- [ ] DOCX upload works (multi-format support)
-- [ ] PPTX upload works
-- [ ] modules.yml contains `pdf: retrieval_albert`
+- [ ] Config commands work
 
-### Monorepo Test (Reflex)
-- [ ] Installation successful
+### Expert Standalone Test — Local Pipeline (Chainlit)
+- [ ] `rag-facile setup <name> --expert` shows structure and pipeline prompts
+- [ ] Selecting "Local" pipeline creates correct directory structure
+- [ ] ragfacile.toml has provider = "local-sqlite"
+- [ ] App runs: `just run` starts Chainlit server
+- [ ] PDF upload works (local extraction)
+
+### Expert Monorepo Test (Reflex)
+- [ ] `rag-facile setup <name> --expert` with monorepo selection works
 - [ ] Setup creates monorepo structure
-- [ ] Templates exist for all packages (including retrieval-albert)
+- [ ] Templates exist for all packages
 - [ ] just sync completes without errors
 - [ ] just type-check passes
 - [ ] just run reflex-chat starts dev server
-- [ ] No import errors in state.py
-- [ ] Dataset generation works
 
 ### Quality Checks
 - [ ] No legacy imports found

--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -329,9 +329,12 @@ Keep track of your testing:
 - [ ] `rag-facile setup <name> --expert` with monorepo selection works
 - [ ] Setup creates monorepo structure
 - [ ] Templates exist for all packages
+- [ ] `ragfacile.toml` has provider = "albert-collections"
 - [ ] just sync completes without errors
 - [ ] just type-check passes
-- [ ] just run reflex-chat starts dev server
+- [ ] `just run reflex-chat` starts dev server
+- [ ] File upload works
+- [ ] Config commands work
 
 ### Quality Checks
 - [ ] No legacy imports found

--- a/apps/cli/src/cli/commands/setup.py
+++ b/apps/cli/src/cli/commands/setup.py
@@ -151,7 +151,7 @@ FRONTENDS = {
 
 # Available modules (packages)
 MODULES = {
-    "PDF": {"template": "retrieval", "available": True},
+    "Local": {"template": "retrieval", "available": True},
     "Albert RAG": {"template": "retrieval", "available": True},
 }
 
@@ -166,7 +166,7 @@ PRESET_CONFIGS: dict[str, PresetConfig] = {
     "fast": {
         "description": "Fast responses, lower accuracy",
         "model_alias": "openweight-small",
-        "retrieval_module": "PDF",
+        "retrieval_module": "Local",
         "temperature": 0.7,
         "language": "fr",
         "system_prompt": "Vous êtes un assistant utile et concis.",
@@ -175,7 +175,7 @@ PRESET_CONFIGS: dict[str, PresetConfig] = {
     "balanced": {
         "description": "Balanced speed and accuracy (recommended)",
         "model_alias": "openweight-medium",
-        "retrieval_module": "PDF",
+        "retrieval_module": "Local",
         "temperature": 0.7,
         "language": "fr",
         "system_prompt": "Vous êtes un assistant utile.",
@@ -184,7 +184,7 @@ PRESET_CONFIGS: dict[str, PresetConfig] = {
     "accurate": {
         "description": "Best accuracy, slower responses",
         "model_alias": "openweight-large",
-        "retrieval_module": "PDF",
+        "retrieval_module": "Local",
         "temperature": 0.7,
         "language": "fr",
         "system_prompt": "Vous êtes un assistant expert et précis.",
@@ -193,7 +193,7 @@ PRESET_CONFIGS: dict[str, PresetConfig] = {
     "legal": {
         "description": "Optimized for legal documents",
         "model_alias": "openweight-large",
-        "retrieval_module": "PDF",
+        "retrieval_module": "Local",
         "temperature": 0.3,
         "language": "fr",
         "system_prompt": "Vous êtes un assistant spécialisé dans l'analyse de documents juridiques.",
@@ -202,7 +202,7 @@ PRESET_CONFIGS: dict[str, PresetConfig] = {
     "hr": {
         "description": "Optimized for HR documents",
         "model_alias": "openweight-medium",
-        "retrieval_module": "PDF",
+        "retrieval_module": "Local",
         "temperature": 0.7,
         "language": "fr",
         "system_prompt": "Vous êtes un assistant spécialisé dans les ressources humaines.",
@@ -524,10 +524,10 @@ def generate_standalone(
     console.print("[bold green]Step 2:[/bold green] Generating project files...")
 
     # Create pyproject.toml for standalone mode
-    # pypdf required for both PDF and Albert RAG (albert has local fallback)
+    # pypdf required for both Local and Albert RAG (albert has local fallback)
     pdf_dep = (
         '\n    "pypdf>=5.0.0",'
-        if ("PDF" in selected_modules or "Albert RAG" in selected_modules)
+        if ("Local" in selected_modules or "Albert RAG" in selected_modules)
         else ""
     )
     # Single source of truth for pipeline modules copied into standalone projects.
@@ -650,7 +650,7 @@ package = true
         )
 
     # Step 8: Create ragfacile.toml config file
-    step_num = 8 if "PDF" in selected_modules else 7
+    step_num = 8 if "Local" in selected_modules else 7
     console.print()
     console.print(
         f"[bold green]Step {step_num}:[/bold green] Creating configuration file..."
@@ -668,7 +668,7 @@ package = true
         )
 
     # Step 9: Create .env file
-    step_num = 9 if "PDF" in selected_modules else 8
+    step_num = 9 if "Local" in selected_modules else 8
     console.print()
     console.print(
         f"[bold green]Step {step_num}:[/bold green] Creating environment file..."
@@ -747,6 +747,13 @@ def run(
         bool,
         typer.Option("--force", "-f", help="Overwrite existing files"),
     ] = False,
+    expert: Annotated[
+        bool,
+        typer.Option(
+            "--expert",
+            help="Show advanced options (project structure, pipeline selection)",
+        ),
+    ] = False,
 ):
     """Setup a new RAG Facile workspace with interactive configuration.
 
@@ -783,16 +790,18 @@ def run(
             console.print("[yellow]Aborted.[/yellow]")
             raise typer.Exit(0)
 
-    # Select project structure first
-    structure_choice = questionary.select(
-        "What type of project structure do you want?",
-        choices=list(PROJECT_STRUCTURES.keys()),
-    ).ask()
-    if not structure_choice:
-        console.print("[red]Aborted.[/red]")
-        raise typer.Exit(1)
-
-    is_standalone = PROJECT_STRUCTURES[structure_choice] == "standalone"
+    # Select project structure (only shown with --expert)
+    if expert:
+        structure_choice = questionary.select(
+            "What type of project structure do you want?",
+            choices=list(PROJECT_STRUCTURES.keys()),
+        ).ask()
+        if not structure_choice:
+            console.print("[red]Aborted.[/red]")
+            raise typer.Exit(1)
+        is_standalone = PROJECT_STRUCTURES[structure_choice] == "standalone"
+    else:
+        is_standalone = True
 
     # Select preset
     if not preset:
@@ -828,24 +837,26 @@ def run(
         console.print("[red]Aborted.[/red]")
         raise typer.Exit(1)
 
-    # Select retrieval module — both handle PDF file attachments,
-    # but use different backends (local pypdf vs Albert parse API).
-    module_choice = questionary.select(
-        "Select your retrieval module:",
-        choices=[
-            questionary.Choice(
-                "Albert RAG - Server-side parsing, search & reranking (recommended)",
-                value="Albert RAG",
-            ),
-            questionary.Choice(
-                "PDF - Local text extraction (offline, simple)",
-                value="PDF",
-            ),
-        ],
-    ).ask()
-    if not module_choice:
-        console.print("[red]Aborted.[/red]")
-        raise typer.Exit(1)
+    # Select RAG pipeline (only shown with --expert)
+    if expert:
+        module_choice = questionary.select(
+            "Select your RAG pipeline:",
+            choices=[
+                questionary.Choice(
+                    "Albert RAG - Server-side parsing, search & reranking (recommended)",
+                    value="Albert RAG",
+                ),
+                questionary.Choice(
+                    "Local - Local text extraction (offline, simple)",
+                    value="Local",
+                ),
+            ],
+        ).ask()
+        if not module_choice:
+            console.print("[red]Aborted.[/red]")
+            raise typer.Exit(1)
+    else:
+        module_choice = "Albert RAG"
 
     selected_modules = [module_choice]
 
@@ -882,7 +893,7 @@ def run(
     console.print(f"  Preset: {preset} ({preset_config['description']})")
     console.print(f"  Frontend: {frontend_choice}")
     console.print(f"  Model: {preset_config['model_alias']}")
-    console.print(f"  Retrieval: {module_choice}")
+    console.print(f"  Pipeline: {module_choice}")
     console.print(f"  API: {env_config['openai_base_url']}")
     console.print()
 

--- a/apps/cli/tests/test_setup.py
+++ b/apps/cli/tests/test_setup.py
@@ -106,11 +106,11 @@ class TestConstants:
         assert "Reflex" in FRONTENDS
         assert FRONTENDS["Reflex"] == "reflex-chat"
 
-    def test_modules_has_pdf(self):
-        """Should have PDF module option."""
-        assert "PDF" in MODULES
-        assert MODULES["PDF"]["template"] == "retrieval"
-        assert MODULES["PDF"]["available"] is True
+    def test_modules_has_local(self):
+        """Should have Local module option."""
+        assert "Local" in MODULES
+        assert MODULES["Local"]["template"] == "retrieval"
+        assert MODULES["Local"]["available"] is True
 
     def test_project_structures_has_standalone(self):
         """Should have standalone project structure option."""
@@ -554,7 +554,7 @@ class TestGenerateStandalone:
             target_path=standalone_target,
             target_display=str(standalone_target),
             frontend_choice="Chainlit",
-            selected_modules=["PDF"],
+            selected_modules=["Local"],
             env_config={
                 "openai_api_key": "test-key",
                 "openai_base_url": "https://api.test.com",
@@ -569,17 +569,17 @@ class TestGenerateStandalone:
         assert (retrieval / "__init__.py").exists()
         assert (retrieval / "albert.py").exists()
 
-    def test_pyproject_includes_pypdf_when_pdf_selected(
+    def test_pyproject_includes_pypdf_when_local_selected(
         self, standalone_target, mock_standalone_deps, preset_config
     ):
-        """Should include pypdf dependency when PDF module is selected."""
+        """Should include pypdf dependency when Local module is selected."""
         from cli.commands.setup import generate_standalone
 
         generate_standalone(
             target_path=standalone_target,
             target_display=str(standalone_target),
             frontend_choice="Chainlit",
-            selected_modules=["PDF"],
+            selected_modules=["Local"],
             env_config={
                 "openai_api_key": "test-key",
                 "openai_base_url": "https://api.test.com",
@@ -606,7 +606,7 @@ class TestGenerateStandalone:
             target_path=standalone_target,
             target_display=str(standalone_target),
             frontend_choice="Chainlit",
-            selected_modules=["PDF"],
+            selected_modules=["Local"],
             env_config={
                 "openai_api_key": "test-key",
                 "openai_base_url": "https://api.test.com",
@@ -631,7 +631,7 @@ class TestGenerateStandalone:
             target_path=standalone_target,
             target_display=str(standalone_target),
             frontend_choice="Chainlit",
-            selected_modules=["PDF"],
+            selected_modules=["Local"],
             env_config={
                 "openai_api_key": "test-key",
                 "openai_base_url": "https://api.test.com",
@@ -657,7 +657,7 @@ class TestGenerateStandalone:
             target_path=standalone_target,
             target_display=str(standalone_target),
             frontend_choice="Chainlit",
-            selected_modules=["PDF"],
+            selected_modules=["Local"],
             env_config={
                 "openai_api_key": "test-key",
                 "openai_base_url": "https://api.test.com",
@@ -682,7 +682,7 @@ class TestGenerateStandalone:
             target_path=standalone_target,
             target_display=str(standalone_target),
             frontend_choice="Chainlit",
-            selected_modules=["PDF"],
+            selected_modules=["Local"],
             env_config={
                 "openai_api_key": "test-key",
                 "openai_base_url": "https://api.test.com",
@@ -884,14 +884,14 @@ class TestWorkspaceCommand:
         # Mock shutil.which to pretend moon is installed
         mocker.patch("shutil.which", return_value="/usr/bin/moon")
 
-        # Mock questionary interactions - select monorepo mode
+        # Mock questionary interactions - select monorepo mode (requires --expert)
         mock_q = mocker.patch("cli.commands.setup.questionary")
         # Use side_effect to return different values for different select calls
         mock_q.select.return_value.ask.side_effect = [
             "Monorepo (for multi-app projects)",  # First call: structure selection
             "balanced",  # Second call: preset selection
             "Chainlit",  # Third call: frontend selection
-            "PDF",  # Fourth call: retrieval module selection
+            "Local",  # Fourth call: pipeline selection
         ]
         mock_q.confirm.return_value.ask.return_value = True
         mock_q.text.return_value.ask.return_value = "test-value"
@@ -919,17 +919,17 @@ class TestWorkspaceCommand:
 
     @pytest.fixture
     def mock_generation_standalone(self, mocker, tmp_path):
-        """Mock all external calls for standalone workspace generation."""
+        """Mock all external calls for standalone workspace generation (--expert mode)."""
         # Mock shutil.which to pretend tools are installed
         mocker.patch("shutil.which", return_value="/usr/bin/uv")
 
-        # Mock questionary interactions - select standalone mode
+        # Mock questionary interactions - select standalone mode (requires --expert)
         mock_q = mocker.patch("cli.commands.setup.questionary")
         mock_q.select.return_value.ask.side_effect = [
             "Simple (recommended for getting started)",  # First call: structure selection
             "balanced",  # Second call: preset selection
             "Chainlit",  # Third call: frontend selection
-            "PDF",  # Fourth call: retrieval module selection
+            "Local",  # Fourth call: pipeline selection
         ]
         mock_q.confirm.return_value.ask.return_value = True
         mock_q.text.return_value.ask.return_value = "test-value"
@@ -960,7 +960,7 @@ class TestWorkspaceCommand:
         # Create the app directory structure that moon generate would create
         (target / "apps" / "chainlit-chat").mkdir(parents=True)
 
-        result = runner.invoke(main_app, ["setup", str(target)])
+        result = runner.invoke(main_app, ["setup", str(target), "--expert"])
 
         # Should complete successfully
         assert result.exit_code == 0, f"Failed with: {result.output}"
@@ -971,7 +971,7 @@ class TestWorkspaceCommand:
         target = tmp_path / "new-app"
         assert not target.exists()
 
-        runner.invoke(main_app, ["setup", str(target)])
+        runner.invoke(main_app, ["setup", str(target), "--expert"])
 
         assert target.exists()
 
@@ -979,7 +979,7 @@ class TestWorkspaceCommand:
         """Should run moon init in the target directory."""
         target = tmp_path / "test-app"
 
-        runner.invoke(main_app, ["setup", str(target)])
+        runner.invoke(main_app, ["setup", str(target), "--expert"])
 
         # Check moon init was called
         calls = mock_generation["subprocess_run"].call_args_list
@@ -990,7 +990,7 @@ class TestWorkspaceCommand:
         """Should run moon generate for templates."""
         target = tmp_path / "test-app"
 
-        runner.invoke(main_app, ["setup", str(target)])
+        runner.invoke(main_app, ["setup", str(target), "--expert"])
 
         # Check moon generate was called for sys-config and chainlit-chat
         calls = mock_generation["subprocess_run"].call_args_list
@@ -1003,7 +1003,7 @@ class TestWorkspaceCommand:
         """Should pass --force flag to moon generate."""
         target = tmp_path / "test-app"
 
-        runner.invoke(main_app, ["setup", str(target), "--force"])
+        runner.invoke(main_app, ["setup", str(target), "--force", "--expert"])
 
         calls = mock_generation["subprocess_run"].call_args_list
         force_calls = [c for c in calls if "--force" in c[0][0]]
@@ -1013,7 +1013,7 @@ class TestWorkspaceCommand:
         """Should copy templates to target workspace."""
         target = tmp_path / "test-app"
 
-        runner.invoke(main_app, ["setup", str(target)])
+        runner.invoke(main_app, ["setup", str(target), "--expert"])
 
         # copytree should be called for each template
         assert mock_generation["copytree"].call_count >= 1
@@ -1024,17 +1024,15 @@ class TestStandaloneWorkspaceCommand:
 
     @pytest.fixture
     def mock_standalone_cli(self, mocker, tmp_path):
-        """Mock all external calls for standalone CLI generation."""
+        """Mock all external calls for standalone CLI generation (default mode, no --expert)."""
         # Mock shutil.which to pretend tools are installed
         mocker.patch("shutil.which", return_value="/usr/bin/uv")
 
-        # Mock questionary interactions - select standalone mode
+        # Mock questionary interactions - default mode skips structure and pipeline
         mock_q = mocker.patch("cli.commands.setup.questionary")
         mock_q.select.return_value.ask.side_effect = [
-            "Simple (recommended for getting started)",  # First call: structure selection
-            "balanced",  # Second call: preset selection
-            "Chainlit",  # Third call: frontend selection
-            "PDF",  # Fourth call: retrieval module selection
+            "balanced",  # First call: preset selection
+            "Chainlit",  # Second call: frontend selection
         ]
         mock_q.confirm.return_value.ask.return_value = True
         mock_q.text.return_value.ask.return_value = "test-value"
@@ -1123,10 +1121,10 @@ class TestPathNormalization:
         """Should normalize /private/tmp to /tmp in output."""
         # Create a path that looks like macOS /private/tmp
         mock_q = mocker.patch("cli.commands.setup.questionary")
-        # Need to handle both select calls (structure and frontend)
+        # Default mode: only preset and frontend selects (no structure/pipeline)
         mock_q.select.return_value.ask.side_effect = [
-            "Simple (recommended for getting started)",
-            "Chainlit",
+            "balanced",  # Preset
+            "Chainlit",  # Frontend
         ]
         mock_q.checkbox.return_value.ask.return_value = []
         mock_q.confirm.return_value.ask.return_value = False  # Abort early
@@ -1142,8 +1140,8 @@ class TestPathNormalization:
 class TestStructureSelectionPrompt:
     """Tests for the project structure selection prompt."""
 
-    def test_structure_prompt_appears_before_frontend(self, mocker):
-        """Should ask for structure, then preset, then frontend."""
+    def test_structure_prompt_appears_in_expert_mode(self, mocker):
+        """With --expert, should ask for structure, then preset, then frontend, then pipeline."""
         mock_q = mocker.patch("cli.commands.setup.questionary")
         mock_q.select.return_value.ask.side_effect = [
             "Simple (recommended for getting started)",  # Structure
@@ -1151,9 +1149,9 @@ class TestStructureSelectionPrompt:
             None,  # Frontend - return None to abort
         ]
 
-        runner.invoke(main_app, ["setup", "/tmp/test"])
+        runner.invoke(main_app, ["setup", "/tmp/test", "--expert"])
 
-        # Should have been called three times for select
+        # Should have been called three times before abort
         assert mock_q.select.call_count == 3
 
         # First call should be for structure
@@ -1169,13 +1167,47 @@ class TestStructureSelectionPrompt:
         assert "frontend" in third_call_prompt.lower()
 
     def test_aborts_when_structure_not_selected(self, mocker):
-        """Should abort when user doesn't select a structure."""
+        """Should abort when user doesn't select a structure in expert mode."""
         mock_q = mocker.patch("cli.commands.setup.questionary")
         mock_q.select.return_value.ask.side_effect = [
             None,  # No structure selected
         ]
 
-        result = runner.invoke(main_app, ["setup", "/tmp/test"])
+        result = runner.invoke(main_app, ["setup", "/tmp/test", "--expert"])
 
         assert result.exit_code == 1
         assert "Aborted" in result.output
+
+    def test_default_mode_skips_structure_and_pipeline_prompts(self, mocker):
+        """Without --expert, should only ask for preset and frontend (2 selects)."""
+        mock_q = mocker.patch("cli.commands.setup.questionary")
+        mock_q.select.return_value.ask.side_effect = [
+            "balanced",  # First call: preset selection
+            None,  # Second call: frontend - return None to abort
+        ]
+
+        runner.invoke(main_app, ["setup", "/tmp/test"])
+
+        # Should have been called twice (preset + frontend), no structure or pipeline
+        assert mock_q.select.call_count == 2
+
+        # First call should be for preset (not structure)
+        first_call_prompt = mock_q.select.call_args_list[0][0][0]
+        assert "preset" in first_call_prompt.lower()
+
+    def test_default_mode_defaults_to_standalone_and_albert_rag(self, mocker):
+        """Without --expert, should default to standalone + Albert RAG."""
+        mock_q = mocker.patch("cli.commands.setup.questionary")
+        mock_q.select.return_value.ask.side_effect = [
+            "balanced",  # Preset
+            "Chainlit",  # Frontend
+        ]
+        mock_q.text.return_value.ask.return_value = "test-key"
+        mock_q.confirm.return_value.ask.return_value = False  # Abort at confirmation
+
+        result = runner.invoke(main_app, ["setup", "/tmp/test"])
+
+        # Summary should show Albert RAG as pipeline
+        assert "Albert RAG" in result.output
+        # Summary should show standalone structure
+        assert "Simple (standalone)" in result.output

--- a/apps/cli/tests/test_setup.py
+++ b/apps/cli/tests/test_setup.py
@@ -1210,4 +1210,6 @@ class TestStructureSelectionPrompt:
         # Summary should show Albert RAG as pipeline
         assert "Albert RAG" in result.output
         # Summary should show standalone structure
-        assert "Simple (standalone)" in result.output
+        # Rich adds ANSI codes around parentheses, so check substrings separately
+        assert "Simple" in result.output
+        assert "standalone" in result.output

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -78,15 +78,19 @@ rag-facile setup my-rag-app
 
 The CLI will interactively guide you through:
 
-1. **Project structure** — Simple or Monorepo (see below)
-2. **Configuration preset** — Balanced, Fast, Accurate, Legal, or HR
-3. **Frontend** — Chainlit or Reflex
-4. **Retrieval module** — PDF (local extraction) or Albert RAG (server-side parsing + search)
-5. **Environment** — Your Albert API key (presets handle the rest)
+1. **Configuration preset** — Balanced, Fast, Accurate, Legal, or HR
+2. **Frontend** — Chainlit or Reflex
+3. **Environment** — Your Albert API key (presets handle the rest)
+
+By default, the CLI creates a simple standalone project using the Albert RAG pipeline. For advanced options (project structure, pipeline selection), use `--expert`:
+
+```bash
+rag-facile setup my-rag-app --expert
+```
 
 After configuration, the CLI automatically:
 
-- Creates your workspace with the selected components
+- Creates your project with all pipeline components
 - Writes `ragfacile.toml` based on your chosen preset
 - Creates your `.env` file with your credentials
 - Installs all dependencies with `uv sync`
@@ -94,49 +98,62 @@ After configuration, the CLI automatically:
 
 Your app will open in the browser, ready to use.
 
-## Project Structure Options
-
-### Simple (Recommended for Getting Started)
-
-Best for: **Quick prototypes, single-app deployments, learning RAG Facile**
+## Project Structure
 
 ```
 my-rag-app/
 ├── pyproject.toml          # All dependencies in one place
 ├── .env                    # Your API credentials
-├── app.py                  # Your application code
-├── context_loader.py       # Module loading logic
-├── modules.yml             # Retrieval module configuration
 ├── ragfacile.toml          # RAG pipeline configuration
+├── app.py                  # Your application code
 ├── chainlit.md             # Chat welcome message (Chainlit only)
-└── retrieval_basic/ OR retrieval_albert/   # Selected retrieval module
+├── albert/                 # Albert API client
+├── rag_core/               # Configuration system
+├── pipelines/              # Pipeline orchestration
+├── ingestion/              # Document parsing
+├── retrieval/              # Vector search
+├── reranking/              # Cross-encoder re-scoring
+├── context/                # Context assembly
+└── storage/                # Collection management
 ```
 
-**Advantages:**
+## Running Your App
+
+```bash
+cd my-rag-app
+just run
+```
+
+## Advanced: Project Structures (`--expert`)
+
+With `--expert`, you can choose between a simple standalone project or a monorepo:
+
+### Simple (Default)
+
+Best for: **Quick prototypes, single-app deployments, learning RAG Facile**
+
 - Familiar single-project structure
 - No build tools to learn
 - Easy to understand and modify
-- Simple deployment
 
-### Monorepo (For Multi-App Projects)
+### Monorepo
 
 Best for: **Team projects, multiple apps sharing code, production deployments**
 
 ```
 my-rag-app/
 ├── .moon/              # Moon workspace configuration
-│   ├── templates/      # Templates for adding new apps
-│   ├── toolchain.yml   # Python/uv configuration
-│   └── workspace.yml   # Workspace settings
 ├── apps/
 │   └── chainlit-chat/  # Your selected frontend app
-│       ├── app.py
-│       ├── .env        # Your API credentials
-│       └── ...
 ├── packages/
 │   ├── rag-core/       # Configuration system
 │   ├── albert-client/  # Albert API SDK
-│   └── retrieval/      # Unified retrieval package (basic + albert backends)
+│   ├── retrieval/      # Vector search
+│   ├── reranking/      # Cross-encoder re-scoring
+│   ├── context/        # Context assembly
+│   ├── storage/        # Collection management
+│   ├── ingestion/      # Document parsing
+│   └── pipelines/      # Pipeline orchestration
 ├── ragfacile.toml      # RAG pipeline configuration
 ├── justfile            # Common commands
 └── pyproject.toml      # Workspace root
@@ -152,23 +169,14 @@ my-rag-app/
 
 | Scenario | Recommendation |
 |----------|----------------|
-| First time using RAG Facile | **Simple** |
-| Building a quick prototype | **Simple** |
-| Single application deployment | **Simple** |
-| Multiple related apps | **Monorepo** |
-| Team with shared components | **Monorepo** |
-| Need to add apps later | **Monorepo** |
+| First time using RAG Facile | **Simple** (default) |
+| Building a quick prototype | **Simple** (default) |
+| Single application deployment | **Simple** (default) |
+| Multiple related apps | **Monorepo** (`--expert`) |
+| Team with shared components | **Monorepo** (`--expert`) |
+| Need to add apps later | **Monorepo** (`--expert`) |
 
-## Running Your App
-
-### Simple Structure
-
-```bash
-cd my-rag-app
-just run
-```
-
-### Monorepo Structure
+### Running a Monorepo
 
 ```bash
 cd my-rag-app


### PR DESCRIPTION
## Summary

- **`--expert` flag**: Hides monorepo structure and pipeline selection behind `--expert`. Default setup now asks only 3 questions (preset, frontend, API key) instead of 5, creating a standalone project with Albert RAG pipeline.
- **Rename "PDF" → "Local"**: The legacy "PDF" pipeline option is now called "Local" to better describe the pipeline type (local text extraction vs server-side).
- **Reword question**: "Select your retrieval module" → "Select your RAG pipeline" (with `--expert`)
- **Fix stale docs**: Updated `getting-started.md` file trees (removed `context_loader.py`, `modules.yml`, `retrieval_basic/`), overhauled `TEST_PLAN.md` scenarios, updated `README.md` and `AGENTS.md`.

| Mode | Structure prompt | Pipeline prompt | Defaults to |
|------|-----------------|-----------------|-------------|
| Default | Hidden | Hidden | Standalone + Albert RAG |
| `--expert` | Shown | Shown | User chooses |

## Test plan

- [x] All 80 setup tests pass (4 new tests for `--expert` behavior)
- [x] ruff check + format clean
- [x] ty passes
- [x] Manual test: `rag-facile setup /tmp/test-default` (default mode, 3 prompts only)
- [x] Manual test: `rag-facile setup /tmp/test-expert --expert` (expert mode, all prompts)

👾 Generated with [Letta Code](https://letta.com)