### PR TITLE
feat: add CI smoke test — scaffold, build and launch Chainlit app

### DIFF
--- a/.github/workflows/check-install.yml
+++ b/.github/workflows/check-install.yml
@@ -57,7 +57,7 @@ jobs:
   
   linux-install:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     name: "Install on Linux (Ubuntu)"
     
     env:
@@ -124,7 +124,7 @@ jobs:
   
   macos-install-arm64:
     runs-on: macos-14
-    timeout-minutes: 15
+    timeout-minutes: 10
     name: "Install on macOS (Apple Silicon)"
     
     env:
@@ -279,7 +279,7 @@ jobs:
   
   test-summary:
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 1
     name: "Installation Tests Summary"
     needs: [linux-install, macos-install-arm64, windows-install-powershell, windows-install-gitbash]
     if: always()

--- a/.github/workflows/check-install.yml
+++ b/.github/workflows/check-install.yml
@@ -57,6 +57,7 @@ jobs:
   
   linux-install:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     name: "Install on Linux (Ubuntu)"
     
     env:
@@ -86,9 +87,44 @@ jobs:
         run: |
           echo "=== Testing just recipes ==="
           just --list
+      
+      - name: Smoke test — setup, build and launch app
+        shell: bash
+        env:
+          OPENAI_API_KEY: "test-key-for-ci"
+          OPENAI_BASE_URL: "https://albert.api.etalab.gouv.fr/v1"
+        run: |
+          echo "=== Smoke test: scaffold → build → launch → health check ==="
+          
+          # 1. Scaffold a standalone Chainlit app (non-interactive)
+          rag-facile setup /tmp/test-app --preset balanced --yes --no-serve --force
+          
+          # 2. Start Chainlit server in background
+          cd /tmp/test-app
+          uv run chainlit run app.py --host 0.0.0.0 --port 8000 &
+          SERVER_PID=$!
+          
+          # 3. Wait for server to respond (max 60s, poll every 2s)
+          for i in $(seq 1 30); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8000 2>/dev/null || echo "000")
+            if [ "$STATUS" = "200" ]; then
+              echo "✅ Server responded with HTTP 200 after ~$((i * 2)) seconds"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "❌ Server did not respond within 60 seconds (last status: $STATUS)"
+              kill $SERVER_PID 2>/dev/null || true
+              exit 1
+            fi
+            sleep 2
+          done
+          
+          # 4. Cleanup
+          kill $SERVER_PID 2>/dev/null || true
   
   macos-install-arm64:
     runs-on: macos-14
+    timeout-minutes: 15
     name: "Install on macOS (Apple Silicon)"
     
     env:
@@ -124,9 +160,45 @@ jobs:
         run: |
           echo "=== Testing just recipes ==="
           just --list
+      
+      - name: Smoke test — setup, build and launch app
+        shell: bash
+        env:
+          OPENAI_API_KEY: "test-key-for-ci"
+          OPENAI_BASE_URL: "https://albert.api.etalab.gouv.fr/v1"
+          PYTHONUTF8: "1"
+        run: |
+          echo "=== Smoke test: scaffold → build → launch → health check ==="
+          
+          # 1. Scaffold a standalone Chainlit app (non-interactive)
+          rag-facile setup /tmp/test-app --preset balanced --yes --no-serve --force
+          
+          # 2. Start Chainlit server in background
+          cd /tmp/test-app
+          uv run chainlit run app.py --host 0.0.0.0 --port 8000 &
+          SERVER_PID=$!
+          
+          # 3. Wait for server to respond (max 60s, poll every 2s)
+          for i in $(seq 1 30); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8000 2>/dev/null || echo "000")
+            if [ "$STATUS" = "200" ]; then
+              echo "✅ Server responded with HTTP 200 after ~$((i * 2)) seconds"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "❌ Server did not respond within 60 seconds (last status: $STATUS)"
+              kill $SERVER_PID 2>/dev/null || true
+              exit 1
+            fi
+            sleep 2
+          done
+          
+          # 4. Cleanup
+          kill $SERVER_PID 2>/dev/null || true
   
   windows-install-powershell:
     runs-on: windows-latest
+    timeout-minutes: 10
     name: "Install on Windows (PowerShell)"
     
     env:
@@ -170,6 +242,7 @@ jobs:
   
   windows-install-gitbash:
     runs-on: windows-latest
