### PR TITLE
fix: include preset public collections in generated standalone config

### DIFF
--- a/apps/cli/src/cli/commands/setup.py
+++ b/apps/cli/src/cli/commands/setup.py
@@ -398,6 +398,7 @@ def generate_config_file(
     """
     from rag_facile.core import RAGConfig
     from rag_facile.core.loader import save_config
+    from rag_facile.core.presets import load_preset
     from rag_facile.core.schema import (
         ChunkingConfig,
         EvalConfig,
@@ -417,6 +418,12 @@ def generate_config_file(
     else:
         storage_backend = "local-sqlite"
 
+    # Load public collection IDs from the preset (only relevant for Albert backend).
+    # These populate the collection toggle buttons in the chat UI.
+    collections: list[int] = []
+    if storage_backend == "albert-collections":
+        collections = load_preset(preset).storage.collections
+
     # Create config with preset values
     config = RAGConfig(
         meta=MetaConfig(preset=preset, schema_version="1.0.0"),
@@ -433,7 +440,7 @@ def generate_config_file(
             ocr=OCRConfig(enabled=True, dpi=300),
         ),
         chunking=ChunkingConfig(strategy="semantic", chunk_size=512, chunk_overlap=50),
-        storage=StorageConfig(provider=storage_backend),
+        storage=StorageConfig(provider=storage_backend, collections=collections),
         formatting=FormattingConfig(
             output_format="markdown",
             include_confidence=False,


### PR DESCRIPTION
## Summary

- `generate_config_file()` in `setup.py` was creating `StorageConfig(provider=...)` without a `collections` argument, so the list defaulted to `[]`
- Chat apps (Chainlit and Reflex) only render collection toggle buttons when `rag_config.storage.collections` is non-empty — so no toggles ever appeared in standalone-generated apps
- Fix: load the selected preset via `load_preset(preset)` and copy its `storage.collections` into the generated `ragfacile.toml` (Albert backend only)

The `accurate` preset ships `collections = [785, 1094]` (service-public + data-gouv-datasets-catalog), so those two public Albert collections will now appear as toggles in a freshly generated standalone app.

## Test plan

- [x] Run `rag-facile setup my-app` and choose the **accurate** preset with Albert RAG
- [x] Open the generated `ragfacile.toml` — verify `[storage]` contains `collections = [785, 1094]`
- [x] Start the Chainlit app — verify the two collection toggle switches appear in the ⚙️ settings panel
- [ ] Start the Reflex app — verify the two collection badges appear above the input bar
- [ ] Run `rag-facile setup my-app` with **balanced** or **fast** preset — verify `collections = []` (no toggles expected)

👾 Generated with [Letta Code](https://letta.com)