### PR TITLE
chore: add vscode python interpreter settings for worktree support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-	"python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
+	"python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+	"[windows]": {
+		"python.defaultInterpreterPath": "${workspaceFolder}/.venv/Scripts/python.exe"
+	}
 }


### PR DESCRIPTION
Adds `.vscode/settings.json` with `python.defaultInterpreterPath` set to `${workspaceFolder}/.venv/bin/python`.

This ensures the Python extension auto-detects the correct venv in a bare repo + git worktrees setup, where each worktree has its own `.venv`.

🚀 Generated with [Gemini CLI](https://github.com/google/gemini-cli)