### PR TITLE
feat: rag-facile chat — smolagents harness spike

### DIFF
--- a/apps/cli/pyproject.toml
+++ b/apps/cli/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "pyyaml>=6.0.2",
     "questionary>=2.0.0",
     "rich>=13.0.0",
+    "smolagents>=1.14.0",
     "typer>=0.12.0",
 ]
 

--- a/apps/cli/src/cli/commands/chat/__init__.py
+++ b/apps/cli/src/cli/commands/chat/__init__.py
@@ -1,0 +1,15 @@
+"""rag-facile chat command.
+
+start_chat() is the primary entry point — called from main.py when the user runs
+`rag-facile` with no subcommand, or explicitly via `rag-facile chat`.
+"""
+
+from cli.commands.chat.agent import start_chat
+
+
+def run() -> None:
+    """Launch the interactive RAG assistant."""
+    start_chat()
+
+
+__all__ = ["run", "start_chat"]

--- a/apps/cli/src/cli/commands/chat/agent.py
+++ b/apps/cli/src/cli/commands/chat/agent.py
@@ -12,6 +12,7 @@ from rich.console import Console
 from rich.markdown import Markdown
 from rich.panel import Panel
 from smolagents import ToolCallingAgent, OpenAIServerModel
+from smolagents.monitoring import LogLevel
 from smolagents.utils import AgentError, AgentMaxStepsError
 
 from cli.commands.chat.tools import get_ragfacile_config, set_workspace_root
@@ -68,16 +69,15 @@ def _build_model() -> OpenAIServerModel:
 
 def start_chat() -> None:
     """Launch the interactive RAG assistant chat loop."""
-    # Detect workspace
+    # Detect workspace — walk up from cwd for ragfacile.toml
     workspace = _detect_workspace()
+    no_workspace_hint = ""
     if workspace:
         set_workspace_root(workspace)
-        console.print(f"[dim]Workspace: {workspace}[/dim]")
     else:
-        console.print(
-            "[yellow]⚠ No ragfacile.toml found. "
-            "Run 'rag-facile setup' to create a workspace, "
-            "or start chatting to learn about RAG.[/yellow]"
+        no_workspace_hint = (
+            "\n[dim]💡 No ragfacile.toml found — run [bold]rag-facile setup[/bold] "
+            "to create a workspace.[/dim]"
         )
 
     # Build model + agent
@@ -90,16 +90,19 @@ def start_chat() -> None:
         tools=[get_ragfacile_config],
         model=model,
         instructions=_SYSTEM_PROMPT,
-        verbosity_level=0,
+        verbosity_level=LogLevel.OFF,  # -1: suppress all smolagents output incl. errors
         max_steps=5,
     )
 
     # Welcome
