### PR TITLE
feat: collections and dataset generation as chat capabilities

### DIFF
--- a/apps/cli/src/cli/commands/chat/agent.py
+++ b/apps/cli/src/cli/commands/chat/agent.py
@@ -39,6 +39,8 @@ from cli.commands.chat.tools import (
     get_docs,
     get_ragfacile_config,
     get_recent_git_activity,
+    list_collections,
+    run_generate_dataset,
     set_available_skills,
     set_workspace_root,
     update_config,
@@ -66,11 +68,13 @@ in terms of speed vs. quality vs. cost so the user can make an informed decision
 Before responding to any message, decide whether one of these skills applies \
 and call activate_skill(name) as your FIRST action if so:
 
-- explain-rag       → user asks what something IS (concept, definition, "comment ça marche")
-- learn-retrieval   → user reports a PROBLEM with results (bad, irrelevant, missing, "ne trouve pas")
-- tune-pipeline     → user wants to CHANGE or SET a parameter (top_k, top_n, chunk_size, preset…)
-- explore-codebase  → user asks WHERE something is in the code or how it is implemented
-- skill-creator     → user wants to CREATE a new custom skill
+- explain-rag         → user asks what something IS (concept, definition, "comment ça marche")
+- learn-retrieval     → user reports a PROBLEM with results (bad, irrelevant, missing)
+- tune-pipeline       → user wants to CHANGE or SET a parameter (top_k, top_n, preset…)
+- manage-collections  → user asks about collections, wants to enable/disable public datasets
+- generate-dataset    → user wants to generate an evaluation dataset from their documents
+- explore-codebase    → user asks WHERE something is in the code or how it is implemented
+- skill-creator       → user wants to CREATE a new custom skill
 
 Only activate ONE skill per session. If no skill clearly applies, respond directly.
 
@@ -162,6 +166,8 @@ _TOOL_ICONS: dict[str, str] = {
     "get_agents_md": "📋",
     "get_recent_git_activity": "📜",
     "get_docs": "📖",
+    "list_collections": "🗂️",
+    "run_generate_dataset": "🔬",
     "update_config": "✏️",
 }
 
@@ -289,6 +295,8 @@ def start_chat(debug: bool = False) -> None:
             get_agents_md,
             get_recent_git_activity,
             get_docs,
+            list_collections,
+            run_generate_dataset,
             update_config,
         ]
     ] + [_wrap_activate_skill(activate_skill)]

--- a/apps/cli/src/cli/commands/chat/agent.py
+++ b/apps/cli/src/cli/commands/chat/agent.py
@@ -84,13 +84,16 @@ explain what the user could do themselves.
 Before responding to any message, decide whether one of these skills applies \
 and call activate_skill(name) as your FIRST action if so:
 
-- explain-rag         → user asks what something IS (concept, definition, "comment ça marche")
-- learn-retrieval     → user reports a PROBLEM with results (bad, irrelevant, missing)
-- tune-pipeline       → user wants to CHANGE or SET a parameter (top_k, top_n, preset…)
-- manage-collections  → user asks about collections, wants to enable/disable public datasets
-- generate-dataset    → user wants to generate an evaluation dataset from their documents
-- explore-codebase    → user asks WHERE something is in the code or how it is implemented
+- explain-rag         → user asks WHAT something IS (concept, definition, "comment ça marche", "qu'est-ce que")
+- learn-retrieval     → user reports a PROBLEM with results ("mauvais résultats", "ne trouve pas", "non pertinent")
+- tune-pipeline       → user wants to CHANGE a pipeline PARAMETER value (top_k, top_n, chunk_size, preset, temperature…)
+- manage-collections  → ANYTHING about collections: list them, activate one, deactivate one, add an ID ("activer la collection", "désactiver", "ajouter la collection")
+- generate-dataset    → user wants to CREATE an evaluation dataset from documents ("générer un dataset", "évaluer mon pipeline")
+- explore-codebase    → user asks WHERE something is in SOURCE CODE or how it is IMPLEMENTED
 - skill-creator       → user wants to CREATE a new custom skill
