### PR TITLE
docs: update CONTRIBUTING, AGENTS, TEST_PLAN for rag_facile namespace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,9 +46,9 @@ rag-facile/
 │   ├── cli/                       # rag-facile CLI tool
 │   ├── chainlit-chat/             # Chainlit chat UI (golden master)
 │   └── reflex-chat/               # Reflex chat UI (golden master)
-├── packages/                      # Shared packages (rag_facile.* namespace)
+├── packages/                      # Shared packages
 │   ├── rag-core/                  # Core config + schema (rag_facile.core)
-│   ├── albert-client/             # Albert API SDK
+│   ├── albert-client/             # Albert API SDK (uses `albert` namespace, not rag_facile.*)
 │   ├── ingestion/                 # Document parsing (rag_facile.ingestion)
 │   ├── pipelines/                 # Pipeline orchestration (rag_facile.pipelines)
 │   ├── retrieval/                 # Vector search (rag_facile.retrieval)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,22 +44,29 @@ This document contains essential knowledge for coding agents working on RAG Faci
 rag-facile/
 ├── apps/                          # Applications
 │   ├── cli/                       # rag-facile CLI tool
-│   ├── chainlit-chat/             # Chainlit chat UI
-│   ├── reflex-chat/               # Reflex chat UI
-│   ├── admin/                     # Admin interface
-│   └── ingestion/                 # Document ingestion
-├── packages/                      # Shared packages
-│   └── pdf-context/               # PDF extraction utilities
+│   ├── chainlit-chat/             # Chainlit chat UI (golden master)
+│   └── reflex-chat/               # Reflex chat UI (golden master)
+├── packages/                      # Shared packages (rag_facile.* namespace)
+│   ├── rag-core/                  # Core config + schema (rag_facile.core)
+│   ├── albert-client/             # Albert API SDK
+│   ├── ingestion/                 # Document parsing (rag_facile.ingestion)
+│   ├── pipelines/                 # Pipeline orchestration (rag_facile.pipelines)
+│   ├── retrieval/                 # Vector search (rag_facile.retrieval)
+│   ├── reranking/                 # Cross-encoder re-scoring (rag_facile.reranking)
+│   ├── context/                   # Context formatting (rag_facile.context)
+│   ├── storage/                   # Collection management (rag_facile.storage)
+│   └── rag-facile-lib/            # Library bundle for external projects
 ├── .moon/                         # Moon workspace config
 │   ├── templates/                 # App/package templates (Tera syntax)
 │   ├── toolchain.yml              # Python/tool versions
 │   └── workspace.yml              # Workspace definition
 ├── docs/                          # User documentation
-│   ├── guides/                    # How-to guides (proxy-setup.md, etc.)
-│   ├── troubleshooting/           # Problem-solving guides
-│   └── technical/                 # Technical deep-dives
+│   ├── guides/                    # How-to guides (getting-started, proxy, etc.)
+│   ├── reference/                 # Reference docs (ragfacile.toml, components)
+│   └── troubleshooting/           # Problem-solving guides
 ├── pyproject.toml                 # Root workspace config
