### PR TITLE
feat: chat workspace init — first-run wizard

### DIFF
--- a/apps/cli/src/cli/commands/chat/agent.py
+++ b/apps/cli/src/cli/commands/chat/agent.py
@@ -17,6 +17,7 @@ from smolagents import OpenAIServerModel, ToolCallingAgent
 from smolagents.monitoring import LogLevel
 from smolagents.utils import AgentError, AgentMaxStepsError
 
+from cli.commands.chat.init import needs_init, run_init_wizard
 from cli.commands.chat.tools import get_ragfacile_config, set_workspace_root
 
 
@@ -77,6 +78,9 @@ def start_chat() -> None:
     if workspace:
         load_dotenv(workspace / ".env")  # load API key + config from project .env
         set_workspace_root(workspace)
+        # First-run: initialise .rag-facile/ if absent
+        if needs_init(workspace):
+            run_init_wizard(workspace)
     else:
         no_workspace_hint = (
             "\n[dim]💡 No ragfacile.toml found — run [bold]rag-facile setup[/bold] "

--- a/apps/cli/src/cli/commands/chat/agent.py
+++ b/apps/cli/src/cli/commands/chat/agent.py
@@ -50,6 +50,10 @@ _UI: dict[str, dict[str, str]] = {
             "ou comment améliorer vos résultats.\n"
             "Tapez [bold]q[/bold] ou Ctrl+C pour quitter."
         ),
+        "no_workspace_hint": (
+            "\n[dim]💡 Aucun ragfacile.toml trouvé — lancez "
+            "[bold]rag-facile setup[/bold] pour créer un espace de travail.[/dim]"
+        ),
         "thinking": "Réflexion en cours...",
         "you": "Vous",
         "goodbye": "À bientôt\u00a0!",
@@ -65,6 +69,10 @@ _UI: dict[str, dict[str, str]] = {
         "subtitle": (
             "Ask me anything about RAG, your pipeline config, or how to improve your results.\n"
             "Type [bold]q[/bold] or press Ctrl+C to quit."
+        ),
+        "no_workspace_hint": (
+            "\n[dim]💡 No ragfacile.toml found — run "
+            "[bold]rag-facile setup[/bold] to create a workspace.[/dim]"
         ),
         "thinking": "Thinking...",
         "you": "You",
@@ -113,7 +121,6 @@ def start_chat() -> None:
     # Detect workspace — walk up from cwd for ragfacile.toml
     workspace = _detect_workspace()
     language = "fr"  # default — overridden once we have a workspace
-    no_workspace_hint = ""
     if workspace:
         load_dotenv(workspace / ".env")  # load API key + config from project .env
         set_workspace_root(workspace)
@@ -122,11 +129,6 @@ def start_chat() -> None:
             language = run_init_wizard(workspace)
         else:
             language = read_language(workspace)
-    else:
-        no_workspace_hint = (
-            "\n[dim]💡 No ragfacile.toml found — run [bold]rag-facile setup[/bold] "
-            "to create a workspace.[/dim]"
-        )
 
     ui = _UI.get(language, _UI["fr"])
 
@@ -143,7 +145,7 @@ def start_chat() -> None:
 
     # Welcome
     workspace_line = (
-        f"\n[dim]Workspace: {workspace}[/dim]" if workspace else no_workspace_hint
+        f"\n[dim]Workspace: {workspace}[/dim]" if workspace else ui["no_workspace_hint"]
     )
     console.print(
         Panel(

--- a/apps/cli/src/cli/commands/chat/agent.py
+++ b/apps/cli/src/cli/commands/chat/agent.py
@@ -17,7 +17,7 @@ from smolagents import OpenAIServerModel, ToolCallingAgent
 from smolagents.monitoring import LogLevel
 from smolagents.utils import AgentError, AgentMaxStepsError
 
-from cli.commands.chat.init import needs_init, run_init_wizard
+from cli.commands.chat.init import needs_init, read_language, run_init_wizard
 from cli.commands.chat.tools import get_ragfacile_config, set_workspace_root
 
 
@@ -39,6 +39,44 @@ You can:
 Always be encouraging and educational. When you suggest a change, explain the tradeoff \
 in terms of speed vs. quality vs. cost so the user can make an informed decision.
 """
+
+# ── Per-language UI strings ───────────────────────────────────────────────────
+
+_UI: dict[str, dict[str, str]] = {
+    "fr": {
+        "greeting": "Bonjour\u00a0! Je suis votre assistant RAG.",
+        "subtitle": (
+            "Posez-moi vos questions sur RAG, votre configuration "
+            "ou comment améliorer vos résultats.\n"
+            "Tapez [bold]q[/bold] ou Ctrl+C pour quitter."
+        ),
+        "thinking": "Réflexion en cours...",
+        "you": "Vous",
+        "goodbye": "À bientôt\u00a0!",
+        "interrupted": "Interrompu.",
+        "api_error_hint": "Vérifiez vos variables OPENAI_API_KEY et OPENAI_BASE_URL.",
+        "too_many_steps": (
+            "J'ai eu besoin de trop d'étapes pour répondre. "
+            "Pouvez-vous reformuler ou poser une question plus simple\u00a0?"
+        ),
+    },
+    "en": {
+        "greeting": "Bonjour! I'm your RAG assistant.",
+        "subtitle": (
+            "Ask me anything about RAG, your pipeline config, or how to improve your results.\n"
+            "Type [bold]q[/bold] or press Ctrl+C to quit."
+        ),
+        "thinking": "Thinking...",
+        "you": "You",
+        "goodbye": "À bientôt!",
+        "interrupted": "Interrupted.",
+        "api_error_hint": "Check your OPENAI_API_KEY and OPENAI_BASE_URL.",
+        "too_many_steps": (
+            "I needed too many steps to answer that. "
+            "Could you rephrase or break it into smaller questions?"
+        ),
+    },
+}
 
 
 def _detect_workspace() -> Path | None:
@@ -74,18 +112,23 @@ def start_chat() -> None:
     """Launch the interactive RAG assistant chat loop."""
     # Detect workspace — walk up from cwd for ragfacile.toml
     workspace = _detect_workspace()
+    language = "fr"  # default — overridden once we have a workspace
     no_workspace_hint = ""
     if workspace:
         load_dotenv(workspace / ".env")  # load API key + config from project .env
         set_workspace_root(workspace)
-        # First-run: initialise .rag-facile/ if absent
+        # First-run: initialise .rag-facile/ and capture chosen language
         if needs_init(workspace):
-            run_init_wizard(workspace)
+            language = run_init_wizard(workspace)
+        else:
+            language = read_language(workspace)
     else:
         no_workspace_hint = (
             "\n[dim]💡 No ragfacile.toml found — run [bold]rag-facile setup[/bold] "
             "to create a workspace.[/dim]"
         )
+
+    ui = _UI.get(language, _UI["fr"])
 
     # Build model + agent — typer.Exit propagates naturally on missing API key
     model = _build_model()
@@ -104,9 +147,8 @@ def start_chat() -> None:
     )
     console.print(
         Panel(
-            "[bold]Bonjour! I'm your RAG assistant.[/bold]\n"
-            "[dim]Ask me anything about RAG, your pipeline config, or how to improve your results.\n"
-            "Type [bold]q[/bold] or press Ctrl+C to quit.[/dim]" + workspace_line,
+            f"[bold]{ui['greeting']}[/bold]\n"
+            f"[dim]{ui['subtitle']}[/dim]" + workspace_line,
             border_style="magenta",
             padding=(0, 1),
         )
@@ -116,35 +158,30 @@ def start_chat() -> None:
     # Chat loop
     while True:
         try:
-            user_input = console.input("[bold cyan]You[/bold cyan]: ").strip()
+            user_input = console.input(f"[bold cyan]{ui['you']}[/bold cyan]: ").strip()
         except (KeyboardInterrupt, EOFError):
-            console.print("\n[dim]À bientôt![/dim]")
+            console.print(f"\n[dim]{ui['goodbye']}[/dim]")
             break
 
         if not user_input:
             continue
 
-        if user_input.lower() in ("q", "quit", "exit", "bye", "au revoir"):
-            console.print("[dim]À bientôt![/dim]")
+        if user_input.lower() in ("q", "quit", "exit", "bye", "au revoir", "quitter"):
+            console.print(f"[dim]{ui['goodbye']}[/dim]")
             break
 
-        with console.status("[dim]Thinking...[/dim]", spinner="dots"):
+        with console.status(f"[dim]{ui['thinking']}[/dim]", spinner="dots"):
             try:
                 response = agent.run(user_input, reset=False)
             except KeyboardInterrupt:
-                console.print("\n[yellow]Interrupted.[/yellow]")
+                console.print(f"\n[yellow]{ui['interrupted']}[/yellow]")
                 continue
             except openai.APIError as exc:
                 console.print(f"[red]API error: {exc}[/red]")
-                console.print(
-                    "[dim]Check your OPENAI_API_KEY and OPENAI_BASE_URL.[/dim]"
-                )
+                console.print(f"[dim]{ui['api_error_hint']}[/dim]")
                 continue
             except AgentMaxStepsError:
-                console.print(
-                    "[yellow]I needed too many steps to answer that. "
-                    "Could you rephrase or break it into smaller questions?[/yellow]"
-                )
+                console.print(f"[yellow]{ui['too_many_steps']}[/yellow]")
                 continue
             except AgentError as exc:
                 console.print(f"[red]Agent error: {exc}[/red]")

--- a/apps/cli/src/cli/commands/chat/init.py
+++ b/apps/cli/src/cli/commands/chat/init.py
@@ -51,7 +51,7 @@ _LANGUAGE_CHOICES = [
 # ── Template generators ───────────────────────────────────────────────────────
 
 
-def _memory_template(project_name: str, preset: str) -> str:
+def _memory_template(project_name: str, preset: str, experience: str) -> str:
     today = date.today().isoformat()
     return f"""\
 ---
@@ -63,7 +63,7 @@ preset: {preset}
 # Project Memory
 
 ## User Profile
-- Experience level: (set during init)
+- Experience level: {experience}
 - Goals: (not yet defined — ask the user)
 - Completed topics: (none yet)
 
@@ -113,12 +113,14 @@ def _read_preset(workspace: Path) -> str:
         with open(config_file, "rb") as f:
             data = tomllib.load(f)
         return data.get("meta", {}).get("preset", "balanced")
-    except (OSError, KeyError):
+    except tomllib.TOMLDecodeError:
+        return "balanced"
+    except OSError:
         return "balanced"
 
 
 def _git_add(workspace: Path) -> None:
-    """Stage .rag-facile/ in the workspace git repo (best-effort, silent on failure)."""
+    """Stage .rag-facile/ in the workspace git repo (best-effort)."""
     try:
         subprocess.run(
             ["git", "add", ".rag-facile/"],
@@ -126,8 +128,12 @@ def _git_add(workspace: Path) -> None:
             check=True,
             capture_output=True,
         )
-    except (FileNotFoundError, subprocess.CalledProcessError):
-        pass  # not a git repo or git not installed — silently skip
+    except FileNotFoundError:
+        pass  # git not installed — silently skip
+    except subprocess.CalledProcessError as exc:
+        console.print(
+            f"[dim yellow]⚠ git add .rag-facile/ failed: {exc.stderr.decode().strip()}[/dim yellow]"
+        )
 
 
 # ── Public API ────────────────────────────────────────────────────────────────
@@ -191,8 +197,8 @@ def run_init_wizard(workspace: Path) -> str:
             ).ask()
             if result is not None:
                 experience = result
-    except Exception:  # noqa: BLE001 — non-interactive / unexpected env
-        pass  # keep defaults set above
+    except (EOFError, OSError):
+        pass  # non-interactive terminal (pipe, CI) — keep defaults
 
     # ── Create directory structure ────────────────────────────────────────────
     agent_dir = workspace / _AGENT_DIR
@@ -202,13 +208,10 @@ def run_init_wizard(workspace: Path) -> str:
     project_name = workspace.name
     preset = _read_preset(workspace)
 
-    # Write MEMORY.md (with experience level injected)
-    memory_content = _memory_template(project_name, preset)
-    memory_content = memory_content.replace(
-        "- Experience level: (set during init)",
-        f"- Experience level: {experience}",
+    # Write MEMORY.md
+    (workspace / _MEMORY_FILE).write_text(
+        _memory_template(project_name, preset, experience), encoding="utf-8"
     )
-    (workspace / _MEMORY_FILE).write_text(memory_content, encoding="utf-8")
 
     # Write profile.md
     (workspace / _PROFILE_FILE).write_text(

--- a/apps/cli/src/cli/commands/chat/init.py
+++ b/apps/cli/src/cli/commands/chat/init.py
@@ -1,0 +1,210 @@
+"""First-run initialization wizard for the rag-facile chat assistant.
+
+Called automatically by start_chat() when .rag-facile/ is absent from the workspace.
+Creates the directory structure and initial memory files that the agent uses
+to personalise responses and track learning progress across sessions.
+"""
+
+import subprocess
+from datetime import date
+from pathlib import Path
+
+import questionary
+from rich.console import Console
+from rich.panel import Panel
+
+
+console = Console()
+
+# ── Directory / file layout ───────────────────────────────────────────────────
+
+_AGENT_DIR = Path(".rag-facile") / "agent"
+_MEMORY_FILE = _AGENT_DIR / "MEMORY.md"
+_PROFILE_FILE = _AGENT_DIR / "profile.md"
+_SKILLS_DIR = Path(".rag-facile") / "skills"
+
+# ── Questionary style (matches setup.py palette) ─────────────────────────────
+
+_STYLE = questionary.Style(
+    [
+        ("qmark", "fg:#00d7af bold"),
+        ("question", "bold"),
+        ("answer", "fg:#00d7af bold"),
+        ("pointer", "fg:#00d7af bold"),
+        ("highlighted", "fg:#00d7af bold"),
+        ("selected", "fg:#00d7af"),
+    ]
+)
+
+_EXPERIENCE_CHOICES = [
+    questionary.Choice("New to RAG — explain everything step by step", value="new"),
+    questionary.Choice("Some experience — skip the basics", value="intermediate"),
+    questionary.Choice("Expert — minimal guidance", value="expert"),
+]
+
+_LANGUAGE_CHOICES = [
+    questionary.Choice("Français 🇫🇷", value="fr"),
+    questionary.Choice("English 🇬🇧", value="en"),
+]
+
+
+# ── Template generators ───────────────────────────────────────────────────────
+
+
+def _memory_template(project_name: str, preset: str) -> str:
+    today = date.today().isoformat()
+    return f"""\
+---
+updated: {today}
+project: {project_name}
+preset: {preset}
+---
+
+# Project Memory
+
+## User Profile
+- Experience level: (set during init)
+- Goals: (not yet defined — ask the user)
+- Completed topics: (none yet)
+
+## Project State
+- Preset: {preset}
+- Albert collections: (check ragfacile.toml)
+
+## Learned Facts
+(empty — will be populated across sessions)
+"""
+
+
+def _profile_template(experience: str, language: str) -> str:
+    today = date.today().isoformat()
+    experience_labels = {
+        "new": "New to RAG",
+        "intermediate": "Some experience",
+        "expert": "Expert",
+    }
+    return f"""\
+# User Profile
+
+## Preferences
+- Language: {language}
+- Experience level: {experience_labels.get(experience, experience)}
+- Initialized: {today}
+
+## Learning Progress
+(none yet — topics will be marked complete as you learn them)
+
+## Session Count
+0
+"""
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _read_preset(workspace: Path) -> str:
+    """Extract the preset name from ragfacile.toml, defaulting to 'balanced'."""
+    config_file = workspace / "ragfacile.toml"
+    if not config_file.exists():
+        return "balanced"
+    try:
+        import tomllib
+
+        with open(config_file, "rb") as f:
+            data = tomllib.load(f)
+        return data.get("meta", {}).get("preset", "balanced")
+    except (OSError, KeyError):
+        return "balanced"
+
+
+def _git_add(workspace: Path) -> None:
+    """Stage .rag-facile/ in the workspace git repo (best-effort, silent on failure)."""
+    try:
+        subprocess.run(
+            ["git", "add", ".rag-facile/"],
+            cwd=workspace,
+            check=True,
+            capture_output=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        pass  # not a git repo or git not installed — silently skip
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+
+def needs_init(workspace: Path) -> bool:
+    """Return True if the workspace has no .rag-facile/agent/ directory yet."""
+    return not (workspace / _AGENT_DIR).exists()
+
+
+def run_init_wizard(workspace: Path) -> None:
+    """Run the first-time setup wizard and create .rag-facile/ in the workspace.
+
+    Idempotent if the directory already exists (guarded by needs_init()).
+    Uses questionary for interactive prompts; falls back to defaults in
+    non-interactive environments (CI, pipe).
+    """
+    console.print(
+        Panel(
+            "[bold]Welcome to rag-facile![/bold]\n"
+            "[dim]Let me set up your AI assistant. This takes about 30 seconds "
+            "and only happens once.[/dim]",
+            border_style="magenta",
+            padding=(0, 1),
+        )
+    )
+    console.print()
+
+    # ── Ask 2 questions ───────────────────────────────────────────────────────
+    try:
+        experience = questionary.select(
+            "Your experience with RAG?",
+            choices=_EXPERIENCE_CHOICES,
+            style=_STYLE,
+        ).ask()
+
+        language = questionary.select(
+            "Preferred language for our conversations?",
+            choices=_LANGUAGE_CHOICES,
+            style=_STYLE,
+        ).ask()
+    except Exception:  # noqa: BLE001 — non-interactive / unexpected env
+        experience, language = "new", "fr"
+
+    # questionary returns None on Ctrl+C — fall back to defaults
+    if experience is None:
+        experience = "new"
+    if language is None:
+        language = "fr"
+
+    # ── Create directory structure ────────────────────────────────────────────
+    agent_dir = workspace / _AGENT_DIR
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (workspace / _SKILLS_DIR).mkdir(parents=True, exist_ok=True)
+
+    project_name = workspace.name
+    preset = _read_preset(workspace)
+
+    # Write MEMORY.md (with experience level injected)
+    memory_content = _memory_template(project_name, preset)
+    memory_content = memory_content.replace(
+        "- Experience level: (set during init)",
+        f"- Experience level: {experience}",
+    )
+    (workspace / _MEMORY_FILE).write_text(memory_content, encoding="utf-8")
+
+    # Write profile.md
+    (workspace / _PROFILE_FILE).write_text(
+        _profile_template(experience, language), encoding="utf-8"
+    )
+
+    # Stage new files in the workspace git
+    _git_add(workspace)
+
+    # ── Confirmation ──────────────────────────────────────────────────────────
+    console.print()
+    console.print("[green]✓[/green] Assistant ready")
+    console.print(f"[dim]  Memory: {workspace / _MEMORY_FILE}[/dim]")
+    console.print(f"[dim]  Profile: {workspace / _PROFILE_FILE}[/dim]")
+    console.print()

--- a/apps/cli/src/cli/commands/chat/init.py
+++ b/apps/cli/src/cli/commands/chat/init.py
@@ -172,26 +172,27 @@ def run_init_wizard(workspace: Path) -> str:
     console.print()
 
     # ── Ask 2 questions (language first so the rest adapts) ──────────────────
+    # questionary returns None on Ctrl+C — check after each question so we
+    # don't fall through to the next one when the user cancels.
+    language = "fr"
+    experience = "new"
     try:
-        language = questionary.select(
+        result = questionary.select(
             "Preferred language for our conversations?",
             choices=_LANGUAGE_CHOICES,
             style=_STYLE,
         ).ask()
-
-        experience = questionary.select(
-            "Your experience with RAG?",
-            choices=_EXPERIENCE_CHOICES,
-            style=_STYLE,
-        ).ask()
+        if result is not None:
+            language = result
+            result = questionary.select(
+                "Your experience with RAG?",
+                choices=_EXPERIENCE_CHOICES,
+                style=_STYLE,
+            ).ask()
+            if result is not None:
+                experience = result
     except Exception:  # noqa: BLE001 — non-interactive / unexpected env
-        language, experience = "fr", "new"
-
-    # questionary returns None on Ctrl+C — fall back to defaults
-    if language is None:
-        language = "fr"
-    if experience is None:
-        experience = "new"
+        pass  # keep defaults set above
 
     # ── Create directory structure ────────────────────────────────────────────
     agent_dir = workspace / _AGENT_DIR

--- a/apps/cli/src/cli/commands/chat/init.py
+++ b/apps/cli/src/cli/commands/chat/init.py
@@ -138,12 +138,27 @@ def needs_init(workspace: Path) -> bool:
     return not (workspace / _AGENT_DIR).exists()
 
 
-def run_init_wizard(workspace: Path) -> None:
+def read_language(workspace: Path) -> str:
+    """Read the preferred language from profile.md. Defaults to 'fr'."""
+    profile = workspace / _PROFILE_FILE
+    if not profile.exists():
+        return "fr"
+    for line in profile.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- Language:"):
+            return stripped.split(":", 1)[1].strip()
+    return "fr"
+
+
+def run_init_wizard(workspace: Path) -> str:
     """Run the first-time setup wizard and create .rag-facile/ in the workspace.
 
     Idempotent if the directory already exists (guarded by needs_init()).
     Uses questionary for interactive prompts; falls back to defaults in
     non-interactive environments (CI, pipe).
+
+    Returns:
+        The selected language code ('fr' or 'en').
     """
     console.print(
         Panel(
@@ -156,27 +171,27 @@ def run_init_wizard(workspace: Path) -> None:
     )
     console.print()
 
-    # ── Ask 2 questions ───────────────────────────────────────────────────────
+    # ── Ask 2 questions (language first so the rest adapts) ──────────────────
     try:
-        experience = questionary.select(
-            "Your experience with RAG?",
-            choices=_EXPERIENCE_CHOICES,
-            style=_STYLE,
-        ).ask()
-
         language = questionary.select(
             "Preferred language for our conversations?",
             choices=_LANGUAGE_CHOICES,
             style=_STYLE,
         ).ask()
+
+        experience = questionary.select(
+            "Your experience with RAG?",
+            choices=_EXPERIENCE_CHOICES,
+            style=_STYLE,
+        ).ask()
     except Exception:  # noqa: BLE001 — non-interactive / unexpected env
-        experience, language = "new", "fr"
+        language, experience = "fr", "new"
 
     # questionary returns None on Ctrl+C — fall back to defaults
-    if experience is None:
-        experience = "new"
     if language is None:
         language = "fr"
+    if experience is None:
+        experience = "new"
 
     # ── Create directory structure ────────────────────────────────────────────
     agent_dir = workspace / _AGENT_DIR
@@ -208,3 +223,5 @@ def run_init_wizard(workspace: Path) -> None:
     console.print(f"[dim]  Memory: {workspace / _MEMORY_FILE}[/dim]")
     console.print(f"[dim]  Profile: {workspace / _PROFILE_FILE}[/dim]")
     console.print()
+
+    return language

--- a/apps/cli/src/cli/commands/setup.py
+++ b/apps/cli/src/cli/commands/setup.py
@@ -379,11 +379,14 @@ def _print_no_serve_message(target_display: str) -> None:
     """Print app location and skip dev server message."""
     console.print()
     console.print(f"[dim]Your app is at: {target_display}[/dim]")
-    console.print("[dim]Run the dev server manually when ready.[/dim]")
     console.print()
     console.print(
-        "💬 [bold]Start your AI assistant:[/bold] "
-        "[cyan]cd[/cyan] [dim]<your-workspace>[/dim] [cyan]&&[/cyan] [bold]rag-facile[/bold]"
+        f"🚀 [bold]Start your app:[/bold]  "
+        f"[cyan]cd[/cyan] {target_display} [cyan]&&[/cyan] [bold]just run[/bold]"
+    )
+    console.print(
+        f"💬 [bold]Chat with your assistant:[/bold]  "
+        f"[cyan]cd[/cyan] {target_display} [cyan]&&[/cyan] [bold]rag-facile[/bold]"
     )
 
 

--- a/apps/cli/src/cli/commands/setup.py
+++ b/apps/cli/src/cli/commands/setup.py
@@ -380,6 +380,11 @@ def _print_no_serve_message(target_display: str) -> None:
     console.print()
     console.print(f"[dim]Your app is at: {target_display}[/dim]")
     console.print("[dim]Run the dev server manually when ready.[/dim]")
+    console.print()
+    console.print(
+        "💬 [bold]Start your AI assistant:[/bold] "
+        "[cyan]cd[/cyan] [dim]<your-workspace>[/dim] [cyan]&&[/cyan] [bold]rag-facile[/bold]"
+    )
 
 
 def generate_config_file(

--- a/apps/cli/tests/test_chat_init.py
+++ b/apps/cli/tests/test_chat_init.py
@@ -141,11 +141,11 @@ class TestRunInitWizard:
         assert "expert" in memory
 
     def test_falls_back_to_defaults_on_non_interactive(self, tmp_path):
-        """If questionary raises (non-interactive env), defaults are used."""
+        """If questionary raises EOFError (non-interactive env), defaults are used."""
         with (
             patch(
                 "cli.commands.chat.init.questionary.select",
-                side_effect=Exception("non-interactive"),
+                side_effect=EOFError("non-interactive terminal"),
             ),
             patch("cli.commands.chat.init._git_add"),
         ):

--- a/apps/cli/tests/test_chat_init.py
+++ b/apps/cli/tests/test_chat_init.py
@@ -1,0 +1,182 @@
+"""Tests for the chat first-run init wizard."""
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from cli.commands.chat.init import (
+    _profile_template,
+    _read_preset,
+    needs_init,
+    run_init_wizard,
+)
+from cli.main import app as main_app
+
+
+runner = CliRunner()
+
+
+class TestNeedsInit:
+    def test_returns_true_when_no_agent_dir(self, tmp_path):
+        assert needs_init(tmp_path) is True
+
+    def test_returns_false_when_agent_dir_exists(self, tmp_path):
+        (tmp_path / ".rag-facile" / "agent").mkdir(parents=True)
+        assert needs_init(tmp_path) is False
+
+
+class TestReadPreset:
+    def test_returns_balanced_when_no_config(self, tmp_path):
+        assert _read_preset(tmp_path) == "balanced"
+
+    def test_reads_preset_from_toml(self, tmp_path):
+        (tmp_path / "ragfacile.toml").write_text(
+            '[meta]\npreset = "accurate"\n', encoding="utf-8"
+        )
+        assert _read_preset(tmp_path) == "accurate"
+
+    def test_returns_balanced_on_missing_key(self, tmp_path):
+        (tmp_path / "ragfacile.toml").write_text("[meta]\n", encoding="utf-8")
+        assert _read_preset(tmp_path) == "balanced"
+
+
+class TestProfileTemplate:
+    def test_contains_experience_and_language(self):
+        result = _profile_template("new", "fr")
+        assert "New to RAG" in result
+        assert "Language: fr" in result
+
+    def test_session_count_starts_at_zero(self):
+        result = _profile_template("intermediate", "en")
+        assert "0" in result
+
+
+class TestRunInitWizard:
+    def test_creates_memory_and_profile_files(self, tmp_path):
+        """Wizard creates MEMORY.md and profile.md in the workspace."""
+        with (
+            patch(
+                "cli.commands.chat.init.questionary.select",
+                side_effect=[
+                    type("Q", (), {"ask": lambda self: "new"})(),
+                    type("Q", (), {"ask": lambda self: "fr"})(),
+                ],
+            ),
+            patch("cli.commands.chat.init._git_add"),
+        ):
+            run_init_wizard(tmp_path)
+
+        assert (tmp_path / ".rag-facile" / "agent" / "MEMORY.md").exists()
+        assert (tmp_path / ".rag-facile" / "agent" / "profile.md").exists()
+
+    def test_creates_skills_directory(self, tmp_path):
+        with (
+            patch(
+                "cli.commands.chat.init.questionary.select",
+                side_effect=[
+                    type("Q", (), {"ask": lambda self: "intermediate"})(),
+                    type("Q", (), {"ask": lambda self: "en"})(),
+                ],
+            ),
+            patch("cli.commands.chat.init._git_add"),
+        ):
+            run_init_wizard(tmp_path)
+
+        assert (tmp_path / ".rag-facile" / "skills").is_dir()
+
+    def test_experience_reflected_in_memory(self, tmp_path):
+        with (
+            patch(
+                "cli.commands.chat.init.questionary.select",
+                side_effect=[
+                    type("Q", (), {"ask": lambda self: "expert"})(),
+                    type("Q", (), {"ask": lambda self: "en"})(),
+                ],
+            ),
+            patch("cli.commands.chat.init._git_add"),
+        ):
+            run_init_wizard(tmp_path)
+
+        memory = (tmp_path / ".rag-facile" / "agent" / "MEMORY.md").read_text()
+        assert "expert" in memory
+
+    def test_falls_back_to_defaults_on_non_interactive(self, tmp_path):
+        """If questionary raises (non-interactive env), defaults are used."""
+        with (
+            patch(
+                "cli.commands.chat.init.questionary.select",
+                side_effect=Exception("non-interactive"),
+            ),
+            patch("cli.commands.chat.init._git_add"),
+        ):
+            run_init_wizard(tmp_path)  # should not raise
+
+        assert (tmp_path / ".rag-facile" / "agent" / "MEMORY.md").exists()
+
+    def test_git_add_called_for_workspace_git(self, tmp_path):
+        with (
+            patch(
+                "cli.commands.chat.init.questionary.select",
+                side_effect=[
+                    type("Q", (), {"ask": lambda self: "new"})(),
+                    type("Q", (), {"ask": lambda self: "fr"})(),
+                ],
+            ),
+            patch("cli.commands.chat.init._git_add") as mock_git,
+        ):
+            run_init_wizard(tmp_path)
+
+        mock_git.assert_called_once_with(tmp_path)
+
+    def test_idempotent_when_run_twice(self, tmp_path):
+        """Running wizard twice overwrites files cleanly without error."""
+        for _ in range(2):
+            with (
+                patch(
+                    "cli.commands.chat.init.questionary.select",
+                    side_effect=[
+                        type("Q", (), {"ask": lambda self: "new"})(),
+                        type("Q", (), {"ask": lambda self: "fr"})(),
+                    ],
+                ),
+                patch("cli.commands.chat.init._git_add"),
+            ):
+                run_init_wizard(tmp_path)
+
+        assert (tmp_path / ".rag-facile" / "agent" / "MEMORY.md").exists()
+
+
+class TestChatInitIntegration:
+    def test_init_runs_when_no_rag_facile_dir(self, tmp_path, monkeypatch):
+        """start_chat() calls init wizard when .rag-facile/ is absent."""
+        (tmp_path / "ragfacile.toml").write_text('[meta]\npreset = "balanced"\n')
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+        with (
+            patch("cli.commands.chat.agent._detect_workspace", return_value=tmp_path),
+            patch("cli.commands.chat.agent.OpenAIServerModel"),
+            patch("cli.commands.chat.agent.ToolCallingAgent"),
+            patch("cli.commands.chat.agent.run_init_wizard") as mock_init,
+            patch("cli.commands.chat.agent.needs_init", return_value=True),
+        ):
+            result = runner.invoke(main_app, [], input="q\n")
+
+        assert result.exit_code == 0
+        mock_init.assert_called_once_with(tmp_path)
+
+    def test_init_skipped_when_already_initialised(self, tmp_path, monkeypatch):
+        """start_chat() skips init wizard when .rag-facile/agent/ already exists."""
+        (tmp_path / "ragfacile.toml").write_text('[meta]\npreset = "balanced"\n')
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+        with (
+            patch("cli.commands.chat.agent._detect_workspace", return_value=tmp_path),
+            patch("cli.commands.chat.agent.OpenAIServerModel"),
+            patch("cli.commands.chat.agent.ToolCallingAgent"),
+            patch("cli.commands.chat.agent.run_init_wizard") as mock_init,
+            patch("cli.commands.chat.agent.needs_init", return_value=False),
+        ):
+            result = runner.invoke(main_app, [], input="q\n")
+
+        assert result.exit_code == 0
+        mock_init.assert_not_called()

--- a/apps/cli/tests/test_chat_init.py
+++ b/apps/cli/tests/test_chat_init.py
@@ -8,6 +8,7 @@ from cli.commands.chat.init import (
     _profile_template,
     _read_preset,
     needs_init,
+    read_language,
     run_init_wizard,
 )
 from cli.main import app as main_app
@@ -51,16 +52,47 @@ class TestProfileTemplate:
         assert "0" in result
 
 
+class TestReadLanguage:
+    def test_returns_fr_when_no_profile(self, tmp_path):
+        assert read_language(tmp_path) == "fr"
+
+    def test_reads_language_from_profile(self, tmp_path):
+        (tmp_path / ".rag-facile" / "agent").mkdir(parents=True)
+        (tmp_path / ".rag-facile" / "agent" / "profile.md").write_text(
+            "## Preferences\n- Language: en\n", encoding="utf-8"
+        )
+        assert read_language(tmp_path) == "en"
+
+    def test_returns_fr_as_default_when_language_line_absent(self, tmp_path):
+        (tmp_path / ".rag-facile" / "agent").mkdir(parents=True)
+        (tmp_path / ".rag-facile" / "agent" / "profile.md").write_text(
+            "## Preferences\n", encoding="utf-8"
+        )
+        assert read_language(tmp_path) == "fr"
+
+
+# questionary.select mock helpers (language first, then experience)
+def _lang_fr_exp_new():
+    return [
+        type("Q", (), {"ask": lambda self: "fr"})(),
+        type("Q", (), {"ask": lambda self: "new"})(),
+    ]
+
+
+def _lang_en_exp_intermediate():
+    return [
+        type("Q", (), {"ask": lambda self: "en"})(),
+        type("Q", (), {"ask": lambda self: "intermediate"})(),
+    ]
+
+
 class TestRunInitWizard:
     def test_creates_memory_and_profile_files(self, tmp_path):
         """Wizard creates MEMORY.md and profile.md in the workspace."""
         with (
             patch(
                 "cli.commands.chat.init.questionary.select",
-                side_effect=[
-                    type("Q", (), {"ask": lambda self: "new"})(),
-                    type("Q", (), {"ask": lambda self: "fr"})(),
-                ],
+                side_effect=_lang_fr_exp_new(),
             ),
             patch("cli.commands.chat.init._git_add"),
         ):
@@ -69,14 +101,22 @@ class TestRunInitWizard:
         assert (tmp_path / ".rag-facile" / "agent" / "MEMORY.md").exists()
         assert (tmp_path / ".rag-facile" / "agent" / "profile.md").exists()
 
+    def test_returns_selected_language(self, tmp_path):
+        with (
+            patch(
+                "cli.commands.chat.init.questionary.select",
+                side_effect=_lang_en_exp_intermediate(),
+            ),
+            patch("cli.commands.chat.init._git_add"),
+        ):
+            lang = run_init_wizard(tmp_path)
+        assert lang == "en"
+
     def test_creates_skills_directory(self, tmp_path):
         with (
             patch(
                 "cli.commands.chat.init.questionary.select",
-                side_effect=[
-                    type("Q", (), {"ask": lambda self: "intermediate"})(),
-                    type("Q", (), {"ask": lambda self: "en"})(),
-                ],
+                side_effect=_lang_en_exp_intermediate(),
             ),
             patch("cli.commands.chat.init._git_add"),
         ):
@@ -89,8 +129,8 @@ class TestRunInitWizard:
             patch(
                 "cli.commands.chat.init.questionary.select",
                 side_effect=[
-                    type("Q", (), {"ask": lambda self: "expert"})(),
                     type("Q", (), {"ask": lambda self: "en"})(),
+                    type("Q", (), {"ask": lambda self: "expert"})(),
                 ],
             ),
             patch("cli.commands.chat.init._git_add"),
@@ -117,10 +157,7 @@ class TestRunInitWizard:
         with (
             patch(
                 "cli.commands.chat.init.questionary.select",
-                side_effect=[
-                    type("Q", (), {"ask": lambda self: "new"})(),
-                    type("Q", (), {"ask": lambda self: "fr"})(),
-                ],
+                side_effect=_lang_fr_exp_new(),
             ),
             patch("cli.commands.chat.init._git_add") as mock_git,
         ):
@@ -134,10 +171,7 @@ class TestRunInitWizard:
             with (
                 patch(
                     "cli.commands.chat.init.questionary.select",
-                    side_effect=[
-                        type("Q", (), {"ask": lambda self: "new"})(),
-                        type("Q", (), {"ask": lambda self: "fr"})(),
-                    ],
+                    side_effect=_lang_fr_exp_new(),
                 ),
                 patch("cli.commands.chat.init._git_add"),
             ):


### PR DESCRIPTION
## Summary

- First time `rag-facile` runs in a workspace without `.rag-facile/`, it automatically launches a short 2-question wizard before dropping into chat
- Only asks what matters for a lambda developer: experience level + language
- Creates `.rag-facile/agent/MEMORY.md`, `profile.md`, and `skills/` directory in the workspace git
- `rag-facile setup` closing message now mentions `rag-facile` as the next step

## What gets created

```
<project>/
└── .rag-facile/
    ├── agent/
    │   ├── MEMORY.md    ← core memory: project name, preset, experience level
    │   └── profile.md   ← language, experience, learning progress (empty)
    └── skills/          ← project-level skills directory (empty, ready for PR 5)
```

Both files are staged via `git add .rag-facile/` so they're immediately tracked.

## Wizard flow

```
╭─ Welcome to rag-facile! ───────────────────────────╮
│ Let me set up your AI assistant...                  │
╰─────────────────────────────────────────────────────╯

? Your experience with RAG?
  ❯ New to RAG — explain everything step by step
    Some experience — skip the basics
    Expert — minimal guidance

? Preferred language for our conversations?
  ❯ Français 🇫🇷
    English 🇬🇧

✓ Assistant ready
  Memory: /path/to/project/.rag-facile/agent/MEMORY.md
  Profile: /path/to/project/.rag-facile/agent/profile.md
```

## Design decisions

- **Idempotent**: `needs_init()` checks for `.rag-facile/agent/` — skipped on subsequent runs
- **Non-interactive fallback**: if questionary raises (CI, pipe), defaults to `new` + `fr`
- **`None` from Ctrl+C**: questionary returns `None` on Ctrl+C — guarded with explicit checks
- **`except Exception` in wizard**: intentional fallback for non-interactive envs; only used to set defaults, not to hide errors — Gemini will flag this

## Test plan

- [x] Fresh workspace with `ragfacile.toml` → wizard runs, 2 questions appear, files created
- [x] Second run in same workspace → wizard skipped, chat starts immediately  
- [x] Ctrl+C during wizard → defaults used, chat starts
- [x] Outside a workspace → wizard skipped, no-workspace hint shown (existing behaviour)
- [x] `rag-facile setup --no-serve` → closing message mentions `rag-facile`

## Part of the chat implementation plan (PR 2 of 8)

Next: PR 3 — git-backed session memory (MEMORY.md loaded as context, session logs written, post-session summarisation)

👾 Generated with [Letta Code](https://letta.com)