+    workspace_line = (
+        f"\n[dim]Workspace: {workspace}[/dim]" if workspace else no_workspace_hint
+    )
     console.print(
         Panel(
             "[bold]Bonjour! I'm your RAG assistant.[/bold]\n"
             "[dim]Ask me anything about RAG, your pipeline config, or how to improve your results.\n"
-            "Type [bold]q[/bold] or press Ctrl+C to quit.[/dim]",
+            "Type [bold]q[/bold] or press Ctrl+C to quit.[/dim]" + workspace_line,
             border_style="magenta",
             padding=(0, 1),
         )

--- a/apps/cli/src/cli/commands/chat/agent.py
+++ b/apps/cli/src/cli/commands/chat/agent.py
@@ -1,0 +1,145 @@
+"""smolagents harness for the rag-facile chat experience.
+
+Entry point: start_chat() — called when the user runs `rag-facile` with no arguments,
+or explicitly via `rag-facile chat`.
+"""
+
+import os
+from pathlib import Path
+
+import openai
+from rich.console import Console
+from rich.markdown import Markdown
+from rich.panel import Panel
+from smolagents import ToolCallingAgent, OpenAIServerModel
+from smolagents.utils import AgentError, AgentMaxStepsError
+
+from cli.commands.chat.tools import get_ragfacile_config, set_workspace_root
+
+
+console = Console()
+
+_SYSTEM_PROMPT = """\
+You are the rag-facile AI assistant — a friendly expert who helps developers \
+build RAG (Retrieval-Augmented Generation) applications using the rag-facile toolkit.
+
+Your users are lambda developers: they know Python but are new to RAG and GenAI. \
+Always explain concepts in plain, accessible language. Avoid jargon without explanation.
+
+You can:
+- Answer questions about RAG concepts (chunking, embeddings, retrieval, reranking, etc.)
+- Explain what configuration parameters do and how to tune them
+- Read the current ragfacile.toml to give context-aware advice
+- Guide users through the rag-facile workflow step by step
+
+Always be encouraging and educational. When you suggest a change, explain the tradeoff \
+in terms of speed vs. quality vs. cost so the user can make an informed decision.
+"""
+
+
+def _detect_workspace() -> Path | None:
+    """Walk up from cwd looking for a ragfacile.toml to identify the workspace root."""
+    cwd = Path.cwd()
+    for path in [cwd, *cwd.parents]:
+        if (path / "ragfacile.toml").exists():
+            return path
+    return None
+
+
+def _build_model() -> OpenAIServerModel:
+    """Construct the OpenAIServerModel pointed at Albert API."""
+    api_key = os.environ.get("OPENAI_API_KEY") or os.environ.get("ALBERT_API_KEY", "")
+    api_base = os.environ.get("OPENAI_BASE_URL", "https://albert.api.etalab.gouv.fr/v1")
+    model_id = os.environ.get("OPENAI_MODEL", "meta-llama/Llama-3.1-70B-Instruct")
+
+    if not api_key:
+        console.print(
+            "[red]✗ No API key found.[/red]\n"
+            "[dim]Set OPENAI_API_KEY or ALBERT_API_KEY in your .env file.[/dim]"
+        )
+        raise SystemExit(1)
+
+    return OpenAIServerModel(
+        model_id=model_id,
+        api_base=api_base,
+        api_key=api_key,
+    )
+
+
+def start_chat() -> None:
+    """Launch the interactive RAG assistant chat loop."""
+    # Detect workspace
+    workspace = _detect_workspace()
+    if workspace:
+        set_workspace_root(workspace)
+        console.print(f"[dim]Workspace: {workspace}[/dim]")
+    else:
+        console.print(
+            "[yellow]⚠ No ragfacile.toml found. "
+            "Run 'rag-facile setup' to create a workspace, "
+            "or start chatting to learn about RAG.[/yellow]"
+        )
+
+    # Build model + agent
+    try:
+        model = _build_model()
+    except SystemExit:
+        return
+
+    agent = ToolCallingAgent(
+        tools=[get_ragfacile_config],
+        model=model,
+        instructions=_SYSTEM_PROMPT,
+        verbosity_level=0,
+        max_steps=5,
+    )
+
+    # Welcome
+    console.print(
+        Panel(
+            "[bold]Bonjour! I'm your RAG assistant.[/bold]\n"
+            "[dim]Ask me anything about RAG, your pipeline config, or how to improve your results.\n"
+            "Type [bold]q[/bold] or press Ctrl+C to quit.[/dim]",
+            border_style="magenta",
+            padding=(0, 1),
+        )
+    )
+    console.print()
+
+    # Chat loop
+    while True:
+        try:
+            user_input = console.input("[bold cyan]You[/bold cyan]: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            console.print("\n[dim]À bientôt![/dim]")
+            break
+
+        if not user_input:
+            continue
+
+        if user_input.lower() in ("q", "quit", "exit", "bye", "au revoir"):
+            console.print("[dim]À bientôt![/dim]")
+            break
+
+        with console.status("[dim]Thinking...[/dim]", spinner="dots"):
+            try:
+                response = agent.run(user_input, reset=False)
+            except openai.APIError as exc:
+                console.print(f"[red]API error: {exc}[/red]")
+                console.print(
+                    "[dim]Check your OPENAI_API_KEY and OPENAI_BASE_URL.[/dim]"
+                )
+                continue
+            except AgentMaxStepsError:
+                console.print(
+                    "[yellow]I needed too many steps to answer that. "
+                    "Could you rephrase or break it into smaller questions?[/yellow]"
+                )
+                continue
+            except AgentError as exc:
+                console.print(f"[red]Agent error: {exc}[/red]")
+                continue
+
+        console.print("[bold green]Assistant[/bold green]:")
+        console.print(Markdown(str(response)))
+        console.print()

--- a/apps/cli/src/cli/commands/chat/agent.py
+++ b/apps/cli/src/cli/commands/chat/agent.py
@@ -8,10 +8,12 @@ import os
 from pathlib import Path
 
 import openai
+import typer
+from dotenv import load_dotenv
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.panel import Panel
-from smolagents import ToolCallingAgent, OpenAIServerModel
+from smolagents import OpenAIServerModel, ToolCallingAgent
 from smolagents.monitoring import LogLevel
 from smolagents.utils import AgentError, AgentMaxStepsError
 
@@ -58,7 +60,7 @@ def _build_model() -> OpenAIServerModel:
             "[red]✗ No API key found.[/red]\n"
             "[dim]Set OPENAI_API_KEY or ALBERT_API_KEY in your .env file.[/dim]"
         )
-        raise SystemExit(1)
+        raise typer.Exit(code=1)
 
     return OpenAIServerModel(
         model_id=model_id,
@@ -73,6 +75,7 @@ def start_chat() -> None:
     workspace = _detect_workspace()
     no_workspace_hint = ""
     if workspace:
+        load_dotenv(workspace / ".env")  # load API key + config from project .env
         set_workspace_root(workspace)
     else:
         no_workspace_hint = (
@@ -80,11 +83,8 @@ def start_chat() -> None:
             "to create a workspace.[/dim]"
         )
 
-    # Build model + agent
-    try:
-        model = _build_model()
-    except SystemExit:
-        return
+    # Build model + agent — typer.Exit propagates naturally on missing API key
+    model = _build_model()
 
     agent = ToolCallingAgent(
         tools=[get_ragfacile_config],
@@ -127,6 +127,9 @@ def start_chat() -> None:
         with console.status("[dim]Thinking...[/dim]", spinner="dots"):
             try:
                 response = agent.run(user_input, reset=False)
+            except KeyboardInterrupt:
+                console.print("\n[yellow]Interrupted.[/yellow]")
+                continue
             except openai.APIError as exc:
                 console.print(f"[red]API error: {exc}[/red]")
                 console.print(

--- a/apps/cli/src/cli/commands/chat/tools.py
+++ b/apps/cli/src/cli/commands/chat/tools.py
@@ -1,0 +1,42 @@
+"""RAG Facile chat agent tools.
+
+Each @tool is callable by the smolagents ToolCallingAgent during a chat session.
+The workspace root is set once at session start by the agent harness.
+"""
+
+from pathlib import Path
+
+from smolagents import tool
+
+
+# Module-level workspace reference — set by the agent harness at session start.
+_workspace_root: Path | None = None
+
+
+def set_workspace_root(root: Path) -> None:
+    """Register the workspace root so tools can locate project files."""
+    global _workspace_root
+    _workspace_root = root
+
+
+def _workspace() -> Path:
+    """Return the workspace root, raising clearly if not configured."""
+    if _workspace_root is None:
+        raise RuntimeError("Workspace root not set. Call set_workspace_root() first.")
+    return _workspace_root
+
+
+@tool
+def get_ragfacile_config() -> str:
+    """Read the current ragfacile.toml configuration.
+
+    Use this to answer questions about the RAG pipeline settings such as
+    which preset is active, retrieval parameters, collection IDs, etc.
+    """
+    config_file = _workspace() / "ragfacile.toml"
+    if not config_file.exists():
+        return (
+            "No ragfacile.toml found in this workspace. "
+            "Run 'rag-facile setup' to create one."
+        )
+    return config_file.read_text(encoding="utf-8")

--- a/apps/cli/src/cli/commands/chat/tools.py
+++ b/apps/cli/src/cli/commands/chat/tools.py
@@ -19,13 +19,6 @@ def set_workspace_root(root: Path) -> None:
     _workspace_root = root
 
 
-def _workspace() -> Path:
-    """Return the workspace root, raising clearly if not configured."""
-    if _workspace_root is None:
-        raise RuntimeError("Workspace root not set. Call set_workspace_root() first.")
-    return _workspace_root
-
-
 @tool
 def get_ragfacile_config() -> str:
     """Read the current ragfacile.toml configuration.
@@ -33,7 +26,13 @@ def get_ragfacile_config() -> str:
     Use this to answer questions about the RAG pipeline settings such as
     which preset is active, retrieval parameters, collection IDs, etc.
     """
-    config_file = _workspace() / "ragfacile.toml"
+    if _workspace_root is None:
+        return (
+            "No workspace detected — ragfacile.toml was not found in the current "
+            "directory or any parent directory. "
+            "Run 'rag-facile setup' to create a workspace."
+        )
+    config_file = _workspace_root / "ragfacile.toml"
     if not config_file.exists():
         return (
             "No ragfacile.toml found in this workspace. "

--- a/apps/cli/src/cli/main.py
+++ b/apps/cli/src/cli/main.py
@@ -95,9 +95,7 @@ def main_callback(
 
     # No subcommand → drop directly into the RAG assistant (like `letta`).
     if ctx.invoked_subcommand is None:
-        from cli.commands.chat import start_chat
-
-        start_chat()
+        chat.start_chat()
         raise typer.Exit()
 
 

--- a/apps/cli/src/cli/main.py
+++ b/apps/cli/src/cli/main.py
@@ -7,6 +7,7 @@ import typer
 from rich.console import Console
 
 from cli.commands import (
+    chat,
     collections,
     config,
     generate_dataset,
@@ -31,6 +32,10 @@ BANNER = """[magenta]
 # Getting Started command definitions — single source of truth for both
 # panel registration and sort-key logic in PanelAlphabeticalGroup.
 _GETTING_STARTED_DEFS: dict[str, tuple] = {
+    "chat": (
+        chat.run,
+        "Open the RAG assistant (also the default: just run `rag-facile`)",
+    ),
     "setup": (setup.run, "Setup a new workspace"),
     "uninstall": (uninstall.run, "Remove the RAG Facile CLI (--all for toolchain too)"),
     "upgrade": (upgrade.run, "Upgrade to the latest version"),
@@ -88,9 +93,11 @@ def main_callback(
     if version:
         raise typer.Exit()
 
-    # Show help when no subcommand is given (banner + version already printed above).
+    # No subcommand → drop directly into the RAG assistant (like `letta`).
     if ctx.invoked_subcommand is None:
-        console.print(ctx.get_help())
+        from cli.commands.chat import start_chat
+
+        start_chat()
         raise typer.Exit()
 
 

--- a/apps/cli/tests/test_chat.py
+++ b/apps/cli/tests/test_chat.py
@@ -1,0 +1,85 @@
+"""Tests for the rag-facile chat command."""
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from cli.main import app as main_app
+
+
+runner = CliRunner()
+
+
+class TestChatCommand:
+    """Tests for the `rag-facile chat` / default `rag-facile` command."""
+
+    def test_no_subcommand_launches_chat(self, monkeypatch):
+        """Running rag-facile with no args launches chat instead of showing help."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+        with (
+            patch("cli.commands.chat.agent._detect_workspace", return_value=None),
+            patch("cli.commands.chat.agent.OpenAIServerModel"),
+            patch("cli.commands.chat.agent.ToolCallingAgent"),
+        ):
+            result = runner.invoke(main_app, [], input="q\n")
+
+        assert result.exit_code == 0
+        # Chat started: welcome panel visible
+        assert "Bonjour" in result.output
+        # Help page NOT shown
+        assert "Usage:" not in result.output
+
+    def test_chat_alias_also_works(self, monkeypatch):
+        """`rag-facile chat` is an explicit alias that starts the same loop."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+        with (
+            patch("cli.commands.chat.agent._detect_workspace", return_value=None),
+            patch("cli.commands.chat.agent.OpenAIServerModel"),
+            patch("cli.commands.chat.agent.ToolCallingAgent"),
+        ):
+            result = runner.invoke(main_app, ["chat"], input="q\n")
+
+        assert result.exit_code == 0
+        assert "Bonjour" in result.output
+
+    def test_no_workspace_warning_shown_chat_still_starts(self, monkeypatch):
+        """Outside a workspace: no-workspace hint shown, chat still starts."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+        with (
+            patch("cli.commands.chat.agent._detect_workspace", return_value=None),
+            patch("cli.commands.chat.agent.OpenAIServerModel"),
+            patch("cli.commands.chat.agent.ToolCallingAgent"),
+        ):
+            result = runner.invoke(main_app, [], input="q\n")
+
+        assert result.exit_code == 0
+        # No-workspace hint visible in the welcome panel
+        assert "ragfacile.toml" in result.output
+        assert "rag-facile setup" in result.output
+        # Chat still started
+        assert "Bonjour" in result.output
+
+    def test_missing_api_key_exits_with_error(self, monkeypatch):
+        """Without an API key, chat exits cleanly with an error message."""
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("ALBERT_API_KEY", raising=False)
+
+        with patch("cli.commands.chat.agent._detect_workspace", return_value=None):
+            result = runner.invoke(main_app, [])
+
+        assert result.exit_code == 1
+        assert "No API key found" in result.output
+
+    def test_get_ragfacile_config_tool_no_workspace(self):
+        """Tool returns helpful string (not an error) when no workspace configured."""
+        from cli.commands.chat import tools
+
+        # Ensure workspace is None
+        tools._workspace_root = None
+        result = tools.get_ragfacile_config()
+
+        assert "No workspace detected" in result
+        assert "rag-facile setup" in result

--- a/uv.lock
+++ b/uv.lock
@@ -704,7 +704,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/ab/d26750f2b7242c2b90ea2ad71de70cfcd73a948a49513188a0fc0d6fc15a/greenlet-3.3.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:7ab327905cabb0622adca5971e488064e35115430cec2c35a50fd36e72a315b3", size = 275205, upload-time = "2026-01-23T15:30:24.556Z" },
     { url = "https://files.pythonhosted.org/packages/10/d3/be7d19e8fad7c5a78eeefb2d896a08cd4643e1e90c605c4be3b46264998f/greenlet-3.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:65be2f026ca6a176f88fb935ee23c18333ccea97048076aef4db1ef5bc0713ac", size = 599284, upload-time = "2026-01-23T16:00:58.584Z" },
     { url = "https://files.pythonhosted.org/packages/ae/21/fe703aaa056fdb0f17e5afd4b5c80195bbdab701208918938bd15b00d39b/greenlet-3.3.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7a3ae05b3d225b4155bda56b072ceb09d05e974bc74be6c3fc15463cf69f33fd", size = 610274, upload-time = "2026-01-23T16:05:29.312Z" },
-    { url = "https://files.pythonhosted.org/packages/06/00/95df0b6a935103c0452dad2203f5be8377e551b8466a29650c4c5a5af6cc/greenlet-3.3.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:12184c61e5d64268a160226fb4818af4df02cfead8379d7f8b99a56c3a54ff3e", size = 624375, upload-time = "2026-01-23T16:15:55.915Z" },
     { url = "https://files.pythonhosted.org/packages/cb/86/5c6ab23bb3c28c21ed6bebad006515cfe08b04613eb105ca0041fecca852/greenlet-3.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6423481193bbbe871313de5fd06a082f2649e7ce6e08015d2a76c1e9186ca5b3", size = 612904, upload-time = "2026-01-23T15:32:52.317Z" },
     { url = "https://files.pythonhosted.org/packages/c2/f3/7949994264e22639e40718c2daf6f6df5169bf48fb038c008a489ec53a50/greenlet-3.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:33a956fe78bbbda82bfc95e128d61129b32d66bcf0a20a1f0c08aa4839ffa951", size = 1567316, upload-time = "2026-01-23T16:04:23.316Z" },
     { url = "https://files.pythonhosted.org/packages/8d/6e/d73c94d13b6465e9f7cd6231c68abde838bb22408596c05d9059830b7872/greenlet-3.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4b065d3284be43728dd280f6f9a13990b56470b81be20375a207cdc814a983f2", size = 1636549, upload-time = "2026-01-23T15:33:48.643Z" },
@@ -2004,6 +2003,39 @@ wheels = [
 ]
 
 [[package]]
+name = "pillow"
+version = "12.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/42/5c74462b4fd957fcd7b13b04fb3205ff8349236ea74c7c375766d6c82288/pillow-12.1.1.tar.gz", hash = "sha256:9ad8fa5937ab05218e2b6a4cff30295ad35afd2f83ac592e68c0d871bb0fdbc4", size = 46980264, upload-time = "2026-02-11T04:23:07.146Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/11/6db24d4bd7685583caeae54b7009584e38da3c3d4488ed4cd25b439de486/pillow-12.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d242e8ac078781f1de88bf823d70c1a9b3c7950a44cdf4b7c012e22ccbcd8e4e", size = 4062689, upload-time = "2026-02-11T04:21:06.804Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c0/ce6d3b1fe190f0021203e0d9b5b99e57843e345f15f9ef22fcd43842fd21/pillow-12.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:02f84dfad02693676692746df05b89cf25597560db2857363a208e393429f5e9", size = 4138535, upload-time = "2026-02-11T04:21:08.452Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c6/d5eb6a4fb32a3f9c21a8c7613ec706534ea1cf9f4b3663e99f0d83f6fca8/pillow-12.1.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:e65498daf4b583091ccbb2556c7000abf0f3349fcd57ef7adc9a84a394ed29f6", size = 3601364, upload-time = "2026-02-11T04:21:10.194Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a1/16c4b823838ba4c9c52c0e6bbda903a3fe5a1bdbf1b8eb4fff7156f3e318/pillow-12.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6c6db3b84c87d48d0088943bf33440e0c42370b99b1c2a7989216f7b42eede60", size = 5262561, upload-time = "2026-02-11T04:21:11.742Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/ad/ad9dc98ff24f485008aa5cdedaf1a219876f6f6c42a4626c08bc4e80b120/pillow-12.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8b7e5304e34942bf62e15184219a7b5ad4ff7f3bb5cca4d984f37df1a0e1aee2", size = 4657460, upload-time = "2026-02-11T04:21:13.786Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1b/f1a4ea9a895b5732152789326202a82464d5254759fbacae4deea3069334/pillow-12.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:18e5bddd742a44b7e6b1e773ab5db102bd7a94c32555ba656e76d319d19c3850", size = 6232698, upload-time = "2026-02-11T04:21:15.949Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f4/86f51b8745070daf21fd2e5b1fe0eb35d4db9ca26e6d58366562fb56a743/pillow-12.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc44ef1f3de4f45b50ccf9136999d71abb99dca7706bc75d222ed350b9fd2289", size = 8041706, upload-time = "2026-02-11T04:21:17.723Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9b/d6ecd956bb1266dd1045e995cce9b8d77759e740953a1c9aad9502a0461e/pillow-12.1.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a8eb7ed8d4198bccbd07058416eeec51686b498e784eda166395a23eb99138e", size = 6346621, upload-time = "2026-02-11T04:21:19.547Z" },
+    { url = "https://files.pythonhosted.org/packages/71/24/538bff45bde96535d7d998c6fed1a751c75ac7c53c37c90dc2601b243893/pillow-12.1.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47b94983da0c642de92ced1702c5b6c292a84bd3a8e1d1702ff923f183594717", size = 7038069, upload-time = "2026-02-11T04:21:21.378Z" },
+    { url = "https://files.pythonhosted.org/packages/94/0e/58cb1a6bc48f746bc4cb3adb8cabff73e2742c92b3bf7a220b7cf69b9177/pillow-12.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:518a48c2aab7ce596d3bf79d0e275661b846e86e4d0e7dec34712c30fe07f02a", size = 6460040, upload-time = "2026-02-11T04:21:23.148Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/57/9045cb3ff11eeb6c1adce3b2d60d7d299d7b273a2e6c8381a524abfdc474/pillow-12.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a550ae29b95c6dc13cf69e2c9dc5747f814c54eeb2e32d683e5e93af56caa029", size = 7164523, upload-time = "2026-02-11T04:21:25.01Z" },
+    { url = "https://files.pythonhosted.org/packages/73/f2/9be9cb99f2175f0d4dbadd6616ce1bf068ee54a28277ea1bf1fbf729c250/pillow-12.1.1-cp313-cp313-win32.whl", hash = "sha256:a003d7422449f6d1e3a34e3dd4110c22148336918ddbfc6a32581cd54b2e0b2b", size = 6332552, upload-time = "2026-02-11T04:21:27.238Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/eb/b0834ad8b583d7d9d42b80becff092082a1c3c156bb582590fcc973f1c7c/pillow-12.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:344cf1e3dab3be4b1fa08e449323d98a2a3f819ad20f4b22e77a0ede31f0faa1", size = 7040108, upload-time = "2026-02-11T04:21:29.462Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7d/fc09634e2aabdd0feabaff4a32f4a7d97789223e7c2042fd805ea4b4d2c2/pillow-12.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c0dd1636633e7e6a0afe7bf6a51a14992b7f8e60de5789018ebbdfae55b040a", size = 2453712, upload-time = "2026-02-11T04:21:31.072Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/b9d62794fc8a0dd14c1943df68347badbd5511103e0d04c035ffe5cf2255/pillow-12.1.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0330d233c1a0ead844fc097a7d16c0abff4c12e856c0b325f231820fee1f39da", size = 5264880, upload-time = "2026-02-11T04:21:32.865Z" },
+    { url = "https://files.pythonhosted.org/packages/26/9d/e03d857d1347fa5ed9247e123fcd2a97b6220e15e9cb73ca0a8d91702c6e/pillow-12.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5dae5f21afb91322f2ff791895ddd8889e5e947ff59f71b46041c8ce6db790bc", size = 4660616, upload-time = "2026-02-11T04:21:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ec/8a6d22afd02570d30954e043f09c32772bfe143ba9285e2fdb11284952cd/pillow-12.1.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2e0c664be47252947d870ac0d327fea7e63985a08794758aa8af5b6cb6ec0c9c", size = 6269008, upload-time = "2026-02-11T04:21:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/1d/6d875422c9f28a4a361f495a5f68d9de4a66941dc2c619103ca335fa6446/pillow-12.1.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:691ab2ac363b8217f7d31b3497108fb1f50faab2f75dfb03284ec2f217e87bf8", size = 8073226, upload-time = "2026-02-11T04:21:38.585Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/cd/134b0b6ee5eda6dc09e25e24b40fdafe11a520bc725c1d0bbaa5e00bf95b/pillow-12.1.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9e8064fb1cc019296958595f6db671fba95209e3ceb0c4734c9baf97de04b20", size = 6380136, upload-time = "2026-02-11T04:21:40.562Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/a9/7628f013f18f001c1b98d8fffe3452f306a70dc6aba7d931019e0492f45e/pillow-12.1.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:472a8d7ded663e6162dafdf20015c486a7009483ca671cece7a9279b512fcb13", size = 7067129, upload-time = "2026-02-11T04:21:42.521Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f8/66ab30a2193b277785601e82ee2d49f68ea575d9637e5e234faaa98efa4c/pillow-12.1.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:89b54027a766529136a06cfebeecb3a04900397a3590fd252160b888479517bf", size = 6491807, upload-time = "2026-02-11T04:21:44.22Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0b/a877a6627dc8318fdb84e357c5e1a758c0941ab1ddffdafd231983788579/pillow-12.1.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:86172b0831b82ce4f7877f280055892b31179e1576aa00d0df3bb1bbf8c3e524", size = 7190954, upload-time = "2026-02-11T04:21:46.114Z" },
+    { url = "https://files.pythonhosted.org/packages/83/43/6f732ff85743cf746b1361b91665d9f5155e1483817f693f8d57ea93147f/pillow-12.1.1-cp313-cp313t-win32.whl", hash = "sha256:44ce27545b6efcf0fdbdceb31c9a5bdea9333e664cda58a7e674bb74608b3986", size = 6336441, upload-time = "2026-02-11T04:21:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/44/e865ef3986611bb75bfabdf94a590016ea327833f434558801122979cd0e/pillow-12.1.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a285e3eb7a5a45a2ff504e31f4a8d1b12ef62e84e5411c6804a42197c1cf586c", size = 7045383, upload-time = "2026-02-11T04:21:50.015Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/c6/f4fb24268d0c6908b9f04143697ea18b0379490cb74ba9e8d41b898bd005/pillow-12.1.1-cp313-cp313t-win_arm64.whl", hash = "sha256:cc7d296b5ea4d29e6570dabeaed58d31c3fea35a633a69679fb03d7664f43fb3", size = 2456104, upload-time = "2026-02-11T04:21:51.633Z" },
+]
+
+[[package]]
 name = "pipelines"
 version = "0.16.0"
 source = { editable = "packages/pipelines" }
@@ -2530,6 +2562,7 @@ dependencies = [
     { name = "reranking" },
     { name = "retrieval" },
     { name = "rich" },
+    { name = "smolagents" },
     { name = "storage" },
     { name = "typer" },
 ]
@@ -2558,6 +2591,7 @@ requires-dist = [
     { name = "reranking", editable = "packages/reranking" },
     { name = "retrieval", editable = "packages/retrieval" },
     { name = "rich", specifier = ">=13.0.0" },
+    { name = "smolagents", specifier = ">=1.14.0" },
     { name = "storage", editable = "packages/storage" },
     { name = "typer", specifier = ">=0.12.0" },
 ]
@@ -2832,6 +2866,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "smolagents"
+version = "1.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "jinja2" },
+    { name = "pillow" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/bc/ad2f168b82d26597257adb071c51348dd94da0bc29a6cc10ba4c1bee27c8/smolagents-1.22.0.tar.gz", hash = "sha256:5fb66f48e3b3ab5e8defcef577a89d5b6dfa8fcb55fc98a58e156cb3c59eb68f", size = 213047, upload-time = "2025-09-25T08:42:56.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/17/54d7de27b7ac2722ac2c0f452da612bf4af80ae09f90231b44bb7b12b33d/smolagents-1.22.0-py3-none-any.whl", hash = "sha256:5334adb4e7e5814cd814f1d9ad7efa806ef57f53db40635a29d2bd727774c5f5", size = 149836, upload-time = "2025-09-25T08:42:54.205Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `rag-facile` with no arguments now drops directly into the RAG assistant — same UX pattern as `letta`
- `rag-facile chat` registered as an explicit alias in the 🚀 Getting Started help panel
- smolagents `ToolCallingAgent` + `OpenAIServerModel` pointed at Albert API (OpenAI-compatible)
- First `@tool`: `get_ragfacile_config` reads `ragfacile.toml` so the agent can answer config questions without the user having to paste anything
- Workspace auto-detected by walking up from cwd until `ragfacile.toml` is found
- Rich terminal UI: spinner while thinking, Markdown-rendered responses, graceful Ctrl+C
- `verbosity_level=0` suppresses smolagents internal step output — clean UX for lambda devs

## What this PR validates (the 3 spikes)

1. ✅ **Albert API + smolagents tool calling** — `OpenAIServerModel` + `ToolCallingAgent` + Albert endpoint
2. ✅ **Clean terminal output** — smolagents verbosity suppressed, Rich Markdown rendering
3. ✅ **`@tool` callable from agent** — `get_ragfacile_config` proven end-to-end

## Test plan

- [x] `rag-facile --help` → `chat` appears first in 🚀 Getting Started panel
- [x] `rag-facile` (no args, in a workspace) → welcome panel + chat loop starts
- [x] `rag-facile` (no args, outside a workspace) → warning shown, chat still starts
- [x] `rag-facile chat` → same result as above
- [x] "What preset am I using?" → agent calls `get_ragfacile_config`, returns correct value
- [x] `q` / Ctrl+C → exits cleanly with "À bientôt!"
- [x] Bad API key → friendly error, no traceback

## This is PR 1 of 8

Part of the `rag-facile chat` implementation plan. Next: PR 2 — first-run init wizard that creates `.rag-facile/agent/MEMORY.md` and `profile.md`.

👾 Generated with [Letta Code](https://letta.com)