-├── install.sh                     # Installation script
+├── install.sh                     # Installation script (macOS/Linux)
+├── install.ps1                    # Installation script (Windows)
 └── README.md                      # Main project documentation
 ```
 
@@ -132,8 +139,8 @@ rag-facile/
 - **Framework**: Typer (FastAPI creator's CLI framework)
 - **Files**:
   - `main.py` - Root app definition
-  - `commands/` - Command implementations
-  - `providers/` - Pluggable provider implementations (Letta, Albert, etc.)
+  - `commands/` - Command implementations (`setup.py`, `generate_dataset.py`, `version.py`, `config/`, `collections/`)
+  - `commands/eval/providers/` - Pluggable dataset generation providers (Letta, Albert)
 
 ### Important Patterns
 
@@ -171,10 +178,10 @@ app = typer.Typer(
 
 ### Providers Pattern
 
-Pluggable provider architecture for data sources (Letta Cloud, Albert API, etc.):
+Pluggable provider architecture for dataset generation (Letta Cloud, Albert API, etc.):
 
-```python
-# apps/cli/src/cli/commands/eval/providers/
+```
+apps/cli/src/cli/commands/eval/providers/
 ├── __init__.py              # Factory for provider selection
 ├── letta.py                 # Letta Cloud provider
 ├── albert.py                # Albert API provider
@@ -217,13 +224,12 @@ Pluggable provider architecture for data sources (Letta Cloud, Albert API, etc.)
 
 ## 5. Project Patterns & Gotchas
 
-### Monorepo Package Setup
+### Adding a New Package to the Monorepo
 
-When adding a new app/package:
-1. Create `apps/myapp/` or `packages/mypkg/`
-2. Include `pyproject.toml` with version
-3. Add `# x-release-please-version` comment after version
-4. Add to root `pyproject.toml`:
+When adding a new package to the monorepo (`packages/mypkg/`):
+1. Create `packages/mypkg/` with `pyproject.toml` and source under `packages/mypkg/src/rag_facile/mypkg/`
+2. Add `# x-release-please-version` comment after version in pyproject.toml
+3. Add to root `pyproject.toml`:
    ```toml
    [project]
    dependencies = ["my-package"]
@@ -231,7 +237,8 @@ When adding a new app/package:
    [tool.uv.sources]
    my-package = { workspace = true }
    ```
-5. Add `pyproject.toml` path to `release-please-config.json` → `extra-files`
+4. Add `pyproject.toml` path to `release-please-config.json` → `extra-files`
+5. If the package is a pipeline phase, add it to `packages/rag-facile-lib/pyproject.toml` dependencies
 
 ### Template Generation
 
@@ -258,65 +265,30 @@ When adding a new app/package:
 
 ## 6. Recent Work & Features (Feb 2026)
 
-### Issue #46: Proxy Support (✅ Completed Feb 6, 2026)
-- **Problem**: Proto plugin installation fails on networks with proxies/VPNs
-- **Root Cause**: Proto's reqwest doesn't auto-detect HTTP_PROXY env vars
-- **Solution**: Enhanced install.sh with automatic proxy detection + .prototools generation
-- **Implementation**:
-  - `setup_proxy_config()` function detects and configures proxy
-  - Creates `~/.proto/.prototools` with proxy settings
-  - Detects corporate proxies (SSL inspection) and provides guidance
-  - Improved error messages with troubleshooting steps
-- **Documentation**: 
-  - `docs/guides/proxy-setup.md` - User guide for corporate networks
-  - `docs/troubleshooting/proxy.md` - Symptom-based troubleshooting
-  - `docs/technical/` - Research and investigation details
+### Library Package + rag_facile Namespace (✅ PR #121, Feb 17, 2026)
+- **What changed**: All 7 pipeline packages now live under `rag_facile.*` namespace
+- **Packages**: `rag_facile.core`, `rag_facile.ingestion`, `rag_facile.pipelines`, `rag_facile.retrieval`, `rag_facile.reranking`, `rag_facile.context`, `rag_facile.storage`
+- **New bundle**: `packages/rag-facile-lib/` bundles all pipeline packages for external projects
+- **Generated projects** now depend on `rag-facile-lib` via git URL (no more copying pipeline source)
+- **Standalone** structure: `pyproject.toml` + frontend app + `src/<name>/` for user code
+- **Monorepo** setup: inlines workspace config directly (no sys-config template)
+- **Import style**: `from rag_facile.pipelines import get_pipeline` (not `from pipelines import ...`)
 
