### PR TITLE
fix: ignore Chainlit translation files in nested paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,8 +209,8 @@ marimo/_static/
 marimo/_lsp/
 
 # Chainlit
-.chainlit/*
-!.chainlit/config.toml
+**/.chainlit/**
+!**/.chainlit/config.toml
 .files/
 
 # Templates (generated dynamically)


### PR DESCRIPTION
## Summary
- Fixed `.gitignore` pattern for Chainlit runtime files: `.chainlit/*` → `**/.chainlit/**`
- The old `*` pattern didn't match subdirectories (like `translations/`), and lacked `**/` prefix so it only matched at repo root — not under `apps/chainlit-chat/`
- `config.toml` remains tracked via the negation pattern

## Test plan
- [x] `git check-ignore` confirms `translations/*.json` is now ignored
- [x] `git check-ignore` confirms `config.toml` is still **not** ignored
- [x] Run `chainlit run` — verify translations regenerate and don't show in `git status`

👾 Generated with [Letta Code](https://letta.com)