+
+Important: "activer/désactiver une collection" is ALWAYS manage-collections, never tune-pipeline. \
+tune-pipeline is only for numeric/string pipeline parameters, NOT for collections.
 
 Only activate ONE skill per session. If no skill clearly applies, respond directly.
 
@@ -322,7 +325,7 @@ def start_chat(debug: bool = False) -> None:
         model=model,
         instructions=_SYSTEM_PROMPT,
         verbosity_level=LogLevel.INFO if debug else LogLevel.OFF,
-        max_steps=5,
+        max_steps=10,
     )
 
     session_turns: list[tuple[str, str]] = []  # accumulated for post-session update

--- a/apps/cli/src/cli/commands/chat/agent.py
+++ b/apps/cli/src/cli/commands/chat/agent.py
@@ -63,6 +63,22 @@ You can:
 Always be encouraging and educational. When you suggest a change, explain the tradeoff \
 in terms of speed vs. quality vs. cost so the user can make an informed decision.
 
+## RULE — Use tools, never explain manual edits
+
+When the user asks you to DO something you have a tool for, USE the tool.
+Do NOT explain how the user could do it manually instead.
+
+Examples of what NOT to do:
+- User: "active la collection 785" → WRONG: explain how to edit ragfacile.toml manually
+- User: "mets top_k à 15" → WRONG: show the TOML syntax the user should type
+
+Examples of what TO do:
+- User: "active la collection 785" → RIGHT: call update_config with confirmation
+- User: "mets top_k à 15" → RIGHT: call update_config with confirmation
+
+The agent's value is that it can act on behalf of the user — not that it can \
+explain what the user could do themselves.
+
 ## Skill activation
 
 Before responding to any message, decide whether one of these skills applies \

--- a/apps/cli/src/cli/commands/chat/tools.py
+++ b/apps/cli/src/cli/commands/chat/tools.py
@@ -226,6 +226,121 @@ def activate_skill(name: str) -> str:
     return load_skill(_available_skills[name])
 
 
+# ── Collections ───────────────────────────────────────────────────────────────
+
+
+@tool
+def list_collections() -> str:
+    """List all collections accessible on the Albert API.
+
+    Use this when the user asks which collections are available, wants to know
+    what public datasets exist, or needs collection IDs to enable in ragfacile.toml.
+    Returns a plain-text table with ID, name, document count and visibility.
+    """
+    try:
+        from albert import AlbertClient
+        import httpx
+    except ImportError:
+        return "albert-client package not available. Install with: uv pip install albert-client"
+
+    try:
+        client = AlbertClient()
+    except ValueError as exc:
+        return (
+            f"Albert API not configured: {exc}. Set OPENAI_API_KEY in your .env file."
+        )
+
+    try:
+        result = client.list_collections(limit=100)
+    except httpx.HTTPStatusError as exc:
+        return f"Failed to fetch collections from Albert API: {exc}"
+
+    collections = result.data
+    if not collections:
+        return "No collections found. Your account may not have access to any collections yet."
+
+    lines = [f"{'ID':<8} {'Visibility':<12} {'Docs':<8} Name"]
+    lines.append("-" * 70)
+    for col in collections:
+        visibility = col.visibility or "—"
+        docs = f"{col.documents:,}" if col.documents else "0"
+        name = col.name or "—"
+        lines.append(f"{col.id!s:<8} {visibility:<12} {docs:<8} {name}")
+
+    public_ids = [str(c.id) for c in collections if c.visibility == "public"]
+    lines.append("")
+    if public_ids:
+        lines.append(f"Public collection IDs: {', '.join(public_ids)}")
+        lines.append(
+            "To enable them: update ragfacile.toml storage.collections with these IDs."
+        )
+
+    return "\n".join(lines)
+
+
+# ── Dataset generation ────────────────────────────────────────────────────────
+
+
+@tool
+def run_generate_dataset(
+    docs_path: str, output_file: str, num_questions: int = 20
+) -> str:
+    """Generate a synthetic Q&A evaluation dataset from documents in a directory.
+
+    Use this after the user has confirmed the docs path and output file.
+    Runs rag-facile generate-dataset under the hood using the albert provider.
+    This can take several minutes — let the user know before calling.
+
+    Args:
+        docs_path: Path to the directory containing source documents (PDF, Markdown, HTML).
+        output_file: Path for the output JSONL file, e.g. 'golden_dataset.jsonl'.
+        num_questions: Number of Q&A pairs to generate (default 20, max 100).
+    """
+    if _workspace_root is None:
+        return "No workspace detected. Run 'rag-facile setup' to create a workspace."
+
+    docs = Path(docs_path)
+    if not docs.exists():
+        return f"Directory '{docs_path}' does not exist. Please provide a valid path."
+    if not docs.is_dir():
+        return f"'{docs_path}' is a file, not a directory. Please provide a directory path."
+
+    num_questions = max(1, min(num_questions, 100))
+
+    try:
+        result = subprocess.run(
+            [
+                "rag-facile",
+                "generate-dataset",
+                str(docs),
+                "--output",
+                output_file,
+                "--num-questions",
+                str(num_questions),
+                "--provider",
+                "albert",
+            ],
+            cwd=_workspace_root,
+            capture_output=True,
+            text=True,
+            timeout=600,  # 10 minutes — generation can be slow
+        )
+    except FileNotFoundError:
+        return "rag-facile CLI not found. Ensure the package is installed correctly."
+    except subprocess.TimeoutExpired:
+        return (
+            "Dataset generation timed out after 10 minutes. Try with fewer questions."
+        )
+
+    if result.returncode == 0:
+        return (
+            f"✓ Dataset generated: {output_file}\n"
+            f"  {num_questions} Q&A pairs from documents in {docs_path}.\n"
+            "  Use this file with 'rag-facile eval' to measure retrieval quality."
+        )
+    return f"Generation failed:\n{result.stderr.strip() or result.stdout.strip()}"
+
+
 # ── Config editing ────────────────────────────────────────────────────────────
 
 