-### CLI Refactoring (✅ Completed Feb 5, 2026)
-- **From**: `rag-facile eval generate`
-- **To**: `rag-facile generate-dataset` (alphabetical ordering)
-- **Also**: `generate workspace` → `setup` (simpler, clearer intent)
-- **Current order**: `generate-dataset`, `setup`, `version`
+### True RAG Pipeline (✅ PR #96, Feb 16, 2026)
+- **What changed**: Replaced context-stuffing with real RAG (auto-managed Albert collections)
+- **Flow**: `process_file()` → create collection → upload (Albert chunks + embeds) → `process_query()` → search → rerank → format context → inject into user message
+- **Key pattern**: Context injected per-turn into user message, not accumulated as system messages
+
+### Expert Flag + Default Flow (✅ PR #107/113, Feb 17, 2026)
+- **Default setup** (no `--expert`): 2 prompts only (preset + API key), defaults to standalone + Chainlit + Albert RAG
+- **Expert setup** (`--expert`): Shows all 5 prompts (structure, preset, frontend, pipeline, API key)
+- **Pipeline names**: "Albert RAG" (server-side, recommended) and "Local" (offline, simple)
 
 ### Data Foundry / Eval Features
 - **Command**: `rag-facile generate-dataset ./docs -o output.jsonl`
 - **Purpose**: Generate synthetic Q/A evaluation datasets from documents
-- **Providers**:
-  - Letta Cloud (built-in, uses pre-configured agent)
-  - Albert API (OpenGateLLM) - alternative provider
-- **Implementation**:
-  - `apps/cli/src/cli/commands/eval/providers/`
-  - Provider pattern allows easy addition of new data sources
-  - Both providers: upload documents → retrieve context → generate samples
-
-### Albert API Provider Integration
-- **Feature**: Alternative to Letta Cloud for eval data generation
-- **Configuration**: Via env vars (OPENAI_API_KEY, OPENAI_BASE_URL, OPENAI_MODEL)
-- **Implementation**: `providers/albert.py` (211 lines, fully tested)
-- **Architecture**: Implements `DataFoundryProvider` protocol (same as Letta)
-
-### PDF Extraction & Preprocessing
-- **Feature**: Auto-extract PDFs to markdown before upload
-- **Benefit**: 90% size reduction (0.39 MB → 38.28 KB real-world)
-- **Why**: Eliminates timeout issues with large files
-- **Implementation**: `DocumentPreprocessor` class in `providers/document_preprocessor.py`
-- **Used by**: Both Letta and Albert providers
-
-### Prompt Hardening
-- **Issue**: LLMs generating partial output, extraneous text
-- **Solution**: Strict, repeated prompts with visual warnings
-  - Added "⚠️ AUTOMATED CONVERSATION" warning
-  - Added "🔴 CRITICAL OUTPUT FORMAT" section
-  - Explicit "DO NOT" statements about extraneous text
-  - Final reinforcement: "NOW OUTPUT ONLY THE JSONL - NO PREAMBLE"
-- **Result**: Reliable JSONL-only output from both providers
-
-### Debug Output & Logging
-- **Flag**: `--debug` enables verbose console logging
-- **Default**: INFO-level logs only to file (clean console output)
-- **With --debug**: DEBUG-level logs to both file and console
-- **Log location**: Adjacent to output file (e.g., `output.jsonl.log`)
-- **Critical for**: Albert API debugging (no UI like Letta Cloud)
+- **Providers**: Letta Cloud (default) or Albert API
+- **Implementation**: `apps/cli/src/cli/commands/eval/providers/`
 
 ## 7. Code Quality Standards
 
@@ -356,9 +328,10 @@ python -m pytest apps/cli/tests/
 - Check for missing type hints in new code
 - May need to configure `[tool.ty.rules]` for false positives
 
-### "Import not found" (from workspace packages)
-- Ensure package listed in root `pyproject.toml` dependencies
-- Ensure mapping in `[tool.uv.sources]`
+### "Import not found" (from workspace packages or rag_facile namespace)
+- All pipeline packages use the `rag_facile.*` namespace (e.g., `from rag_facile.pipelines import get_pipeline`)
+- In the monorepo: ensure the package is listed in root `pyproject.toml` dependencies + `[tool.uv.sources]`
+- In generated projects: ensure `rag-facile-lib` is in dependencies and `uv sync` has run
 - Run `uv sync` to regenerate lockfile
 
 ### "Moon command failed"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ rag-facile/
 │   └── reflex-chat/         # Reflex frontend (golden master)
 ├── packages/                # Shared packages
 │   ├── rag-core/            # Core config + schema (rag_facile.core)