+    timeout-minutes: 10
     name: "Install on Windows (Git Bash)"
     
     env:
@@ -206,6 +279,7 @@ jobs:
   
   test-summary:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     name: "Installation Tests Summary"
     needs: [linux-install, macos-install-arm64, windows-install-powershell, windows-install-gitbash]
     if: always()

--- a/apps/cli/src/cli/commands/generate_dataset.py
+++ b/apps/cli/src/cli/commands/generate_dataset.py
@@ -35,30 +35,6 @@ def run(
             resolve_path=True,
         ),
     ],
-    output: Annotated[
-        Path,
-        typer.Option(
-            "--output",
-            "-o",
-            help="Output JSONL file path",
-        ),
-    ] = Path("golden_dataset.jsonl"),
-    samples: Annotated[
-        int | None,
-        typer.Option(
-            "--samples",
-            "-n",
-            help="Target number of Q/A pairs to generate (default: from config)",
-        ),
-    ] = None,
-    provider: Annotated[
-        str,
-        typer.Option(
-            "--provider",
-            "-p",
-            help="Data Foundry provider to use (letta or albert, default: from config)",
-        ),
-    ] = "",
     agent_id: Annotated[
         str,
         typer.Option(
@@ -74,6 +50,30 @@ def run(
             help="Enable debug logging (verbose output to file and console)",
         ),
     ] = False,
+    output: Annotated[
+        Path,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Output JSONL file path",
+        ),
+    ] = Path("golden_dataset.jsonl"),
+    provider: Annotated[
+        str,
+        typer.Option(
+            "--provider",
+            "-p",
+            help="Data Foundry provider to use (letta or albert, default: from config)",
+        ),
+    ] = "",
+    samples: Annotated[
+        int | None,
+        typer.Option(
+            "--samples",
+            "-n",
+            help="Target number of Q/A pairs to generate (default: from config)",
+        ),
+    ] = None,
 ) -> None:
     """Generate synthetic Q/A evaluation dataset from documents.
 

--- a/apps/cli/src/cli/commands/setup.py
+++ b/apps/cli/src/cli/commands/setup.py
@@ -421,6 +421,13 @@ def render_template_file(template_path: Path, variables: dict[str, str | bool]) 
     return content
 
 
+def _print_no_serve_message(target_display: str) -> None:
+    """Print app location and skip dev server message."""
+    console.print()
+    console.print(f"[dim]Your app is at: {target_display}[/dim]")
+    console.print("[dim]Run the dev server manually when ready.[/dim]")
+
+
 def generate_config_file(
     workspace_root: Path,
     preset: str,
@@ -493,7 +500,6 @@ def generate_standalone(
     env_config: dict[str, str],
     preset: str,
     preset_config: PresetConfig,
-    force: bool,
     no_serve: bool = False,
 ) -> None:
     """Generate a standalone (non-monorepo) project structure."""
@@ -706,9 +712,7 @@ OPENAI_BASE_URL={env_config["openai_base_url"]}
 
     # Step 7: Start the dev server (unless --no-serve)
     if no_serve:
-        console.print()
-        console.print(f"[dim]Your app is at: {target_display}[/dim]")
-        console.print("[dim]Run the dev server manually when ready.[/dim]")
+        _print_no_serve_message(target_display)
         return
 
     step_num += 1
@@ -948,7 +952,6 @@ def run(
             env_config=env_config,
             preset=preset,
             preset_config=preset_config,
-            force=force,
             no_serve=no_serve,
         )
         return  # Exit after standalone generation
@@ -1190,9 +1193,7 @@ OPENAI_BASE_URL={env_config["openai_base_url"]}
 
     # Start the dev server (unless --no-serve)
     if no_serve:
-        console.print()
-        console.print(f"[dim]Your app is at: {target_display}[/dim]")
-        console.print("[dim]Run the dev server manually when ready.[/dim]")
+        _print_no_serve_message(target_display)
         return
 
     console.print()

--- a/apps/cli/src/cli/commands/setup.py
+++ b/apps/cli/src/cli/commands/setup.py
@@ -494,6 +494,7 @@ def generate_standalone(
     preset: str,
     preset_config: PresetConfig,
     force: bool,
+    no_serve: bool = False,
 ) -> None:
     """Generate a standalone (non-monorepo) project structure."""
     templates_dir = get_templates_dir()
@@ -703,7 +704,13 @@ OPENAI_BASE_URL={env_config["openai_base_url"]}
     if not run_command(["uv", "sync"], "install dependencies", cwd=target_path):
         console.print("[yellow]Warning: uv sync failed. Run it manually.[/yellow]")
 
-    # Step 7: Start the dev server
+    # Step 7: Start the dev server (unless --no-serve)
+    if no_serve:
+        console.print()
+        console.print(f"[dim]Your app is at: {target_display}[/dim]")
+        console.print("[dim]Run the dev server manually when ready.[/dim]")
+        return
+
     step_num += 1
     console.print()
     console.print(
@@ -754,6 +761,21 @@ def run(
             help="Show advanced options (project structure, frontend, pipeline selection)",
         ),
     ] = False,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Skip all prompts (use defaults and env vars for API key)",
+        ),
+    ] = False,
+    no_serve: Annotated[
+        bool,
+        typer.Option(
+            "--no-serve",
+            help="Skip launching the dev server after setup",
+        ),
+    ] = False,
 ):
     """Setup a new RAG Facile workspace with interactive configuration.
 
