### PR TITLE
fix: harden skill routing against hallucination

### DIFF
--- a/apps/cli/src/cli/commands/chat/agent.py
+++ b/apps/cli/src/cli/commands/chat/agent.py
@@ -63,16 +63,32 @@ in terms of speed vs. quality vs. cost so the user can make an informed decision
 
 ## Skill activation
 
-Before responding to any message, decide whether one of these skills applies \
-and call activate_skill(name) as your FIRST action if so:
+Before responding, decide if ONE skill clearly applies. Call activate_skill(name) as \
+your FIRST action ONLY WHEN you are confident it matches — do NOT force a skill if unsure.
 
-- explain-rag       → user asks what something IS (concept, definition, "comment ça marche")
-- learn-retrieval   → user reports a PROBLEM with results (bad, irrelevant, missing, "ne trouve pas")
-- tune-pipeline     → user wants to CHANGE or SET a parameter (top_k, top_n, chunk_size, preset…)
-- explore-codebase  → user asks WHERE something is in the code or how it is implemented
-- skill-creator     → user wants to CREATE a new custom skill
+- explain-rag      → user asks WHAT something IS or HOW it works, specifically about RAG \
+or rag-facile concepts (chunking, embeddings, retrieval, reranking, presets…). \
+DO NOT use for general questions or simple factual lookups unrelated to RAG.
 
-Only activate ONE skill per session. If no skill clearly applies, respond directly.
+- learn-retrieval  → user reports a QUALITY PROBLEM with their results (bad, irrelevant, \
+not finding the right documents). \
+DO NOT use if the user is requesting a specific parameter change — use tune-pipeline instead.
+
+- tune-pipeline    → user wants to CHANGE or SET a specific config parameter \
+(top_k, top_n, chunk_size, preset, model…). \
+DO NOT use for questions about what a parameter means — use explain-rag for that. \
+If the user BOTH reports a problem AND asks to change a value, prefer tune-pipeline.
+
+- explore-codebase → user asks WHERE something is implemented in the rag-facile source code, \
+or wants to navigate a specific package or file. \
+DO NOT use for conceptual questions about how RAG works — use explain-rag for that.
+
+- skill-creator    → user explicitly wants to CREATE a new custom skill file. \
+Requires the user to have stated a skill topic or purpose. \
+DO NOT use if the user is merely asking about skills or how they work.
+
+Only activate ONE skill per session. If no skill clearly fits, respond directly in \
+natural language — this is always a valid choice.
 
 ## STRICT RULE — Configuration changes (update_config)
 

--- a/apps/cli/src/cli/commands/chat/skills.py
+++ b/apps/cli/src/cli/commands/chat/skills.py
@@ -18,77 +18,6 @@ from pathlib import Path
 
 import yaml
 
-# ── Keyword triggers for auto-detection ──────────────────────────────────────
-
-_SKILL_KEYWORDS: dict[str, list[str]] = {
-    "explain-rag": [
-        "what is",
-        "explain",
-        "how does",
-        "comment fonctionne",
-        "c'est quoi",
-        "understand",
-        "comprendre",
-        "définition",
-    ],
-    "learn-retrieval": [
-        # Symptom-based triggers only — the user has a PROBLEM, not a change in mind
-        "results bad",
-        "mauvais résultats",
-        "not finding",
-        "ne trouve pas",
-        "wrong results",
-        "mauvaise qualité",
-        "irrelevant",
-        "non pertinent",
-        "retrieval problem",
-        "problème de recherche",
-    ],
-    "tune-pipeline": [
-        # Intent-to-change triggers — the user wants to SET or ADJUST something
-        "tune",
-        "optimize",
-        "améliorer",
-        "improve",
-        "preset",
-        "slower",
-        "faster",
-        "plus rapide",
-        "plus lent",
-        "performance",
-        "top_k",
-        "top_n",
-        "chunk",
-        "mets",
-        "set",
-        "change",
-        "modifier",
-        "augmenter",
-        "diminuer",
-        "increase",
-        "decrease",
-    ],
-    "explore-codebase": [
-        "source",
-        "code",
-        "where is",
-        "où est",
-        "how is implemented",
-        "comment est implémenté",
-        "package",
-        "module",
-    ],
-    "skill-creator": [
-        "create skill",
-        "new skill",
-        "créer une compétence",
-        "add skill",
-        "custom skill",
-        "write skill",
-    ],
-}
-
-
 # ── Discovery ─────────────────────────────────────────────────────────────────
 
 