-│   ├── albert-client/       # Albert API SDK
+│   ├── albert-client/       # Albert API SDK (uses `albert` namespace, not rag_facile.*)
 │   ├── ingestion/           # Document parsing (rag_facile.ingestion)
 │   ├── pipelines/           # Pipeline orchestration (rag_facile.pipelines)
 │   ├── retrieval/           # Vector search (rag_facile.retrieval)
@@ -124,6 +124,9 @@ RAG Facile uses a **phase-based pipeline** under the `rag_facile.*` namespace. E
 | `packages/context/` | `rag_facile.context` | Format retrieved chunks → LLM context |
 | `packages/pipelines/` | `rag_facile.pipelines` | Orchestrates all phases |
 | `packages/rag-facile-lib/` | — | Bundles all the above for external projects |
+| `packages/albert-client/` | `albert` | Low-level Albert API SDK — **not** under `rag_facile.*` |
+
+> **Note**: `albert-client` is versioned independently (tracks the Albert API OpenAPI spec) and is intentionally kept outside the `rag_facile.*` namespace so it can be used standalone.
 
 **Pipeline selection** is driven by `storage.provider` in `ragfacile.toml`:
 ```toml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,9 +74,15 @@ rag-facile/
 │   ├── chainlit-chat/       # Chainlit frontend (golden master)
 │   └── reflex-chat/         # Reflex frontend (golden master)
 ├── packages/                # Shared packages
-│   ├── rag-core/            # RAG Configuration System
+│   ├── rag-core/            # Core config + schema (rag_facile.core)
 │   ├── albert-client/       # Albert API SDK
-│   └── retrieval/           # Unified retrieval package (basic + albert backends)
+│   ├── ingestion/           # Document parsing (rag_facile.ingestion)
+│   ├── pipelines/           # Pipeline orchestration (rag_facile.pipelines)
+│   ├── retrieval/           # Vector search (rag_facile.retrieval)
+│   ├── reranking/           # Cross-encoder re-scoring (rag_facile.reranking)
+│   ├── context/             # Context formatting (rag_facile.context)
+│   ├── storage/             # Collection management (rag_facile.storage)
+│   └── rag-facile-lib/      # Library bundle (all pipeline packages)
 ├── docs/                    # User and contributor documentation
 │   ├── guides/              # Getting started, setup, pipelines
 │   ├── reference/           # Components, config, ragfacile.toml
@@ -102,44 +108,52 @@ Templates live in `.moon/templates/` and are automatically bundled into the CLI 
 moon run cli:test
 ```
 
-### Understanding Retrieval System
+### Understanding the Pipeline Architecture
 
-RAG Facile uses a **unified retrieval package** (`packages/retrieval/`) with two backends that are selected at runtime via `ragfacile.toml`:
+RAG Facile uses a **phase-based pipeline** under the `rag_facile.*` namespace. Each RAG pipeline phase is its own package, and `rag_facile.pipelines` orchestrates them all.
 
-- **basic** — Local PDF extraction via pypdf (lightweight, offline)
-- **albert** — Full RAG via Albert API (ingestion, search, reranking)
+**Package → namespace mapping:**
 
-Backend selection is automatic based on `storage.provider` config:
+| Package | Import namespace | Responsibility |
+|---------|-----------------|----------------|
+| `packages/rag-core/` | `rag_facile.core` | Config schema, presets, `RAGConfig` |
+| `packages/ingestion/` | `rag_facile.ingestion` | Document parsing (local pypdf or Albert API) |
+| `packages/storage/` | `rag_facile.storage` | Collection management (Albert API) |
+| `packages/retrieval/` | `rag_facile.retrieval` | Vector search |
+| `packages/reranking/` | `rag_facile.reranking` | Cross-encoder re-scoring |
+| `packages/context/` | `rag_facile.context` | Format retrieved chunks → LLM context |
+| `packages/pipelines/` | `rag_facile.pipelines` | Orchestrates all phases |
+| `packages/rag-facile-lib/` | — | Bundles all the above for external projects |
+
+**Pipeline selection** is driven by `storage.provider` in `ragfacile.toml`:
 ```toml
 [storage]
-provider = "albert-collections"  # Uses Albert RAG
-# provider = "local-sqlite"      # Uses basic context injection
+provider = "albert-collections"  # Full Albert RAG (default)
+# provider = "local-sqlite"      # Local text extraction (offline)
 ```
 