--- a/apps/cli/src/cli/skills/generate-dataset/SKILL.md
+++ b/apps/cli/src/cli/skills/generate-dataset/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: generate-dataset
+description: Guide the user through generating a synthetic Q&A evaluation dataset from their documents using the Albert API. Use when the user wants to evaluate their RAG pipeline or create test data.
+triggers: ["generate dataset", "golden dataset", "evaluation dataset", "créer dataset", "générer dataset", "eval", "évaluation", "test data"]
+---
+
+# Skill: Generate Dataset
+
+You guide the user through generating a synthetic Q&A evaluation dataset from
+their documents. This dataset is used to measure RAG pipeline quality.
+
+## What is a golden dataset?
+A golden dataset is a set of question-answer pairs generated from the user's
+actual documents. It lets them measure how well their RAG pipeline retrieves
+the right information. More Q&A pairs = more reliable evaluation.
+
+## Step 1 — Check the workspace
+Call `get_ragfacile_config()` to confirm the workspace is set up correctly.
+The user needs an Albert API key configured to use the Albert provider.
+
+## Step 2 — Find the source documents
+Ask: "Où sont vos documents source ? (chemin vers le dossier, ex: ./docs)"
+The directory should contain PDF, Markdown, or HTML files.
+Verify the path exists and explain: "Je vais utiliser ces documents pour
+générer des paires question-réponse via l'API Albert."
+
+## Step 3 — Set the output file
+Suggest a sensible default: `golden_dataset.jsonl` in the workspace root.
+Ask if they want a different name or location.
+
+## Step 4 — Choose the number of questions
+Recommend 20 questions for a first run (fast, gives a quick signal).
+Explain: "Plus il y a de questions, plus l'évaluation est précise,
+mais la génération prend plus de temps (~1 min pour 20 questions)."
+Max: 100 questions.
+
+## Step 5 — Confirm and run
+Summarise before starting:
+- Source: <docs_path>
+- Output: <output_file>
+- Questions: <num>
+- Provider: Albert API
+- Duration: ~<estimate> minutes
+
+Ask: "Puis-je lancer la génération ?"
+On yes: call `run_generate_dataset(docs_path, output_file, num_questions)`.
+Warn the user it may take a few minutes and they should not close the terminal.
+
+## Step 6 — Explain next steps
+On success, explain how to use the dataset:
+"Votre dataset est prêt. Pour évaluer votre pipeline RAG :
+  rag-facile eval --dataset golden_dataset.jsonl
+Cela mesurera la précision de votre pipeline sur vos propres documents."
+
+## Rules
+- Always confirm docs path, output file and question count before calling run_generate_dataset
+- Never call run_generate_dataset without explicit user confirmation
+- If generation fails, show the error and suggest checking API key and docs format
+- Remind users that only PDF, Markdown and HTML files are supported

