### PR TITLE
feat: move frontend choice behind --expert flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@ rag-facile/
 ### Command Structure
 **Current commands** (alphabetically ordered):
 - `generate-dataset` - Generate synthetic Q/A evaluation datasets
-- `setup <name> [--expert]` - Setup a new RAG Facile workspace (--expert shows project structure and pipeline options)
+- `setup <name> [--expert]` - Setup a new RAG Facile workspace (--expert shows project structure, frontend, and pipeline options)
 - `version` - Show CLI version
 
 **Key Pattern**: Alphabetical ordering is important - check help output order when adding commands

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ rag-facile --help
 rag-facile setup my-rag-app
 ```
 
-The CLI will guide you through choosing a configuration preset and a frontend. After setup, it installs dependencies and starts the dev server — your app opens in the browser, ready to use. Use `--expert` for advanced options like project structure and pipeline selection.
+The CLI will guide you through choosing a configuration preset and your API key. After setup, it installs dependencies and starts the dev server — your app opens in the browser, ready to use. Use `--expert` for advanced options like project structure, frontend, and pipeline selection.
 
 ## Upgrade
 

--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -37,11 +37,10 @@ rag-facile setup my-rag-app
 
 **Interactive Prompts** — Select:
 - **Preset**: "balanced"
-- **Frontend**: "Chainlit"
 - **API Key**: Provide your Albert API key
 - **Confirm**: "Yes"
 
-> **Note**: No structure or pipeline prompts appear — the default is standalone + Albert RAG.
+> **Note**: No structure, frontend, or pipeline prompts appear — the default is standalone + Chainlit + Albert RAG.
 
 ### Step 4: Verify Generated Files
 Navigate to `my-rag-app/` and check:
@@ -89,7 +88,7 @@ rag-facile setup my-local-app --expert
 **Interactive Prompts** — Select:
 - **Structure**: "Simple (recommended for getting started)"
 - **Preset**: "balanced"
-- **Frontend**: "Chainlit"
+- **Frontend**: "Chainlit" (only shown with `--expert`)
 - **Pipeline**: "Local - Local text extraction (offline, simple)"
 - **API Key**: Provide your Albert API key (or dummy value for testing)
 - **Confirm**: "Yes"
@@ -310,7 +309,7 @@ Keep track of your testing:
 ### Default Standalone Test — Albert RAG (Chainlit)
 - [ ] Installation successful
 - [ ] rag-facile --version works
-- [ ] Default setup (no --expert) skips structure and pipeline prompts
+- [ ] Default setup (no --expert) skips structure, frontend, and pipeline prompts
 - [ ] Setup creates correct directory structure (flat, no apps/ or .moon/)
 - [ ] All pipeline packages present (albert/, rag_core/, pipelines/, etc.)
 - [ ] ragfacile.toml has provider = "albert-collections"
@@ -319,7 +318,7 @@ Keep track of your testing:
 - [ ] Config commands work
 
 ### Expert Standalone Test — Local Pipeline (Chainlit)
-- [ ] `rag-facile setup <name> --expert` shows structure and pipeline prompts
+- [ ] `rag-facile setup <name> --expert` shows structure, frontend, and pipeline prompts
 - [ ] Selecting "Local" pipeline creates correct directory structure
 - [ ] ragfacile.toml has provider = "local-sqlite"
 - [ ] App runs: `just run` starts Chainlit server

--- a/apps/cli/src/cli/commands/setup.py
+++ b/apps/cli/src/cli/commands/setup.py
@@ -751,7 +751,7 @@ def run(
         bool,
         typer.Option(
             "--expert",
-            help="Show advanced options (project structure, pipeline selection)",
+            help="Show advanced options (project structure, frontend, pipeline selection)",
         ),
     ] = False,
 ):
@@ -828,14 +828,17 @@ def run(
 
     preset_config = PRESET_CONFIGS[preset]
 
-    # Select frontend
-    frontend_choice = questionary.select(
-        "Select your frontend app:",
-        choices=list(FRONTENDS.keys()),
-    ).ask()
-    if not frontend_choice:
-        console.print("[red]Aborted.[/red]")
-        raise typer.Exit(1)
+    # Select frontend (only shown with --expert)
+    if expert:
+        frontend_choice = questionary.select(
+            "Select your frontend app:",
+            choices=list(FRONTENDS.keys()),
+        ).ask()
+        if not frontend_choice:
+            console.print("[red]Aborted.[/red]")
+            raise typer.Exit(1)
+    else:
+        frontend_choice = "Chainlit"
 
     # Select RAG pipeline (only shown with --expert)
     if expert:

--- a/apps/cli/tests/test_setup.py
+++ b/apps/cli/tests/test_setup.py
@@ -1028,11 +1028,10 @@ class TestStandaloneWorkspaceCommand:
         # Mock shutil.which to pretend tools are installed
         mocker.patch("shutil.which", return_value="/usr/bin/uv")
 
-        # Mock questionary interactions - default mode skips structure and pipeline
+        # Mock questionary interactions - default mode skips structure, frontend, and pipeline
         mock_q = mocker.patch("cli.commands.setup.questionary")
         mock_q.select.return_value.ask.side_effect = [
-            "balanced",  # First call: preset selection
-            "Chainlit",  # Second call: frontend selection
+            "balanced",  # Only call: preset selection
         ]
         mock_q.confirm.return_value.ask.return_value = True
         mock_q.text.return_value.ask.return_value = "test-value"
@@ -1121,10 +1120,9 @@ class TestPathNormalization:
         """Should normalize /private/tmp to /tmp in output."""
         # Create a path that looks like macOS /private/tmp
         mock_q = mocker.patch("cli.commands.setup.questionary")
-        # Default mode: only preset and frontend selects (no structure/pipeline)
+        # Default mode: only preset select (no structure/frontend/pipeline)
         mock_q.select.return_value.ask.side_effect = [
             "balanced",  # Preset
-            "Chainlit",  # Frontend
         ]
         mock_q.checkbox.return_value.ask.return_value = []
         mock_q.confirm.return_value.ask.return_value = False  # Abort early
@@ -1146,13 +1144,14 @@ class TestStructureSelectionPrompt:
         mock_q.select.return_value.ask.side_effect = [
             "Simple (recommended for getting started)",  # Structure
             "balanced",  # Preset
-            None,  # Frontend - return None to abort
+            "Chainlit",  # Frontend
+            None,  # Pipeline - return None to abort
         ]
 
         runner.invoke(main_app, ["setup", "/tmp/test", "--expert"])
 
-        # Should have been called three times before abort
-        assert mock_q.select.call_count == 3
+        # Should have been called four times before abort
+        assert mock_q.select.call_count == 4
 
         # First call should be for structure
         first_call_prompt = mock_q.select.call_args_list[0][0][0]
@@ -1166,6 +1165,10 @@ class TestStructureSelectionPrompt:
         third_call_prompt = mock_q.select.call_args_list[2][0][0]
         assert "frontend" in third_call_prompt.lower()
 
+        # Fourth call should be for pipeline
+        fourth_call_prompt = mock_q.select.call_args_list[3][0][0]
+        assert "pipeline" in fourth_call_prompt.lower()
+
     def test_aborts_when_structure_not_selected(self, mocker):
         """Should abort when user doesn't select a structure in expert mode."""
         mock_q = mocker.patch("cli.commands.setup.questionary")
@@ -1178,29 +1181,29 @@ class TestStructureSelectionPrompt:
         assert result.exit_code == 1
         assert "Aborted" in result.output
 
-    def test_default_mode_skips_structure_and_pipeline_prompts(self, mocker):
-        """Without --expert, should only ask for preset and frontend (2 selects)."""
+    def test_default_mode_skips_structure_frontend_and_pipeline_prompts(self, mocker):
+        """Without --expert, should only ask for preset (1 select)."""
         mock_q = mocker.patch("cli.commands.setup.questionary")
         mock_q.select.return_value.ask.side_effect = [
-            "balanced",  # First call: preset selection
-            None,  # Second call: frontend - return None to abort
+            "balanced",  # Only call: preset selection
         ]
+        mock_q.text.return_value.ask.return_value = "test-key"
+        mock_q.confirm.return_value.ask.return_value = False  # Abort at confirmation
 
         runner.invoke(main_app, ["setup", "/tmp/test"])
 
-        # Should have been called twice (preset + frontend), no structure or pipeline
-        assert mock_q.select.call_count == 2
+        # Should have been called once (preset only), no structure, frontend, or pipeline
+        assert mock_q.select.call_count == 1
 
-        # First call should be for preset (not structure)
+        # Only call should be for preset (not structure or frontend)
         first_call_prompt = mock_q.select.call_args_list[0][0][0]
         assert "preset" in first_call_prompt.lower()
 
-    def test_default_mode_defaults_to_standalone_and_albert_rag(self, mocker):
-        """Without --expert, should default to standalone + Albert RAG."""
+    def test_default_mode_defaults_to_standalone_chainlit_and_albert_rag(self, mocker):
+        """Without --expert, should default to standalone + Chainlit + Albert RAG."""
         mock_q = mocker.patch("cli.commands.setup.questionary")
         mock_q.select.return_value.ask.side_effect = [
-            "balanced",  # Preset
-            "Chainlit",  # Frontend
+            "balanced",  # Only select: Preset
         ]
         mock_q.text.return_value.ask.return_value = "test-key"
         mock_q.confirm.return_value.ask.return_value = False  # Abort at confirmation
@@ -1209,6 +1212,8 @@ class TestStructureSelectionPrompt:
 
         # Summary should show Albert RAG as pipeline
         assert "Albert RAG" in result.output
+        # Summary should show Chainlit as frontend
+        assert "Chainlit" in result.output
         # Summary should show standalone structure
         # Rich adds ANSI codes around parentheses, so check substrings separately
         assert "Simple" in result.output

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -89,10 +89,9 @@ rag-facile setup my-rag-app
 The CLI will interactively guide you through:
 
 1. **Configuration preset** — Balanced, Fast, Accurate, Legal, or HR
-2. **Frontend** — Chainlit or Reflex
-3. **Environment** — Your Albert API key (presets handle the rest)
+2. **Environment** — Your Albert API key (presets handle the rest)
 
-By default, the CLI creates a simple standalone project using the Albert RAG pipeline. For advanced options (project structure, pipeline selection), use `--expert`:
+By default, the CLI creates a simple standalone Chainlit project using the Albert RAG pipeline. For advanced options (project structure, frontend, pipeline selection), use `--expert`:
 
 ```bash
 rag-facile setup my-rag-app --expert

