### PR TITLE
fix: bundle context and reranking to correct paths for standalone setup

### DIFF
--- a/apps/cli/pyproject.toml
+++ b/apps/cli/pyproject.toml
@@ -54,11 +54,11 @@ packages = ["src/cli"]
 [tool.hatch.build.targets.wheel.force-include]
 "../../.moon/templates" = "cli/templates"
 "../../packages/albert-client/src/albert" = "cli/albert_src"
-"../../packages/context/src/context" = "cli/templates/context"
+"../../packages/context/src/context" = "cli/context_src"
 "../../packages/ingestion/src/ingestion" = "cli/ingestion_src"
 "../../packages/pipelines/src/pipelines" = "cli/pipelines_src"
 "../../packages/rag-core/src/rag_core" = "cli/rag_core_src"
-"../../packages/reranking/src/reranking" = "cli/templates/reranking"
+"../../packages/reranking/src/reranking" = "cli/reranking_src"
 "../../packages/retrieval/src/retrieval" = "cli/retrieval_src"
 "../../packages/storage/src/storage" = "cli/storage_src"
 "src/cli/templates/ragfacile.toml" = "cli/templates/ragfacile.toml"

--- a/uv.lock
+++ b/uv.lock
@@ -329,7 +329,7 @@ wheels = [
 
 [[package]]
 name = "chainlit-chat"
-version = "0.12.1"
+version = "0.13.0"
 source = { editable = "apps/chainlit-chat" }
 dependencies = [
     { name = "albert-client" },
@@ -405,7 +405,7 @@ wheels = [
 
 [[package]]
 name = "context"
-version = "0.12.1"
+version = "0.13.0"
 source = { editable = "packages/context" }
 dependencies = [
     { name = "rag-core" },
@@ -849,7 +849,7 @@ wheels = [
 
 [[package]]
 name = "ingestion"
-version = "0.12.1"
+version = "0.13.0"
 source = { editable = "packages/ingestion" }
 dependencies = [
     { name = "albert-client" },
@@ -1968,7 +1968,7 @@ wheels = [
 
 [[package]]
 name = "pipelines"
-version = "0.12.1"
+version = "0.13.0"
 source = { editable = "packages/pipelines" }
 dependencies = [
     { name = "context" },
@@ -2379,7 +2379,7 @@ wheels = [
 
 [[package]]
 name = "rag-core"
-version = "0.12.1"
+version = "0.13.0"
 source = { editable = "packages/rag-core" }
 dependencies = [
     { name = "pydantic" },
@@ -2396,7 +2396,7 @@ requires-dist = [
 
 [[package]]
 name = "rag-facile"
-version = "0.12.1"
+version = "0.13.0"
 source = { virtual = "." }
 dependencies = [
     { name = "albert-client" },
@@ -2453,7 +2453,7 @@ dev = [
 
 [[package]]
 name = "rag-facile-cli"
-version = "0.12.1"
+version = "0.13.0"
 source = { editable = "apps/cli" }
 dependencies = [
     { name = "albert-client" },
@@ -2562,7 +2562,7 @@ wheels = [
 
 [[package]]
 name = "reflex-chat"
-version = "0.12.1"
+version = "0.13.0"
 source = { editable = "apps/reflex-chat" }
 dependencies = [
     { name = "albert-client" },
@@ -2614,7 +2614,7 @@ wheels = [
 
 [[package]]
 name = "reranking"
-version = "0.12.1"
+version = "0.13.0"
 source = { editable = "packages/reranking" }
 dependencies = [
     { name = "albert-client" },
@@ -2641,7 +2641,7 @@ wheels = [
 
 [[package]]
 name = "retrieval"
-version = "0.12.1"
+version = "0.13.0"
 source = { editable = "packages/retrieval" }
 dependencies = [
     { name = "albert-client" },
@@ -2832,7 +2832,7 @@ wheels = [
 
 [[package]]
 name = "storage"
-version = "0.12.1"
+version = "0.13.0"
 source = { editable = "packages/storage" }
 dependencies = [
     { name = "albert-client" },


### PR DESCRIPTION
## Summary

- Fixed hatch `force-include` paths for `context` and `reranking` packages in `apps/cli/pyproject.toml`
- Both were bundled to `cli/templates/<name>` instead of `cli/<name>_src`, breaking standalone setup when running from the installed CLI
- `get_context_source()` and `get_reranking_source()` expected `<name>_src` paths (matching all other packages) but couldn't find them, silently skipped the copy, and `uv sync` failed with `error: package directory 'context' does not exist`

## Test plan

- [x] 102/102 CLI tests pass (1 pre-existing known failure: `test_generate_letta_requires_env_vars`)
- [x] `ruff check` + `ruff format` clean
- [x] Manual: install CLI via `uv tool install` → `rag-facile setup` → verify context/reranking dirs are copied

👾 Generated with [Letta Code](https://letta.com)