--- a/apps/cli/src/cli/skills/manage-collections/SKILL.md
+++ b/apps/cli/src/cli/skills/manage-collections/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: manage-collections
+description: Discover, understand and enable/disable Albert API collections in ragfacile.toml. Use when the user asks about available datasets, wants to add a public collection, or wants to toggle collections on or off.
+triggers: ["collections", "dataset public", "collection", "activer", "désactiver", "enable collection", "disable collection"]
+---
+
+# Skill: Manage Collections
+
+You help the user discover available collections on the Albert API and configure
+which ones are active in their RAG pipeline.
+
+## Step 1 — Fetch available collections
+Call `list_collections()` to retrieve all accessible collections.
+Present the results clearly: highlight public collections (available to all users)
+and the user's private ones separately.
+
+## Step 2 — Explain what collections are
+If the user seems unfamiliar, explain briefly:
+- Collections are pre-indexed document sets stored on the Albert API
+- Public collections include government datasets (service-public.fr, légifrance, etc.)
+- Enabling a collection means the RAG pipeline will search it on every query
+- Multiple collections can be active simultaneously
+
+## Step 3 — Help them choose
+Ask: "Quelles collections souhaitez-vous activer dans votre pipeline RAG ?"
+Show the current active collections from `get_ragfacile_config()`.
+Suggest relevant public ones based on their use case if known.
+
+## Step 4 — Update the configuration
+Once the user picks collection IDs, follow the update_config confirmation flow:
+- Explain the change: "Je vais activer les collections X, Y, Z."
+- Ask explicitly: "Puis-je mettre à jour storage.collections ? Le changement
+  sera enregistré dans ragfacile.toml et committé dans git."
+- On yes: call `update_config("storage.collections", "[id1, id2, ...]")`
+
+## Rules
+- Never modify collections without explicit user confirmation
+- Always show current config before proposing changes
+- Remind the user that session collections (uploaded files) are separate from
+  public collections — both can be active at the same time

--- a/apps/cli/src/cli/skills/manage-collections/SKILL.md
+++ b/apps/cli/src/cli/skills/manage-collections/SKILL.md
@@ -26,15 +26,23 @@ Ask: "Quelles collections souhaitez-vous activer dans votre pipeline RAG ?"
 Show the current active collections from `get_ragfacile_config()`.
 Suggest relevant public ones based on their use case if known.
 
-## Step 4 — Update the configuration
-Once the user picks collection IDs, follow the update_config confirmation flow:
-- Explain the change: "Je vais activer les collections X, Y, Z."
-- Ask explicitly: "Puis-je mettre à jour storage.collections ? Le changement
-  sera enregistré dans ragfacile.toml et committé dans git."
-- On yes: call `update_config("storage.collections", "[id1, id2, ...]")`
+## Step 4 — Update the configuration with update_config
+
+CRITICAL: When the user asks to activate or deactivate a collection, you MUST
+call `update_config` — do NOT explain how to manually edit ragfacile.toml.
+The agent can write the file directly. Manual editing instructions are never helpful here.
+
+Flow:
+1. Read the current list from `get_ragfacile_config()` (e.g. `[783, 784, 785]`)
+2. Compute the new list (add or remove the requested ID)
+3. Say: "Je vais mettre à jour storage.collections : [783, 784, 785] → [783, 784, 785, 79783].
+   Puis-je effectuer ce changement ? Il sera enregistré dans ragfacile.toml et committé dans git."
+4. Wait for explicit "oui" / "yes"
+5. Call: `update_config("storage.collections", "[783, 784, 785, 79783]")`
 
 ## Rules