@@ -208,7 +137,13 @@ def _extract_description(skill_path: Path) -> str:
     return str(_parse_frontmatter(skill_path).get("description", ""))
 
 
-# ── Auto-detection ────────────────────────────────────────────────────────────
+def _extract_triggers(skill_path: Path) -> list[str]:
+    """Pull the triggers list from SKILL.md YAML frontmatter."""
+    raw = _parse_frontmatter(skill_path).get("triggers", [])
+    return [str(t) for t in raw] if isinstance(raw, list) else []
+
+
+# ── Keyword-based detection (external/npx skills only) ────────────────────────
 
 
 def auto_detect_skill(
@@ -217,32 +152,17 @@ def auto_detect_skill(
 ) -> str | None:
     """Return the best matching skill name for a user message, or None.
 
-    Uses keyword heuristics — no LLM call needed.
-    Checks built-in keyword map first, then falls back to description matching
-    for project / npx skills that have their own triggers list.
+    Matches against the ``triggers`` list in each skill's YAML frontmatter.
+    Built-in skills are routed semantically by the LLM via ``activate_skill``;
+    this function is a keyword fallback for external / npx skills that define
+    their own triggers.
     """
     msg_lower = message.lower()
-
-    # Check built-in keyword map
-    for skill_name, keywords in _SKILL_KEYWORDS.items():
-        if skill_name in available and any(kw in msg_lower for kw in keywords):
-            return skill_name
-
-    # For external skills: match against their frontmatter triggers list
     for skill_name, skill_path in available.items():
-        if skill_name in _SKILL_KEYWORDS:
-            continue  # already checked above
         triggers = _extract_triggers(skill_path)
         if any(t.lower() in msg_lower for t in triggers):
             return skill_name
-
     return None
-
-
-def _extract_triggers(skill_path: Path) -> list[str]:
-    """Pull the triggers list from SKILL.md YAML frontmatter."""
-    raw = _parse_frontmatter(skill_path).get("triggers", [])
-    return [str(t) for t in raw] if isinstance(raw, list) else []
 
 
 # ── npx skills integration ────────────────────────────────────────────────────

--- a/apps/cli/src/cli/commands/chat/tools.py
+++ b/apps/cli/src/cli/commands/chat/tools.py
@@ -202,16 +202,35 @@ def get_docs(topic: str) -> str:
 def activate_skill(name: str) -> str:
     """Load a skill to guide your behaviour for this session.
 
-    Call this as your FIRST action whenever you recognise the user's intent as
-    matching one of the available skills. Returns the skill's full instructions —
-    read them carefully and follow them for the rest of the session.
+    Call this as your FIRST action ONLY WHEN you are confident the user's intent
+    clearly matches one of the available skills. Do NOT force a skill if unsure —
+    responding directly in natural language is always valid.
+    Returns the skill's full instructions; read them carefully and follow them.
 
-    Available skills and when to use them:
-    - explain-rag      → user asks what something IS (concept, definition, how it works)
-    - learn-retrieval  → user reports a PROBLEM (bad results, not finding docs, irrelevant)
-    - tune-pipeline    → user wants to CHANGE or SET a parameter (top_k, top_n, preset…)
-    - explore-codebase → user asks WHERE something is in the code or how it is implemented
-    - skill-creator    → user wants to CREATE a new custom skill
+    Available skills — use ONLY when the description strictly applies:
+
+    - explain-rag      → user asks WHAT something IS or HOW it works, specifically about
+                         RAG or rag-facile concepts (chunking, embeddings, retrieval…).
+                         DO NOT use for general questions unrelated to RAG.
+
+    - learn-retrieval  → user reports a QUALITY PROBLEM with results (bad, irrelevant,
+                         not finding the right documents).
+                         DO NOT use if the user wants a specific parameter change — use
+                         tune-pipeline instead.
+
+    - tune-pipeline    → user wants to CHANGE or SET a specific config parameter
+                         (top_k, top_n, chunk_size, preset, model…).
+                         DO NOT use for questions about what a parameter means — use
+                         explain-rag for that. If user both reports a problem AND requests
+                         a value change, prefer tune-pipeline.
+
+    - explore-codebase → user asks WHERE something is implemented in the rag-facile source,
+                         or wants to navigate a specific package or file.
+                         DO NOT use for conceptual questions about how RAG works.
+
+    - skill-creator    → user explicitly wants to CREATE a new custom skill file and has
+                         stated a skill topic or purpose.
+                         DO NOT use if the user is merely asking about skills.
 
     Args:
         name: Skill name, e.g. 'tune-pipeline'.

--- a/apps/cli/tests/test_chat_skills.py
+++ b/apps/cli/tests/test_chat_skills.py
@@ -125,21 +125,11 @@ class TestFormatSkillsList:
 
 
 # ── auto_detect_skill ─────────────────────────────────────────────────────────
+# Built-in skills are routed by the LLM via activate_skill().
+# auto_detect_skill() is a keyword fallback for external/npx skills only.
 
 
 class TestAutoDetectSkill:
-    def test_detects_builtin_by_keyword(self, workspace, builtin_dir):
-        with patch(
-            "cli.commands.chat.skills._builtin_skills_dir", return_value=builtin_dir
-        ):
-            skills = discover_skills(workspace)
-        # Force explain-rag into available skills with a fake path
-        skills["explain-rag"] = (
-            workspace / ".agents" / "skills" / "my-skill" / "SKILL.md"
-        )
-        result = auto_detect_skill("what is chunking?", skills)
-        assert result == "explain-rag"
-
     def test_detects_external_skill_by_frontmatter_trigger(self, workspace):
         skills = {
             "my-skill": workspace / ".agents" / "skills" / "my-skill" / "SKILL.md"


### PR DESCRIPTION
## Summary

- **Domain scope on `explain-rag`**: now requires the question to be about RAG/rag-facile concepts specifically — prevents generic "what is X?" from triggering a skill load
- **`DO NOT USE` clauses on every skill**: explicit negations for the most common boundary collisions (`explain-rag` vs `explore-codebase`, `learn-retrieval` vs `tune-pipeline`, etc.)
- **Conflict resolution for `learn-retrieval` + `tune-pipeline`**: when a user both reports a problem and requests a value change, `tune-pipeline` wins
- **Tone down eagerness**: `"WHENEVER you recognise"` → `"ONLY WHEN you are confident"` — the LLM is explicitly told that doing nothing (responding directly) is always valid
- **Both surfaces aligned**: identical contract in `_SYSTEM_PROMPT` and `activate_skill` docstring, so the routing logic is consistent regardless of which one the model attends to
- **Remove `_SKILL_KEYWORDS`**: hardcoded built-in keyword map was dead code since PR #138 dropped keyword detection in favour of LLM routing
- **Preserve `auto_detect_skill`** as a keyword fallback for external/npx skills only (reads `triggers` frontmatter, never called for built-ins)

## Test plan

- [ ] 214/215 tests pass (`test_generate_letta_requires_env_vars` is the pre-existing flaky test, unrelated)
- [ ] `test_detects_builtin_by_keyword` removed (tested deleted functionality)
- [ ] `test_detects_external_skill_by_frontmatter_trigger` still passes (external skill path intact)
- [x] Manual: ask "what is chunking?" → verify `explain-rag` activates
- [x] Manual: ask "how do I install this?" → verify no skill activates
- [x] Manual: ask "my results are bad, can you increase top_k?" → verify `tune-pipeline` wins over `learn-retrieval`

👾 Generated with [Letta Code](https://letta.com)