-Both backends implement the same interface through the factory pattern:
+**Chat apps** import from the `rag_facile.pipelines` namespace:
 ```python
-from retrieval import get_provider
-provider = get_provider()  # Returns basic or albert based on config
-context = provider.process_file("document.pdf")
+from rag_facile.pipelines import get_pipeline
+
+pipeline = get_pipeline(config)
+await pipeline.process_file(file_bytes, mime_type)
+response = await pipeline.process_query(message_history)
 ```
 
-The `context_loader.py` in each app dynamically loads the retrieval package, which then internally selects the right backend based on configuration.
+There is no `context_loader.py` or `modules.yml` — the pipeline factory handles backend selection automatically based on config.
 
 **Key files:**
-- `packages/retrieval/src/retrieval/` — Unified retrieval package
-  - `__init__.py` — Factory pattern for backend selection
-  - `basic.py` — Basic context injection provider
-  - `albert.py` — Albert RAG retrieval
-  - `parser.py` — Document parsing (Albert backend)
-  - `ingestion.py` — Collection management (Albert backend)
-  - `formatter.py` — Context formatting (Albert backend)
-- `packages/rag-core/src/rag_core/pdf.py` — Shared PDF extraction utilities
+- `packages/pipelines/src/rag_facile/pipelines/` — Pipeline orchestration
+  - `__init__.py` — `get_pipeline(config)` factory
+  - `albert.py` — `AlbertPipeline`: ingestion → storage → retrieval → reranking → context
+  - `basic.py` — `BasicPipeline`: local text extraction only
+- `packages/rag-core/src/rag_facile/core/schema.py` — All config Pydantic models
 
-When modifying retrieval logic:
-- Test both backends (see `packages/retrieval/tests/`)
-- Backend switching happens at runtime - no code changes needed
-- `rag-core/pdf.py` provides shared PDF utilities used by both backends
-- The `modules.yml` file determines which module is active (auto-generated from templates)
+When modifying pipeline logic:
+- Changes to orchestration belong in `packages/pipelines/`
+- Each phase package is self-contained (no inter-phase imports)
+- Only `packages/pipelines/` depends on all phase packages
 
 ### Testing the Generate Dataset Command
 
@@ -311,9 +325,9 @@ All checks must pass before merging.
 
 ## Configuration-Driven Architecture
 
-RAG Facile uses a configuration-driven architecture. Most components (apps, packages) do not have hardcoded RAG parameters. Instead, they consume the `RAGConfig` Pydantic model from `packages/core-config`.
+RAG Facile uses a configuration-driven architecture. Most components (apps, packages) do not have hardcoded RAG parameters. Instead, they consume the `RAGConfig` Pydantic model from `packages/rag-core`.
 
 When adding new features that require configuration:
-1. Define the schema in `packages/core-config/src/config/schema.py`.
-2. Update presets in `packages/core-config/presets/` if applicable.
-3. Access the configuration in your code using `rag_config.get_config()`.
+1. Define the schema in `packages/rag-core/src/rag_facile/core/schema.py`.
+2. Update presets in `packages/rag-core/presets/` if applicable.
+3. Access the configuration in your code using `from rag_facile.core import get_config`.

--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -44,18 +44,15 @@ rag-facile setup my-rag-app
 
 ### Step 4: Verify Generated Files
 Navigate to `my-rag-app/` and check:
