### PR TITLE
fix: always show banner before help text or error messages

### DIFF
--- a/apps/cli/src/cli/main.py
+++ b/apps/cli/src/cli/main.py
@@ -1,5 +1,6 @@
+from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as get_version
-from typing import Optional
+from typing import Any, Optional
 
 import click
 import typer
@@ -33,6 +34,21 @@ class AlphabeticalGroup(typer.core.TyperGroup):
     def list_commands(self, ctx: click.Context) -> list[str]:
         return sorted(super().list_commands(ctx))
 
+    def main(self, *args: Any, **kwargs: Any) -> Any:
+        # Print banner and version before any argument parsing or error handling,
+        # so they always appear regardless of subcommand validity.
+        try:
+            console.print(BANNER)
+            try:
+                cli_version = get_version("rag-facile-cli")
+                console.print(f"[cyan]rag-facile v{cli_version}[/cyan]\n")
+            except PackageNotFoundError:
+                pass
+        except Exception:
+            # Skip if terminal doesn't support Unicode (e.g., Git Bash on Windows with cp1252)
+            pass
+        return super().main(*args, **kwargs)
+
 
 app = typer.Typer(
     cls=AlphabeticalGroup,
@@ -53,20 +69,10 @@ def main_callback(
     ),
 ) -> None:
     """RAG Facile CLI - Build RAG applications for the French government."""
-    try:
-        console.print(BANNER)
-    except Exception:
-        # Skip banner if terminal doesn't support Unicode (e.g., Git Bash on Windows with cp1252)
-        # Catching all exceptions since rich may wrap UnicodeEncodeError
-        pass
-
     if version:
-        cli_version = get_version("rag-facile-cli")
-        console.print(f"[cyan]rag-facile v{cli_version}[/cyan]")
         raise typer.Exit()
 
-    # Show help when no subcommand is given (replaces no_args_is_help=True so the
-    # banner is printed first before the help text).
+    # Show help when no subcommand is given (banner + version already printed above).
     if ctx.invoked_subcommand is None:
         console.print(ctx.get_help())
         raise typer.Exit()

--- a/apps/cli/src/cli/main.py
+++ b/apps/cli/src/cli/main.py
@@ -38,13 +38,13 @@ app = typer.Typer(
     cls=AlphabeticalGroup,
     add_completion=False,
     invoke_without_command=True,
-    no_args_is_help=True,
     help="RAG Facile CLI - Build RAG applications for the French government",
 )
 
 
 @app.callback()
 def main_callback(
+    ctx: typer.Context,
     version: Optional[bool] = typer.Option(
         None,
         "--version",
@@ -63,6 +63,12 @@ def main_callback(
     if version:
         cli_version = get_version("rag-facile-cli")
         console.print(f"[cyan]rag-facile v{cli_version}[/cyan]")
+        raise typer.Exit()
+
+    # Show help when no subcommand is given (replaces no_args_is_help=True so the
+    # banner is printed first before the help text).
+    if ctx.invoked_subcommand is None:
+        console.print(ctx.get_help())
         raise typer.Exit()
 
 


### PR DESCRIPTION
## Summary

- `no_args_is_help=True` on the Typer app caused Click to print help inside `parse_args()` and exit before `invoke()` ran — meaning the `@app.callback()` (and its banner print) was never reached when running `rag-facile` with no arguments
- Removed `no_args_is_help=True` and replaced it with an explicit `ctx.invoked_subcommand is None` check inside `main_callback()`, which prints help only *after* the banner has already been shown
- The banner now appears reliably in all entry points: `rag-facile` (no args), `rag-facile setup`, `rag-facile unknowncmd`, etc.

## Test plan

- [x] Run `rag-facile` with no arguments — verify banner appears above the help text
- [x] Run `rag-facile setup` — verify banner still appears (no regression)
- [x] Run `rag-facile --version` — verify banner appears followed by version string
- [x] Run `rag-facile notacommand` — verify banner appears above the "No such command" error

👾 Generated with [Letta Code](https://letta.com)