@@ -766,8 +788,11 @@ def run(
     if not ensure_toolchain():
         raise typer.Exit(1)
 
-    # 1. Gather inputs interactively
+    # 1. Gather inputs interactively (or use defaults with --yes)
     if not target:
+        if yes:
+            console.print("[red]Error: target directory is required with --yes[/red]")
+            raise typer.Exit(1)
         target = questionary.text(
             "Target directory:",
             default="./my-rag-app",
@@ -781,7 +806,7 @@ def run(
     target_display = str(target_path).replace("/private/tmp/", "/tmp/")
 
     # Check if target exists and has content
-    if target_path.exists() and any(target_path.iterdir()) and not force:
+    if target_path.exists() and any(target_path.iterdir()) and not force and not yes:
         overwrite = questionary.confirm(
             f"Directory {target_path} is not empty. Continue anyway?",
             default=False,
@@ -805,20 +830,23 @@ def run(
 
     # Select preset
     if not preset:
-        preset = questionary.select(
-            "Choose a configuration preset:",
-            choices=[
-                questionary.Choice(
-                    f"{name} - {config['description']}",
-                    value=name,
-                )
-                for name, config in PRESET_CONFIGS.items()
-            ],
-            default="balanced",
-        ).ask()
-        if not preset:
-            console.print("[red]Aborted.[/red]")
-            raise typer.Exit(1)
+        if yes:
+            preset = "balanced"
+        else:
+            preset = questionary.select(
+                "Choose a configuration preset:",
+                choices=[
+                    questionary.Choice(
+                        f"{name} - {config['description']}",
+                        value=name,
+                    )
+                    for name, config in PRESET_CONFIGS.items()
+                ],
+                default="balanced",
+            ).ask()
+            if not preset:
+                console.print("[red]Aborted.[/red]")
+                raise typer.Exit(1)
 
     # Validate preset if provided via flag
     if preset not in PRESET_CONFIGS:
@@ -864,25 +892,29 @@ def run(
     selected_modules = [module_choice]
 
     # Prompt for environment configuration (use current env as defaults)
-    console.print()
-    console.print("[bold blue]Environment Configuration[/bold blue]")
-    console.print(
-        "[dim]These values will be saved to .env in your app directory.[/dim]"
-    )
-    console.print(
-        "[dim]Get an API key at https://albert.sites.beta.gouv.fr/access/[/dim]"
-    )
-    console.print()
-
     env_config = {}
 
-    env_config["openai_api_key"] = questionary.text(
-        "OpenAI/Albert API Key:",
-        default=os.getenv("OPENAI_API_KEY", ""),
-    ).ask()
-    if env_config["openai_api_key"] is None:
-        console.print("[red]Aborted.[/red]")
-        raise typer.Exit(1)
+    if yes:
+        # Non-interactive: use env var or empty string
+        env_config["openai_api_key"] = os.getenv("OPENAI_API_KEY", "")
+    else:
+        console.print()
+        console.print("[bold blue]Environment Configuration[/bold blue]")
+        console.print(
+            "[dim]These values will be saved to .env in your app directory.[/dim]"
+        )
+        console.print(
+            "[dim]Get an API key at https://albert.sites.beta.gouv.fr/access/[/dim]"
+        )
+        console.print()
+
+        env_config["openai_api_key"] = questionary.text(
+            "OpenAI/Albert API Key:",
+            default=os.getenv("OPENAI_API_KEY", ""),
+        ).ask()
+        if env_config["openai_api_key"] is None:
+            console.print("[red]Aborted.[/red]")
+            raise typer.Exit(1)
 
     # Use base URL from preset
     env_config["openai_base_url"] = preset_config["openai_base_url"]
@@ -900,10 +932,11 @@ def run(
     console.print(f"  API: {env_config['openai_base_url']}")
     console.print()
 
-    # Confirm
-    if not questionary.confirm("Proceed with generation?", default=True).ask():
-        console.print("[yellow]Aborted.[/yellow]")
-        raise typer.Exit(0)
+    # Confirm (skip with --yes)
+    if not yes:
+        if not questionary.confirm("Proceed with generation?", default=True).ask():
+            console.print("[yellow]Aborted.[/yellow]")
+            raise typer.Exit(0)
 
     # Branch based on project structure choice
     if is_standalone:
@@ -916,6 +949,7 @@ def run(
             preset=preset,
             preset_config=preset_config,
             force=force,
+            no_serve=no_serve,
         )
         return  # Exit after standalone generation
 
@@ -1154,7 +1188,13 @@ OPENAI_BASE_URL={env_config["openai_base_url"]}
     if not run_command(["uv", "sync"], "install dependencies", cwd=target_path):
         console.print("[yellow]Warning: uv sync failed. Run it manually.[/yellow]")
 
-    # Start the dev server
+    # Start the dev server (unless --no-serve)
+    if no_serve:
+        console.print()
+        console.print(f"[dim]Your app is at: {target_display}[/dim]")
+        console.print("[dim]Run the dev server manually when ready.[/dim]")
+        return
+
     console.print()
     console.print(
         f"[bold green]Step 10:[/bold green] Starting {frontend_choice} dev server..."

--- a/apps/cli/src/cli/commands/setup.py
+++ b/apps/cli/src/cli/commands/setup.py
@@ -746,14 +746,6 @@ def run(
         str,
         typer.Argument(help="Target directory for the new workspace"),
     ] = "",
-    preset: Annotated[
-        str | None,
-        typer.Option(help="Configuration preset (fast, balanced, accurate, legal, hr)"),
-    ] = None,
-    force: Annotated[
-        bool,
-        typer.Option("--force", "-f", help="Overwrite existing files"),
-    ] = False,
     expert: Annotated[
         bool,
         typer.Option(
@@ -761,19 +753,27 @@ def run(
             help="Show advanced options (project structure, frontend, pipeline selection)",
         ),
     ] = False,
-    yes: Annotated[
+    force: Annotated[
         bool,
-        typer.Option(
-            "--yes",
-            "-y",
-            help="Skip all prompts (use defaults and env vars for API key)",
-        ),
+        typer.Option("--force", "-f", help="Overwrite existing files"),
     ] = False,
     no_serve: Annotated[
         bool,
         typer.Option(
             "--no-serve",
             help="Skip launching the dev server after setup",
+        ),
+    ] = False,
+    preset: Annotated[
+        str | None,
+        typer.Option(help="Configuration preset (fast, balanced, accurate, legal, hr)"),
+    ] = None,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Skip all prompts (use defaults and env vars for API key)",
         ),
     ] = False,
 ):

--- a/apps/cli/src/cli/commands/uninstall.py
+++ b/apps/cli/src/cli/commands/uninstall.py
@@ -182,12 +182,12 @@ def _clean_windows_path() -> bool:
 
 
 def run(
-    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
     all_tools: bool = typer.Option(
         False,
         "--all",
         help="Also remove the toolchain (proto, moon, uv, just, direnv)",
     ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
 ) -> None:
     """Remove the RAG Facile CLI.
 

--- a/apps/cli/tests/test_setup.py
+++ b/apps/cli/tests/test_setup.py
@@ -411,7 +411,6 @@ class TestGenerateStandalone:
             },
             preset="balanced",
             preset_config=preset_config,
-            force=False,
         )
 
         assert standalone_target.exists()
@@ -433,7 +432,6 @@ class TestGenerateStandalone:
             },
             preset="balanced",
             preset_config=preset_config,
-            force=False,
         )
 
         pyproject = standalone_target / "pyproject.toml"
@@ -460,7 +458,6 @@ class TestGenerateStandalone:
             },
             preset="balanced",
             preset_config=preset_config,
-            force=False,
         )
 
         assert (standalone_target / "app.py").exists()
@@ -484,7 +481,6 @@ class TestGenerateStandalone:
             },
             preset="balanced",
             preset_config=preset_config,
-            force=False,
         )
 
         env_file = standalone_target / ".env"
@@ -512,7 +508,6 @@ class TestGenerateStandalone:
             },
             preset="balanced",
             preset_config=preset_config,
-            force=False,
         )
 
         pipelines = standalone_target / "pipelines"
@@ -537,7 +532,6 @@ class TestGenerateStandalone:
             },
             preset="balanced",
             preset_config=preset_config,
-            force=False,
         )
 
         python_version = standalone_target / ".python-version"
@@ -561,7 +555,6 @@ class TestGenerateStandalone:
             },
             preset="balanced",
             preset_config=preset_config,
-            force=False,
         )
 
         retrieval = standalone_target / "retrieval"
@@ -586,7 +579,6 @@ class TestGenerateStandalone:
             },
             preset="balanced",
             preset_config=preset_config,
-            force=False,
         )
 
         pyproject = standalone_target / "pyproject.toml"
@@ -613,7 +605,6 @@ class TestGenerateStandalone:
             },
             preset="balanced",
             preset_config=preset_config,
-            force=False,
         )
 
         ingestion = standalone_target / "ingestion"
@@ -638,7 +629,6 @@ class TestGenerateStandalone:
             },
             preset="balanced",
             preset_config=preset_config,
-            force=False,
         )
 
         storage = standalone_target / "storage"
@@ -664,7 +654,6 @@ class TestGenerateStandalone:
             },
             preset="balanced",
             preset_config=preset_config,
-            force=False,
         )
 
         context = standalone_target / "context"
@@ -689,7 +678,6 @@ class TestGenerateStandalone:
             },
             preset="balanced",
             preset_config=preset_config,
-            force=False,
         )
 
         reranking = standalone_target / "reranking"
@@ -714,7 +702,6 @@ class TestGenerateStandalone:
             },
             preset="balanced",
             preset_config=preset_config,
-            force=False,
         )
 
         assert (standalone_target / "chainlit.md").exists()
@@ -736,7 +723,6 @@ class TestGenerateStandalone:
             },
             preset="balanced",
             preset_config=preset_config,
-            force=False,
         )
 
         # Check run_command was called with uv sync
@@ -761,7 +747,6 @@ class TestGenerateStandalone:
             },
             preset="balanced",
             preset_config=preset_config,
-            force=False,
         )
 
         # Check subprocess.run was called with chainlit command
@@ -804,7 +789,6 @@ class TestGenerateStandaloneReflex:
             },
             preset="balanced",
             preset_config=preset_config,
-            force=False,
         )
 
         pyproject = standalone_target / "pyproject.toml"
@@ -830,7 +814,6 @@ class TestGenerateStandaloneReflex:
             },
             preset="balanced",
             preset_config=preset_config,
-            force=False,
         )
 
         assert (standalone_target / "rxconfig.py").exists()
@@ -852,7 +835,6 @@ class TestGenerateStandaloneReflex:
             },
             preset="balanced",
             preset_config=preset_config,
-            force=False,
         )
 
         calls = mock_standalone_deps["subprocess"].call_args_list


### PR DESCRIPTION
## Summary

- Add `--yes` and `--no-serve` flags to `rag-facile setup` for non-interactive CI usage
- Add smoke test step to Linux and macOS install checks: scaffolds a standalone Chainlit app, installs deps, launches the server, and verifies HTTP 200 on port 8000 within 60s
- Add `timeout-minutes` to all check-install workflow jobs (15min Linux/macOS, 10min Windows, 2min summary) to prevent runaway builds

## Test plan

- [x] Run Check Install workflow manually — verify smoke test passes on Linux and macOS
- [x] Verify Windows jobs still pass (no smoke test added there)
- [x] Verify `rag-facile setup --help` shows new `--yes` and `--no-serve` flags
- [x] Verify interactive setup still works normally (no flags = same UX as before)

👾 Generated with [Letta Code](https://letta.com)