--- a/uv.lock
+++ b/uv.lock
@@ -329,7 +329,7 @@ wheels = [
 
 [[package]]
 name = "chainlit-chat"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "apps/chainlit-chat" }
 dependencies = [
     { name = "albert-client" },
@@ -405,7 +405,7 @@ wheels = [
 
 [[package]]
 name = "context"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "packages/context" }
 dependencies = [
     { name = "rag-core" },
@@ -849,7 +849,7 @@ wheels = [
 
 [[package]]
 name = "ingestion"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "packages/ingestion" }
 dependencies = [
     { name = "albert-client" },
@@ -1968,7 +1968,7 @@ wheels = [
 
 [[package]]
 name = "pipelines"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "packages/pipelines" }
 dependencies = [
     { name = "context" },
@@ -2379,7 +2379,7 @@ wheels = [
 
 [[package]]
 name = "rag-core"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "packages/rag-core" }
 dependencies = [
     { name = "pydantic" },
@@ -2396,7 +2396,7 @@ requires-dist = [
 
 [[package]]
 name = "rag-facile"
-version = "0.13.0"
+version = "0.14.0"
 source = { virtual = "." }
 dependencies = [
     { name = "albert-client" },
@@ -2453,7 +2453,7 @@ dev = [
 
 [[package]]
 name = "rag-facile-cli"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "apps/cli" }
 dependencies = [
     { name = "albert-client" },
@@ -2562,7 +2562,7 @@ wheels = [
 
 [[package]]
 name = "reflex-chat"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "apps/reflex-chat" }
 dependencies = [
     { name = "albert-client" },
@@ -2614,7 +2614,7 @@ wheels = [
 
 [[package]]
 name = "reranking"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "packages/reranking" }
 dependencies = [
     { name = "albert-client" },
@@ -2641,7 +2641,7 @@ wheels = [
 
 [[package]]
 name = "retrieval"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "packages/retrieval" }
 dependencies = [
     { name = "albert-client" },
@@ -2832,7 +2832,7 @@ wheels = [
 
 [[package]]
 name = "storage"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "packages/storage" }
 dependencies = [
     { name = "albert-client" },


### PR DESCRIPTION
## Summary

- Moves the Chainlit/Reflex frontend selection behind the `--expert` flag in `rag-facile setup`
- Default mode now defaults to **Chainlit** and only asks 2 questions (preset + API key) instead of 3
- `--expert` mode shows all 4 options: project structure → preset → frontend → pipeline

## Changes

- **`setup.py`**: Wrapped frontend `questionary.select` in `if expert:` block, defaults to Chainlit
- **`test_setup.py`**: Updated 6 tests for new prompt flow (mock side_effects, call counts, assertions)
- **Docs**: Updated README, getting-started.md, TEST_PLAN.md, AGENTS.md to reflect new defaults

## Test plan

- [x] All 80 setup tests pass (`uv run python -m pytest apps/cli/tests/test_setup.py`)
- [x] Full CLI suite: 134/135 pass (1 pre-existing failure: `test_generate_letta_requires_env_vars`)
- [x] `ruff check` + `ruff format` clean
- [x] Manual: `rag-facile setup /tmp/test-default` — should only ask preset + API key
- [x] Manual: `rag-facile setup /tmp/test-expert --expert` — should ask structure + preset + frontend + pipeline + API key

👾 Generated with [Letta Code](https://letta.com)