### PR TITLE
fix: remove JSON file type from Albert ingestion provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,7 +209,8 @@ marimo/_static/
 marimo/_lsp/
 
 # Chainlit
-.chainlit/
+.chainlit/*
+!.chainlit/config.toml
 .files/
 
 # Templates (generated dynamically)

--- a/.moon/templates/chainlit-chat/app.py
+++ b/.moon/templates/chainlit-chat/app.py
@@ -6,7 +6,7 @@ import chainlit as cl
 import engineio
 import engineio.payload
 from chainlit.input_widget import Switch
-from pipelines import process_file, process_query
+from pipelines import get_accepted_mime_types, process_file, process_query
 from dotenv import load_dotenv
 
 from albert import AsyncAlbertClient
@@ -135,8 +135,18 @@ async def main(message: cl.Message):
 
     # Handle attachments — ingest into Albert collection for RAG retrieval
     if message.elements:
+        allowed_extensions = {
+            ext for exts in get_accepted_mime_types().values() for ext in exts
+        }
         for element in message.elements:
             if element.path:
+                suffix = os.path.splitext(element.name)[1].lower()
+                if suffix not in allowed_extensions:
+                    await cl.Message(
+                        content=f"Unsupported file type '{suffix}'. "
+                        f"Accepted formats: {', '.join(sorted(allowed_extensions))}"
+                    ).send()
+                    continue
                 try:
                     status = process_file(element.path, element.name)
                     await cl.Message(content=status).send()

--- a/.moon/templates/ingestion/src/ingestion/albert.py
+++ b/.moon/templates/ingestion/src/ingestion/albert.py
@@ -1,7 +1,7 @@
 """Albert API document ingestion provider.
 
 Uses Albert's server-side parse API for high-quality document parsing
-with OCR support. Supports PDF, Markdown, HTML, and JSON files.
+with OCR support. Supports PDF, Markdown, and HTML files.
 Falls back to local pypdf for PDF files when the API returns a server error.
 """
 
@@ -40,13 +40,12 @@ class AlbertProvider(IngestionProvider):
 
     @property
     def supported_extensions(self) -> list[str]:
-        return [".pdf", ".json", ".md", ".html"]
+        return [".pdf", ".md", ".html"]
 
     @property
     def accepted_mime_types(self) -> dict[str, list[str]]:
         return {
             "application/pdf": [".pdf"],
-            "application/json": [".json"],
             "text/markdown": [".md"],
             "text/html": [".html", ".htm"],
         }

--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -68,7 +68,6 @@ just run
 ### Step 6: Test File Upload
 Albert RAG supports the following formats via Albert's parse API:
 - [ ] Upload a `.pdf` file — should parse via Albert API and include in chat
-- [ ] Upload a `.json` file — should parse and include in chat
 - [ ] Upload a `.md` (Markdown) file — should parse and include in chat
 - [ ] Upload an `.html` file — should parse and include in chat
 

--- a/apps/chainlit-chat/.chainlit/config.toml
+++ b/apps/chainlit-chat/.chainlit/config.toml
@@ -1,0 +1,172 @@
+[project]
+# List of environment variables to be provided by each user to use the app.
+user_env = []
+
+# Duration (in seconds) during which the session is saved when the connection is lost
+session_timeout = 3600
+
+# Duration (in seconds) of the user session expiry
+user_session_timeout = 1296000  # 15 days
+
+# Enable third parties caching (e.g., LangChain cache)
+cache = false
+
+# Whether to persist user environment variables (API keys) to the database
+# Set to true to store user env vars in DB, false to exclude them for security
+persist_user_env = false
+
+# Whether to mask user environment variables (API keys) in the UI with password type
+# Set to true to show API keys as ***, false to show them as plain text
+mask_user_env = false
+
+# Authorized origins
+allow_origins = ["*"]
+
+[features]
+# Process and display HTML in messages. This can be a security risk (see https://stackoverflow.com/questions/19603097/why-is-it-dangerous-to-render-user-generated-html-or-javascript)
+unsafe_allow_html = false
+
+# Process and display mathematical expressions. This can clash with "$" characters in messages.
+latex = false
+
+# Autoscroll new user messages at the top of the window
+user_message_autoscroll = true
+
+# Autoscroll new assistant messages
+assistant_message_autoscroll = true
+
+# Automatically tag threads with the current chat profile (if a chat profile is used)
+auto_tag_thread = true
+
+# Allow users to edit their own messages
+edit_message = true
+
+# Allow users to share threads (backend + UI). Requires an app-defined on_shared_thread_view callback.
+allow_thread_sharing = false
+
+# Enable favorite messages
+favorites = false
+
+[features.slack]
+# Add emoji reaction when message is received (requires reactions:write OAuth scope)
+reaction_on_message_received = false
+
+# Authorize users to spontaneously upload files with messages
+[features.spontaneous_file_upload]
+    enabled = true
+    # Define accepted file types using MIME types
+    # Examples:
+    # 1. For specific file types:
+    #    accept = ["image/jpeg", "image/png", "application/pdf"]
+    # 2. For all files of certain type:
+    #    accept = ["image/*", "audio/*", "video/*"]
+    # 3. For specific file extensions:
+    #    accept = { "application/octet-stream" = [".xyz", ".pdb"] }
+    # Restrict to formats supported by the Albert parse API
+    accept = ["application/pdf", "text/markdown", "text/html"]
+    max_files = 20
+    max_size_mb = 500
+
+[features.audio]
+    # Enable audio features
+    enabled = false
+    # Sample rate of the audio
+    sample_rate = 24000
+
+[features.mcp]
+    # Enable Model Context Protocol (MCP) features
+    enabled = false
+
+[features.mcp.sse]
+    enabled = true
+
+[features.mcp.streamable-http]
+    enabled = true
+
+[features.mcp.stdio]
+    enabled = true
+    # Only the executables in the allow list can be used for MCP stdio server.
+    # Only need the base name of the executable, e.g. "npx", not "/usr/bin/npx".
+    # Please don't comment this line for now, we need it to parse the executable name.
+    allowed_executables = [ "npx", "uvx" ]
+
+[UI]
+# Name of the assistant.
+name = "Assistant"
+
+# default_theme = "dark"
+
+# Force a specific language for all users (e.g., "en-US", "he-IL", "fr-FR")
+# If not set, the browser's language will be used
+# language = "en-US"
+
+# layout = "wide"
+
+# default_sidebar_state = "open"
+
+# Chat settings display location: "message_composer" (default) or "sidebar" (header)
+# chat_settings_location = "message_composer"
+
+# Default state of chat settings sidebar when location is "sidebar"
+# default_chat_settings_open = false
+
+# Whether to prompt user confirmation on clicking 'New Chat'
+confirm_new_chat = true
+
+# Description of the assistant. This is used for HTML tags.
+# description = ""
+
+# Chain of Thought (CoT) display mode. Can be "hidden", "tool_call" or "full".
+cot = "full"
+
+# Specify a CSS file that can be used to customize the user interface.
+# The CSS file can be served from the public directory or via an external link.
+# custom_css = "/public/test.css"
+
+# Specify additional attributes for a custom CSS file
+# custom_css_attributes = "media=\"print\""
+
+# Specify a JavaScript file that can be used to customize the user interface.
+# The JavaScript file can be served from the public directory.
+# custom_js = "/public/test.js"
+
+# The style of alert boxes. Can be "classic" or "modern".
+alert_style = "classic"
+
+# Specify additional attributes for custom JS file
+# custom_js_attributes = "async type = \"module\""
+
+# Custom login page image, relative to public directory or external URL
+# login_page_image = "/public/custom-background.jpg"
+
+# Custom login page image filter (Tailwind internal filters, no dark/light variants)
+# login_page_image_filter = "brightness-50 grayscale"
+# login_page_image_dark_filter = "contrast-200 blur-sm"
+
+# Specify a custom meta URL (used for meta tags like og:url)
+# custom_meta_url = "https://github.com/Chainlit/chainlit"
+
+# Specify a custom meta image url.
+# custom_meta_image_url = "https://chainlit-cloud.s3.eu-west-3.amazonaws.com/logo/chainlit_banner.png"
+
+# Load assistant logo directly from URL.
+logo_file_url = ""
+
+# Load assistant avatar image directly from URL.
+default_avatar_file_url = ""
+
+# Specify a custom build directory for the frontend.
+# This can be used to customize the frontend code.
+# Be careful: If this is a relative path, it should not start with a slash.
+# custom_build = "./public/build"
+
+# Specify optional one or more custom links in the header.
+# [[UI.header_links]]
+#     name = "Issues"
+#     display_name = "Report Issue"
+#     icon_url = "https://avatars.githubusercontent.com/u/128686189?s=200&v=4"
+#     url = "https://github.com/Chainlit/chainlit/issues"
+#     target = "_blank" (default)  # Optional: "_self", "_parent", "_top".
+
+[meta]
+generated_by = "2.9.6"

--- a/apps/chainlit-chat/app.py
+++ b/apps/chainlit-chat/app.py
@@ -6,7 +6,7 @@ import chainlit as cl
 import engineio
 import engineio.payload
 from chainlit.input_widget import Switch
-from pipelines import process_file, process_query
+from pipelines import get_accepted_mime_types, process_file, process_query
 from dotenv import load_dotenv
 
 from albert import AsyncAlbertClient
@@ -135,8 +135,18 @@ async def main(message: cl.Message):
 
     # Handle attachments — ingest into Albert collection for RAG retrieval
     if message.elements:
+        allowed_extensions = {
+            ext for exts in get_accepted_mime_types().values() for ext in exts
+        }
         for element in message.elements:
             if element.path:
+                suffix = os.path.splitext(element.name)[1].lower()
+                if suffix not in allowed_extensions:
+                    await cl.Message(
+                        content=f"Unsupported file type '{suffix}'. "
+                        f"Accepted formats: {', '.join(sorted(allowed_extensions))}"
+                    ).send()
+                    continue
                 try:
                     status = process_file(element.path, element.name)
                     await cl.Message(content=status).send()

--- a/docs/reference/components.md
+++ b/docs/reference/components.md
@@ -107,7 +107,7 @@ No code changes or reinstallation needed!
 | Feature | Basic (`local-sqlite`) | Albert (`albert-collections`) |
 |---------|----------------------|-------------------------------|
 | **Extraction** | Local pypdf | Albert API + fallback |
-| **Formats** | PDF only | PDF, JSON, MD, HTML |
+| **Formats** | PDF only | PDF, MD, HTML |
 | **Search** | None (context injection) | Semantic + Hybrid + Reranking |
 | **Persistence** | None (per-session) | Collections (persistent) |
 | **Network** | Offline | Requires API access |

--- a/packages/ingestion/src/ingestion/albert.py
+++ b/packages/ingestion/src/ingestion/albert.py
@@ -1,7 +1,7 @@
 """Albert API document ingestion provider.
 
 Uses Albert's server-side parse API for high-quality document parsing
-with OCR support. Supports PDF, Markdown, HTML, and JSON files.
+with OCR support. Supports PDF, Markdown, and HTML files.
 Falls back to local pypdf for PDF files when the API returns a server error.
 """
 
@@ -40,13 +40,12 @@ class AlbertProvider(IngestionProvider):
 
     @property
     def supported_extensions(self) -> list[str]:
-        return [".pdf", ".json", ".md", ".html"]
+        return [".pdf", ".md", ".html"]
 
     @property
     def accepted_mime_types(self) -> dict[str, list[str]]:
         return {
             "application/pdf": [".pdf"],
-            "application/json": [".json"],
             "text/markdown": [".md"],
             "text/html": [".html", ".htm"],
         }

--- a/packages/pipelines/tests/test_pipelines.py
+++ b/packages/pipelines/tests/test_pipelines.py
@@ -296,13 +296,14 @@ class TestAlbertPipeline:
         self, mock_get_ingestion, mock_get_storage
     ):
         """supported_extensions should come from the Albert ingestion provider."""
+        expected_extensions = [".pdf", ".md", ".html"]
         mock_provider = MagicMock()
-        mock_provider.supported_extensions = [".pdf", ".md", ".html"]
+        mock_provider.supported_extensions = expected_extensions
         mock_get_ingestion.return_value = mock_provider
         mock_get_storage.return_value = MagicMock()
 
         pipeline = AlbertPipeline()
-        assert pipeline.supported_extensions == [".pdf", ".md", ".html"]
+        assert pipeline.supported_extensions == expected_extensions
 
     @patch("storage.get_provider")
     @patch("ingestion.get_provider")

--- a/packages/pipelines/tests/test_pipelines.py
+++ b/packages/pipelines/tests/test_pipelines.py
@@ -297,12 +297,12 @@ class TestAlbertPipeline:
     ):
         """supported_extensions should come from the Albert ingestion provider."""
         mock_provider = MagicMock()
-        mock_provider.supported_extensions = [".pdf", ".json", ".md", ".html"]
+        mock_provider.supported_extensions = [".pdf", ".md", ".html"]
         mock_get_ingestion.return_value = mock_provider
         mock_get_storage.return_value = MagicMock()
 
         pipeline = AlbertPipeline()
-        assert pipeline.supported_extensions == [".pdf", ".json", ".md", ".html"]
+        assert pipeline.supported_extensions == [".pdf", ".md", ".html"]
 
     @patch("storage.get_provider")
     @patch("ingestion.get_provider")


### PR DESCRIPTION
## Summary

- Remove `.json` from Albert ingestion provider's `supported_extensions` and `accepted_mime_types` — Albert API no longer supports this file type
- Update pipeline test mock data to match
- Update `docs/reference/components.md` formats table and `TEST_PLAN.md` upload checklist

## Test plan

- [x] `ruff check` + `ruff format` pass
- [x] Ingestion tests pass (12/12)
- [x] Pipeline `test_supported_extensions_from_ingestion` passes with updated extensions
- [x] Verify `.json` uploads are rejected by the chat apps

👾 Generated with [Letta Code](https://letta.com)