+- ALWAYS use update_config — never tell the user to edit the file manually
 - Never modify collections without explicit user confirmation
-- Always show current config before proposing changes
-- Remind the user that session collections (uploaded files) are separate from
-  public collections — both can be active at the same time
+- Always compute the complete new list (not just the delta) before calling update_config
+- Remind the user to restart their app after the change takes effect
+- Session collections (uploaded files) are separate from public collections — both can be active

--- a/apps/cli/tests/test_chat_capabilities.py
+++ b/apps/cli/tests/test_chat_capabilities.py
@@ -1,0 +1,176 @@
+"""Tests for list_collections and run_generate_dataset tools."""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cli.commands.chat.tools import (
+    list_collections,
+    run_generate_dataset,
+    set_workspace_root,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_workspace():
+    set_workspace_root(None)
+    yield
+    set_workspace_root(None)
+
+
+@pytest.fixture()
+def workspace(tmp_path):
+    set_workspace_root(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture()
+def docs_dir(tmp_path):
+    d = tmp_path / "docs"
+    d.mkdir()
+    (d / "guide.md").write_text("# Guide\nSome content.", encoding="utf-8")
+    return d
+
+
+# ── list_collections ──────────────────────────────────────────────────────────
+
+
+class TestListCollections:
+    def _mock_collection(self, id_, name, visibility="public", documents=100):
+        col = MagicMock()
+        col.id = id_
+        col.name = name
+        col.visibility = visibility
+        col.documents = documents
+        col.description = None
+        return col
+
+    def test_returns_table_with_collections(self):
+        col1 = self._mock_collection(1, "Service Public")
+        col2 = self._mock_collection(2, "My Private", visibility="private")
+        mock_result = MagicMock()
+        mock_result.data = [col1, col2]
+
+        with patch("albert.AlbertClient") as MockClient:
+            MockClient.return_value.list_collections.return_value = mock_result
+            result = list_collections()
+
+        assert "Service Public" in result
+        assert "My Private" in result
+        assert "1" in result
+
+    def test_shows_public_ids_hint(self):
+        col = self._mock_collection(42, "Légifrance", visibility="public")
+        mock_result = MagicMock()
+        mock_result.data = [col]
+
+        with patch("albert.AlbertClient") as MockClient:
+            MockClient.return_value.list_collections.return_value = mock_result
+            result = list_collections()
+
+        assert "42" in result
+        assert "storage.collections" in result
+
+    def test_returns_hint_when_no_collections(self):
+        mock_result = MagicMock()
+        mock_result.data = []
+
+        with patch("albert.AlbertClient") as MockClient:
+            MockClient.return_value.list_collections.return_value = mock_result
+            result = list_collections()
+
+        assert "No collections found" in result
+
+    def test_handles_missing_api_key(self):
+        with patch("albert.AlbertClient", side_effect=ValueError("No API key")):
+            result = list_collections()
+        assert "not configured" in result
+
+    def test_handles_http_error(self):
+        import httpx
+
+        with patch("albert.AlbertClient") as MockClient:
+            MockClient.return_value.list_collections.side_effect = (
+                httpx.HTTPStatusError("403", request=MagicMock(), response=MagicMock())
+            )
+            result = list_collections()
+        assert "Failed" in result
+
+
+# ── run_generate_dataset ──────────────────────────────────────────────────────
+
+
+class TestRunGenerateDataset:
+    def test_returns_hint_when_no_workspace(self, docs_dir):
+        result = run_generate_dataset(str(docs_dir), "out.jsonl")
+        assert "No workspace detected" in result
+
+    def test_returns_error_when_docs_path_missing(self, workspace):
+        result = run_generate_dataset("/nonexistent/path", "out.jsonl")
+        assert "does not exist" in result
+
+    def test_returns_error_when_docs_path_is_file(self, workspace, tmp_path):
+        f = tmp_path / "file.md"
+        f.write_text("x")
+        result = run_generate_dataset(str(f), "out.jsonl")
+        assert "not a directory" in result
+
+    def test_success(self, workspace, docs_dir):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "Generated 20 Q&A pairs."
+        with patch("cli.commands.chat.tools.subprocess.run", return_value=mock_result):
+            result = run_generate_dataset(str(docs_dir), "out.jsonl", num_questions=20)
+        assert "✓" in result
+        assert "out.jsonl" in result
+
+    def test_failure_returns_stderr(self, workspace, docs_dir):
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = "API key invalid"
+        mock_result.stdout = ""
+        with patch("cli.commands.chat.tools.subprocess.run", return_value=mock_result):
+            result = run_generate_dataset(str(docs_dir), "out.jsonl")
+        assert "API key invalid" in result
+
+    def test_timeout(self, workspace, docs_dir):
+        with patch(
+            "cli.commands.chat.tools.subprocess.run",
+            side_effect=subprocess.TimeoutExpired("rag-facile", 600),
+        ):
+            result = run_generate_dataset(str(docs_dir), "out.jsonl")
+        assert "timed out" in result.lower()
+
+    def test_missing_cli(self, workspace, docs_dir):
+        with patch(
+            "cli.commands.chat.tools.subprocess.run",
+            side_effect=FileNotFoundError,
+        ):
+            result = run_generate_dataset(str(docs_dir), "out.jsonl")
+        assert "not found" in result.lower()
+
+    def test_clamps_num_questions(self, workspace, docs_dir):
+        """num_questions is clamped to [1, 100]."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        with patch(
+            "cli.commands.chat.tools.subprocess.run", return_value=mock_result
+        ) as mock_run:
+            run_generate_dataset(str(docs_dir), "out.jsonl", num_questions=999)
+        cmd = mock_run.call_args[0][0]
+        assert "--num-questions" in cmd
+        assert "100" in cmd
+
+    def test_uses_albert_provider(self, workspace, docs_dir):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = ""
+        with patch(
+            "cli.commands.chat.tools.subprocess.run", return_value=mock_result
+        ) as mock_run:
+            run_generate_dataset(str(docs_dir), "out.jsonl")
+        cmd = mock_run.call_args[0][0]
+        assert "--provider" in cmd
+        assert "albert" in cmd


### PR DESCRIPTION
## Summary

Exposes `collections list` and `generate-dataset` as native chat agent capabilities. Lambda users never need to know the CLI commands — they just describe what they want.

- **`list_collections()`** tool — fetches Albert API collections, highlights public IDs, hints how to add them to `ragfacile.toml`
- **`run_generate_dataset()`** tool — runs dataset generation guided by a 6-step skill walkthrough
- **`manage-collections`** skill — discover → explain → choose → enable via `update_config`
- **`generate-dataset`** skill — guided walkthrough from docs path to evaluation-ready JSONL

## Example flows

**Collections:**
```
Vous: quelles collections publiques sont disponibles ?
→ activate_skill("manage-collections")
→ 🗂️ list_collections
→ Shows table, suggests adding IDs to ragfacile.toml
→ Guides through update_config confirmation
```

**Dataset generation:**
```
Vous: je veux évaluer mon pipeline
→ activate_skill("generate-dataset")
→ ⚙️ get_ragfacile_config
→ Asks for docs path, output file, question count
→ 🔬 run_generate_dataset(...)
→ Explains how to use the output with rag-facile eval
```

## Test plan

- [x] "quelles collections sont disponibles ?" → `manage-collections` activates, table shown
- [ ] "active la collection 785" → `update_config("storage.collections", "[785]")` after confirmation
- [ ] "génère un dataset depuis ./docs" → `generate-dataset` activates, wizard runs
- [ ] Invalid docs path → friendly error, no subprocess call
- [ ] Generation timeout → user-friendly message

## Part of the chat implementation plan (PR 7 of 8)

Next: PR 8 — experience-level communication style (`_STYLE_PROMPTS` injected from `profile.md`).

👾 Generated with [Letta Code](https://letta.com)