### PR TITLE
feat: rationalise CLI UX — grouped help panels, simpler setup, smarter just run

### DIFF
--- a/apps/cli/src/cli/commands/setup.py
+++ b/apps/cli/src/cli/commands/setup.py
@@ -758,11 +758,9 @@ def run(
     else:
         is_standalone = True
 
-    # Select preset
+    # Select preset (expert-only interactive picker; --preset flag still works for everyone)
     if not preset:
-        if yes:
-            preset = "balanced"
-        else:
+        if expert and not yes:
             preset = questionary.select(
                 "Choose a configuration preset:",
                 choices=[
@@ -777,6 +775,8 @@ def run(
             if not preset:
                 console.print("[red]Aborted.[/red]")
                 raise typer.Exit(1)
+        else:
+            preset = "balanced"
 
     # Validate preset if provided via flag
     if preset not in PRESET_CONFIGS:

--- a/apps/cli/src/cli/main.py
+++ b/apps/cli/src/cli/main.py
@@ -27,15 +27,24 @@ BANNER = """[magenta]
 [/magenta]"""
 
 
-class AlphabeticalGroup(typer.core.TyperGroup):
-    """Display commands in alphabetical order in help output."""
+# Commands in the Getting Started panel sort before Advanced Tools commands,
+# then alphabetically within each panel.
+_GETTING_STARTED_COMMANDS = {"setup", "uninstall", "upgrade"}
+
+
+class PanelAlphabeticalGroup(typer.core.TyperGroup):
+    """Sort commands by panel (Getting Started first), then alphabetically within each panel."""
 
     def list_commands(self, ctx: click.Context) -> list[str]:
-        return sorted(super().list_commands(ctx))
+        all_names = list(super().list_commands(ctx))
+        return sorted(
+            all_names,
+            key=lambda n: (0 if n in _GETTING_STARTED_COMMANDS else 1, n),
+        )
 
 
 app = typer.Typer(
-    cls=AlphabeticalGroup,
+    cls=PanelAlphabeticalGroup,
     add_completion=False,
     invoke_without_command=True,
     no_args_is_help=True,
@@ -66,7 +75,24 @@ def main_callback(
         raise typer.Exit()
 
 
-# Register commands in alphabetical order
+# Register Getting Started commands first so their panel renders at the top
+app.command(
+    name="setup", help="Setup a new workspace", rich_help_panel="🚀 Getting Started"
+)(setup.run)
+
+app.command(
+    name="uninstall",
+    help="Remove the RAG Facile CLI (--all for toolchain too)",
+    rich_help_panel="🚀 Getting Started",
+)(uninstall.run)
+
+app.command(
+    name="upgrade",
+    help="Upgrade to the latest version",
+    rich_help_panel="🚀 Getting Started",
+)(upgrade.run)
+
+# Advanced Tools — registered after Getting Started so their panel renders below
 
 # Collections command group
 collections_app = typer.Typer(
@@ -77,7 +103,7 @@ collections_app = typer.Typer(
 collections_app.command("list", help="List accessible collections")(
     collections.list_collections
 )
-app.add_typer(collections_app, name="collections")
+app.add_typer(collections_app, name="collections", rich_help_panel="🔧 Advanced Tools")
 
 # Config command group
 config_app = typer.Typer(
@@ -91,20 +117,13 @@ config_app.command("set", help="Set configuration value")(config.set_value)
 config_app.add_typer(
     config.preset(), name="preset", help="Manage configuration presets"
 )
-app.add_typer(config_app, name="config")
+app.add_typer(config_app, name="config", rich_help_panel="🔧 Advanced Tools")
 
 app.command(
     name="generate-dataset",
     help="Generate synthetic Q/A evaluation dataset from documents",
+    rich_help_panel="🔧 Advanced Tools",
 )(generate_dataset.run)
-
-app.command(name="setup", help="Setup a new workspace")(setup.run)
-
-app.command(
-    name="uninstall", help="Remove the RAG Facile CLI (--all for toolchain too)"
-)(uninstall.run)
-
-app.command(name="upgrade", help="Upgrade to the latest version")(upgrade.run)
 
 
 if __name__ == "__main__":

--- a/apps/cli/src/cli/main.py
+++ b/apps/cli/src/cli/main.py
@@ -27,9 +27,16 @@ BANNER = """[magenta]
 [/magenta]"""
 
 
-# Commands in the Getting Started panel sort before Advanced Tools commands,
-# then alphabetically within each panel.
-_GETTING_STARTED_COMMANDS = {"setup", "uninstall", "upgrade"}
+# Getting Started command definitions — single source of truth for both
+# panel registration and sort-key logic in PanelAlphabeticalGroup.
+_GETTING_STARTED_DEFS: dict[str, tuple] = {
+    "setup": (setup.run, "Setup a new workspace"),
+    "uninstall": (uninstall.run, "Remove the RAG Facile CLI (--all for toolchain too)"),
+    "upgrade": (upgrade.run, "Upgrade to the latest version"),
+}
+
+_PANEL_GETTING_STARTED = "🚀 Getting Started"
+_PANEL_ADVANCED_TOOLS = "🔧 Advanced Tools"
 
 
 class PanelAlphabeticalGroup(typer.core.TyperGroup):
@@ -39,7 +46,7 @@ class PanelAlphabeticalGroup(typer.core.TyperGroup):
         all_names = list(super().list_commands(ctx))
         return sorted(
             all_names,
-            key=lambda n: (0 if n in _GETTING_STARTED_COMMANDS else 1, n),
+            key=lambda n: (0 if n in _GETTING_STARTED_DEFS else 1, n),
         )
 
 
@@ -76,21 +83,8 @@ def main_callback(
 
 
 # Register Getting Started commands first so their panel renders at the top
-app.command(
-    name="setup", help="Setup a new workspace", rich_help_panel="🚀 Getting Started"
-)(setup.run)
-
-app.command(
-    name="uninstall",
-    help="Remove the RAG Facile CLI (--all for toolchain too)",
-    rich_help_panel="🚀 Getting Started",
-)(uninstall.run)
-
-app.command(
-    name="upgrade",
-    help="Upgrade to the latest version",
-    rich_help_panel="🚀 Getting Started",
-)(upgrade.run)
+for _name, (_func, _help) in _GETTING_STARTED_DEFS.items():
+    app.command(name=_name, help=_help, rich_help_panel=_PANEL_GETTING_STARTED)(_func)
 
 # Advanced Tools — registered after Getting Started so their panel renders below
 
@@ -103,7 +97,9 @@ collections_app = typer.Typer(
 collections_app.command("list", help="List accessible collections")(
     collections.list_collections
 )
-app.add_typer(collections_app, name="collections", rich_help_panel="🔧 Advanced Tools")
+app.add_typer(
+    collections_app, name="collections", rich_help_panel=_PANEL_ADVANCED_TOOLS
+)
 
 # Config command group
 config_app = typer.Typer(
@@ -117,12 +113,12 @@ config_app.command("set", help="Set configuration value")(config.set_value)
 config_app.add_typer(
     config.preset(), name="preset", help="Manage configuration presets"
 )
-app.add_typer(config_app, name="config", rich_help_panel="🔧 Advanced Tools")
+app.add_typer(config_app, name="config", rich_help_panel=_PANEL_ADVANCED_TOOLS)
 
 app.command(
     name="generate-dataset",
     help="Generate synthetic Q/A evaluation dataset from documents",
-    rich_help_panel="🔧 Advanced Tools",
+    rich_help_panel=_PANEL_ADVANCED_TOOLS,
 )(generate_dataset.run)
 
 

--- a/apps/cli/tests/test_setup.py
+++ b/apps/cli/tests/test_setup.py
@@ -788,11 +788,8 @@ class TestStandaloneWorkspaceCommand:
         # Mock shutil.which to pretend tools are installed
         mocker.patch("shutil.which", return_value="/usr/bin/uv")
 
-        # Mock questionary interactions - default mode skips structure, frontend, and pipeline
+        # Mock questionary interactions - default mode has no select calls (no preset/structure/frontend/pipeline)
         mock_q = mocker.patch("cli.commands.setup.questionary")
-        mock_q.select.return_value.ask.side_effect = [
-            "balanced",  # Only call: preset selection
-        ]
         mock_q.confirm.return_value.ask.return_value = True
         mock_q.text.return_value.ask.return_value = "test-value"
 
@@ -880,10 +877,7 @@ class TestPathNormalization:
         """Should normalize /private/tmp to /tmp in output."""
         # Create a path that looks like macOS /private/tmp
         mock_q = mocker.patch("cli.commands.setup.questionary")
-        # Default mode: only preset select (no structure/frontend/pipeline)
-        mock_q.select.return_value.ask.side_effect = [
-            "balanced",  # Preset
-        ]
+        # Default mode: no select calls (preset/structure/frontend/pipeline all default silently)
         mock_q.checkbox.return_value.ask.return_value = []
         mock_q.confirm.return_value.ask.return_value = False  # Abort early
 
@@ -942,29 +936,20 @@ class TestStructureSelectionPrompt:
         assert "Aborted" in result.output
 
     def test_default_mode_skips_structure_frontend_and_pipeline_prompts(self, mocker):
-        """Without --expert, should only ask for preset (1 select)."""
+        """Without --expert, should ask no select questions (preset/structure/frontend/pipeline all default)."""
         mock_q = mocker.patch("cli.commands.setup.questionary")
-        mock_q.select.return_value.ask.side_effect = [
-            "balanced",  # Only call: preset selection
-        ]
         mock_q.text.return_value.ask.return_value = "test-key"
         mock_q.confirm.return_value.ask.return_value = False  # Abort at confirmation
 
         runner.invoke(main_app, ["setup", "/tmp/test"])
 
-        # Should have been called once (preset only), no structure, frontend, or pipeline
-        assert mock_q.select.call_count == 1
-
-        # Only call should be for preset (not structure or frontend)
-        first_call_prompt = mock_q.select.call_args_list[0][0][0]
-        assert "preset" in first_call_prompt.lower()
+        # No select calls at all — all choices use silent defaults in non-expert mode
+        assert mock_q.select.call_count == 0
 
     def test_default_mode_defaults_to_standalone_chainlit_and_albert_rag(self, mocker):
-        """Without --expert, should default to standalone + Chainlit + Albert RAG."""
+        """Without --expert, should default to standalone + Chainlit + Albert RAG + balanced preset."""
         mock_q = mocker.patch("cli.commands.setup.questionary")
-        mock_q.select.return_value.ask.side_effect = [
-            "balanced",  # Only select: Preset
-        ]
+        # No select calls in non-expert mode — all choices use silent defaults
         mock_q.text.return_value.ask.return_value = "test-key"
         mock_q.confirm.return_value.ask.return_value = False  # Abort at confirmation
 

--- a/justfile
+++ b/justfile
@@ -39,9 +39,9 @@ type-check:
 # Run all checks (format-check, lint, type-check)
 check: format-check lint type-check
 
-# Run a specific app (e.g., just run chainlit-chat)
-run name:
-    cd "apps/{{name}}" && just run
+# Run the chat UI: just run (chainlit) or just run reflex
+run ui="chainlit":
+    cd "apps/{{ui}}-chat" && just run
 
 # Add a new app from a template (e.g., just add chainlit-chat)
 add template:


### PR DESCRIPTION
## Summary

- **Grouped help panels**: `rag-facile --help` now has a `🚀 Getting Started` panel (`setup`, `upgrade`, `uninstall`) and a `🔧 Advanced Tools` panel (`collections`, `config`, `generate-dataset`). Commands are alphabetical within each panel. A `PanelAlphabeticalGroup` class replaces the old `AlphabeticalGroup` to sort by panel priority first, then by name.

- **Simpler non-expert setup**: `rag-facile setup` now asks only for the Albert API key in default mode. Preset, structure, frontend and pipeline all use silent defaults. The `--preset <name>` flag still works for everyone who knows what they want without going `--expert`.

- **`just run` UI selector**: `just run` now defaults to chainlit (`apps/chainlit-chat`). `just run reflex` starts the Reflex UI. Removes the confusing `-chat` suffix requirement.

## Test plan

- [x] `rag-facile --help` shows two labelled panels, Getting Started first
- [x] `rag-facile setup ./my-app` (non-expert) asks only for API key, silently uses `balanced` preset
- [x] `rag-facile setup ./my-app --preset legal` (non-expert + flag) uses `legal` with no prompt
- [x] `rag-facile setup ./my-app --expert` shows all four questions: structure → preset → frontend → pipeline
- [x] `just run` starts chainlit-chat; `just run reflex` starts reflex-chat; `just run chainlit` works explicitly
- [x] All 110 passing tests continue to pass (1 pre-existing failure in `test_generate_letta_requires_env_vars` unrelated to this PR)

👾 Generated with [Letta Code](https://letta.com)