-- [ ] `albert/` directory exists
-- [ ] `rag_core/` directory exists
-- [ ] `pipelines/` directory exists
-- [ ] `ingestion/` directory exists
-- [ ] `retrieval/` directory exists
-- [ ] `reranking/` directory exists
-- [ ] `context/` directory exists
-- [ ] `storage/` directory exists
-- [ ] `pyproject.toml` contains all pipeline packages in `packages = [...]`
+- [ ] `pyproject.toml` exists and contains `rag-facile-lib` as a dependency (via git URL)
+- [ ] `app.py` exists (Chainlit entry point)
+- [ ] `src/my_rag_app/__init__.py` exists (user's module directory)
 - [ ] `.env` file contains `OPENAI_API_KEY` and `OPENAI_BASE_URL`
 - [ ] `ragfacile.toml` exists with `provider = "albert-collections"` in `[storage]`
 - [ ] `.envrc` file exists (direnv configuration)
+- [ ] `justfile` exists
+
+> **Note**: Pipeline packages (`rag_facile.pipelines`, `rag_facile.retrieval`, etc.) are installed as a library dependency (`rag-facile-lib`) via `uv sync`, not copied as source directories.
 
 ### Step 5: Run the App
 ```bash
@@ -94,7 +91,7 @@ rag-facile setup my-local-app --expert
 
 ### Step 2: Verify Generated Files
 Navigate to `my-local-app/` and check:
-- [ ] Same pipeline package directories as Scenario A
+- [ ] Same structure as Scenario A (`pyproject.toml` with `rag-facile-lib`, `app.py`, `src/`)
 - [ ] `ragfacile.toml` exists with `provider = "local-sqlite"` in `[storage]`
 - [ ] `.env` file contains `OPENAI_API_KEY` and `OPENAI_BASE_URL`
 
@@ -133,13 +130,13 @@ rag-facile setup rf-monorepo --expert
 cd rf-monorepo
 ```
 
-Check that these directories exist:
-- [ ] `.moon/templates/rag-core/`
-- [ ] `.moon/templates/albert-client/`
-- [ ] `.moon/templates/retrieval/`
-- [ ] `packages/rag-core/src/rag_core/`
-- [ ] `packages/albert-client/src/albert/`
-- [ ] `packages/retrieval/src/retrieval/`
+Check that these directories/files exist:
+- [ ] `.moon/toolchain.yml` and `.moon/workspace.yml` (workspace config)
+- [ ] `.moon/templates/reflex-chat/` (frontend template only — pipeline packages come from `rag-facile-lib`)
+- [ ] `apps/reflex-chat/` (generated app)
+- [ ] `apps/reflex-chat/pyproject.toml` contains `rag-facile-lib` as a dependency
+- [ ] `pyproject.toml` at workspace root
+- [ ] `justfile` at workspace root
 
 ### Step 3: Enable direnv and Run Workspace Sync
 **Enable direnv** (optional but recommended):
@@ -216,17 +213,18 @@ ls -lh dataset.jsonl
 ## ✅ Final Quality Checklist
 
 ### Code Quality
-- [ ] No `import config` statements (except in old archive comments)
-- [ ] No `import full_context` statements
-- [ ] No `from config.` statements
-- [ ] No `from full_context.` statements
+Pipeline packages use the `rag_facile.*` namespace. Verify no old non-namespaced imports exist in apps or generated templates:
+- [ ] No `from retrieval import` statements (use `from rag_facile.retrieval import`)
+- [ ] No `from pipelines import` statements (use `from rag_facile.pipelines import`)
+- [ ] No `from ingestion import` statements (use `from rag_facile.ingestion import`)
+- [ ] No `from rag_core import` statements (use `from rag_facile.core import`)
+- [ ] No references to `context_loader.py` or `modules.yml`
 
 **Verify with:**
 ```bash
 # From repo root
-grep -r "from config import" --include="*.py" apps/ packages/ 2>/dev/null || echo "✓ No legacy config imports"
-grep -r "from full_context import" --include="*.py" apps/ packages/ 2>/dev/null || echo "✓ No legacy full_context imports"
-grep -r "import config\." --include="*.py" apps/ packages/ 2>/dev/null || echo "✓ No legacy config module imports"
+grep -r "from retrieval import\|from pipelines import\|from ingestion import\|from rag_core import" --include="*.py" apps/ packages/ 2>/dev/null || echo "✓ No legacy pre-namespace imports"
+grep -r "context_loader\|modules\.yml" --include="*.py" --include="*.yml" --include="*.toml" apps/ packages/ 2>/dev/null || echo "✓ No legacy context_loader/modules.yml references"
 ```
 
 ### Conventional Commits
@@ -238,7 +236,7 @@ git log --oneline | head -5
 ### Release-Please
 Check that the GitHub Actions workflow correctly:
 - [ ] Detects the `feat:` commit
-- [ ] Updates version for `rag-core`, `albert-client`, `retrieval-basic`, `retrieval-albert`
+- [ ] Updates version across all packages in `release-please-config.json`
 - [ ] Creates a release PR with changelog entries
 
 ---
@@ -309,9 +307,9 @@ Keep track of your testing:
 - [ ] Installation successful
 - [ ] rag-facile --version works
 - [ ] Default setup (no --expert) skips structure, frontend, and pipeline prompts
-- [ ] Setup creates correct directory structure (flat, no apps/ or .moon/)
-- [ ] All pipeline packages present (albert/, rag_core/, pipelines/, etc.)
-- [ ] ragfacile.toml has provider = "albert-collections"
+- [ ] Setup creates correct structure: `pyproject.toml` (rag-facile-lib dep), `app.py`, `src/<name>/`
+- [ ] `ragfacile.toml` has `provider = "albert-collections"`
+- [ ] `uv sync` installs `rag-facile-lib` (no pipeline source directories)
 - [ ] App runs: `just run` starts Chainlit server
 - [ ] PDF upload works (via Albert parse API)
 - [ ] Config commands work
@@ -325,11 +323,12 @@ Keep track of your testing:
 
 ### Expert Monorepo Test (Reflex)
 - [ ] `rag-facile setup <name> --expert` with monorepo selection works
-- [ ] Setup creates monorepo structure
-- [ ] Templates exist for all packages
-- [ ] `ragfacile.toml` has provider = "albert-collections"
-- [ ] just sync completes without errors
-- [ ] just type-check passes
+- [ ] Setup creates monorepo structure (`.moon/`, `apps/`, `pyproject.toml`, `justfile`)
+- [ ] Only the frontend template is in `.moon/templates/` (pipeline packages come from `rag-facile-lib`)
+- [ ] Generated app's `pyproject.toml` contains `rag-facile-lib` as a dependency
+- [ ] `ragfacile.toml` has `provider = "albert-collections"`
+- [ ] `just sync` completes without errors
+- [ ] `just type-check` passes
 - [ ] `just run reflex-chat` starts dev server
 - [ ] File upload works
 - [ ] Config commands work


### PR DESCRIPTION
## Summary

Fixes stale documentation following the `rag_facile.*` namespace refactor in PR #121.

- **CONTRIBUTING.md**: Expand packages tree (9 packages, not 3), replace "Understanding Retrieval System" section (referenced `context_loader.py`, `modules.yml`, old `from retrieval import` pattern) with accurate "Understanding the Pipeline Architecture" section showing the `rag_facile.*` namespace and `get_pipeline()` factory. Fix `packages/core-config` → `packages/rag-core`.
- **AGENTS.md**: Update repo structure tree (was showing `apps/admin`, `apps/ingestion`, only `pdf-context` package — all pre-2026), replace stale "Recent Work" section with current summaries (PR #121 namespace, PR #96 RAG pipeline, PR #107/113 expert flag), update CLI architecture file tree, fix import troubleshooting guidance, update monorepo package setup steps.
- **TEST_PLAN.md**: Replace the individual pipeline directory checklist in Scenario A/B (was listing `albert/`, `rag_core/`, `pipelines/`... which no longer appear in generated projects) with the `rag-facile-lib` git dependency pattern. Update Scenario C monorepo to match new structure (only frontend template copied). Update quality checklist to check for pre-namespace imports instead of ancient `from config import`. Fix release-please section and test results template.

## Test plan

- [x] Review diffs — all changes are doc-only, no code touched
- [x] Verify CONTRIBUTING.md pipeline table matches actual `packages/` directory
- [x] Verify TEST_PLAN.md Scenario A Step 4 matches what `rag-facile setup my-app` actually generates

👾 Generated with [Letta Code](https://letta.com)