### PR TITLE
feat: RAG conversation tracing and user feedback

### DIFF
--- a/.moon/templates/chainlit-chat/app.py
+++ b/.moon/templates/chainlit-chat/app.py
@@ -1,17 +1,16 @@
-import ast
-import json
 import os
+from datetime import datetime, timezone
+from uuid import uuid4
 
 import chainlit as cl
 import engineio
 import engineio.payload
 from chainlit.input_widget import Switch
-from rag_facile.pipelines import get_accepted_mime_types, process_file, process_query
 from dotenv import load_dotenv
-
-from albert import AsyncAlbertClient
 from rag_facile.core import get_config
 from rag_facile.core.mediatech import get_collection_name
+from rag_facile.pipelines import get_accepted_mime_types, process_file, stream_answer
+from rag_facile.tracing import FeedbackRecord, get_store
 
 
 # Increase the number of packets allowed in a single payload to prevent "Too
@@ -24,63 +23,35 @@ load_dotenv()
 # Load RAG configuration
 rag_config = get_config()
 
-# Configure OpenAI (API credentials still from env vars)
-api_key = os.getenv("OPENAI_API_KEY")
-base_url = os.getenv("OPENAI_BASE_URL")
-# Model comes from config with env var override
-model = os.getenv("OPENAI_MODEL") or rag_config.generation.model
 
-client = AsyncAlbertClient(api_key=api_key, base_url=base_url)
+# ---------------------------------------------------------------------------
+# Feedback tag taxonomy
+# ---------------------------------------------------------------------------
 
-
-# Example dummy function
-def get_current_weather(location, unit="fahrenheit"):
-    """Get the current weather in a given location"""
-    if "paris" in location.lower():
-        return json.dumps({"location": "Paris", "temperature": "22", "unit": "celsius"})
-    elif "london" in location.lower():
-        return json.dumps(
-            {"location": "London", "temperature": "18", "unit": "celsius"}
-        )
-    elif "new york" in location.lower():
-        return json.dumps(
-            {"location": "New York", "temperature": "72", "unit": "fahrenheit"}
-        )
-    else:
-        return json.dumps({"location": location, "temperature": "unknown"})
-
-
-tools = [
-    {
-        "type": "function",
-        "function": {
-            "name": "get_current_weather",
-            "description": "Get the current weather in a given location",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "location": {
-                        "type": "string",
-                        "description": "The city and state, e.g. San Francisco, CA",
-                    },
-                    "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
-                },
-                "required": ["location"],
-            },
-        },
-    }
+_POSITIVE_TAGS = ["Pertinent", "Complet", "Clair", "Utile", "Précis"]
+_NEGATIVE_TAGS = [
+    "Non pertinent",
+    "Incomplet",
+    "Confus",
+    "Éléments faux",
+    "Sources manquantes",
+    "Sources erronées / obsolètes",
 ]
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle hooks
+# ---------------------------------------------------------------------------
 
 
 @cl.on_chat_start
 async def start_chat():
-    # Use system prompt from config
     cl.user_session.set(
         "message_history",
         [{"role": "system", "content": rag_config.generation.system_prompt}],
     )
 
-    # Initialize active collections from config
+    # Initialise active collections from config
     active_collections = list(rag_config.storage.collections)
     cl.user_session.set("active_collections", active_collections)
 
@@ -104,34 +75,15 @@ async def on_settings_update(settings: dict) -> None:
     cl.user_session.set("active_collections", active)
 
 
-@cl.step(type="tool")
-async def call_tool(tool_call, message_history):
-    function_name = tool_call.function.name
-    arguments = ast.literal_eval(tool_call.function.arguments)
-
-    if function_name == "get_current_weather":
-        current_weather = get_current_weather(
-            location=arguments.get("location"),
-            unit=arguments.get("unit"),
-        )
-
-        message_history.append(
-            {
-                "role": "tool",
-                "tool_call_id": tool_call.id,
-                "name": function_name,
-                "content": current_weather,
-            }
-        )
-
-        return current_weather
-    else:
-        return "Function not found"
+# ---------------------------------------------------------------------------
+# Main message handler
+# ---------------------------------------------------------------------------
 
 
 @cl.on_message
 async def main(message: cl.Message):
     message_history = cl.user_session.get("message_history")
+    active_collections: list[int] = cl.user_session.get("active_collections") or []
 
     # Handle attachments — ingest into Albert collection for RAG retrieval
     if message.elements:
@@ -150,128 +102,155 @@ async def main(message: cl.Message):
                 try:
                     status = process_file(element.path, element.name)
                     await cl.Message(content=status).send()
-                except Exception as e:
+                except (OSError, ValueError) as e:
                     await cl.Message(
                         content=f"Error indexing '{element.name}': {e!s}"
                     ).send()
 
-    # Retrieve relevant context using active collections
-    active_collections: list[int] = cl.user_session.get("active_collections") or []
-    retrieved_context = process_query(
-        message.content, collection_ids=active_collections
-    )
-
-    user_content = message.content
-    if retrieved_context:
-        user_content = (
-            "Use the following context to answer the user's question:\n\n"
-            f"{retrieved_context}\n\n"
-            f"Question: {message.content}"
-        )
-
-    message_history.append({"role": "user", "content": user_content})
+    # Pre-generate trace_id so we can attach feedback before stream ends
+    trace_id = str(uuid4())
+    cl.user_session.set("last_trace_id", trace_id)
 
     msg = cl.Message(content="")
-
-    # Send an empty message to start the stream UI
     await msg.send()
 
-    # Common generation parameters from config
-    gen_params = {
-        "stream": rag_config.generation.streaming,
-        "temperature": rag_config.generation.temperature,
-        "max_tokens": rag_config.generation.max_tokens,
-    }
+    # Full RAG turn: retrieve → prompt → stream → trace (all inside stream_answer)
+    async for token in stream_answer(
+        message.content,
+        message_history,
+        trace_id=trace_id,
+        session_id=cl.user_session.get("id", ""),
+        collection_ids=active_collections,
+    ):
+        await msg.stream_token(token)
 
-    # TODO: OpenAI SDK can't infer correct return type when stream parameter is a variable
-    # This causes ty to report no-matching-overload error. Need to either:
-    # 1. Split into separate streaming/non-streaming code paths with literal True/False
-    # 2. Wait for OpenAI SDK to improve overload inference with runtime booleans
-    stream = await client.chat.completions.create(  # ty: ignore[no-matching-overload]
-        model=model,
-        messages=message_history,
-        tools=tools,
-        tool_choice="auto",
-        **gen_params,
+    # Append clean question + answer to history (no injected context)
+    message_history.append({"role": "user", "content": message.content})
+    message_history.append({"role": "assistant", "content": msg.content})
+    await msg.update()
+
+    # Feedback UI — created OUTSIDE any cl.Step to avoid issue #1202
+    if rag_config.tracing.enabled:
+        await _show_feedback_ui(trace_id)
+
+
+# ---------------------------------------------------------------------------
+# Feedback UI helpers
+# ---------------------------------------------------------------------------
+
+
+async def _show_feedback_ui(trace_id: str) -> None:
+    """Send star-rating action row for the last answer."""
+    await cl.Message(
+        content="**Comment évaluez-vous la réponse ?**",
+        actions=[
+            cl.Action(
+                name=f"star_{i}",
+                value=str(i),
+                label="⭐" * i,
+                payload={"trace_id": trace_id},
+            )
+            for i in range(1, 6)
+        ],
+    ).send()
+
+
+async def _ask_sentiment(trace_id: str, star: int) -> None:
+    """Prompt thumbs up/down after a star rating."""
+    res = await cl.AskActionMessage(
+        content="👍 Positive ou 👎 Négative ?",
+        actions=[
+            cl.Action(name="positive", label="👍 Positive", value="positive"),
+            cl.Action(name="negative", label="👎 Négative", value="negative"),
+        ],
+        timeout=120,
+    ).send()
+    if res:
+        await _ask_tags(trace_id, star, res.get("value", ""))
+
+
+async def _ask_tags(trace_id: str, star: int, sentiment: str) -> None:
+    """Prompt quality tags, then free-text comment, then persist."""
+    tags_list = _POSITIVE_TAGS if sentiment == "positive" else _NEGATIVE_TAGS
+    tag_res = await cl.AskActionMessage(
+        content="Sélectionnez les étiquettes applicables :",
+        actions=[cl.Action(name=f"tag_{t}", label=t, value=t) for t in tags_list],
+        timeout=120,
+    ).send()
+    selected_tags = [tag_res["value"]] if tag_res else []
+
+    comment_res = await cl.AskUserMessage(
+        content="Commentaires (optionnel — appuyez sur Entrée pour ignorer) :",
+        timeout=120,
+    ).send()
+    comment = comment_res["output"].strip() if comment_res else None
+    if not comment:
+        comment = None
+
+    _persist_feedback(
+        trace_id=trace_id,
+        star=star,
+        sentiment=sentiment,
+        tags=selected_tags,
+        comment=comment,
     )
 
-    cur_tool_calls = []
 
+def _persist_feedback(
+    trace_id: str,
+    star: int | None,
+    sentiment: str | None,
+    tags: list[str],
+    comment: str | None,
+) -> None:
+    """Write feedback record to the trace store."""
+    fb: FeedbackRecord = {
+        "feedback_id": str(uuid4()),
+        "trace_id": trace_id,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "star_rating": star,
+        "sentiment": sentiment,
+        "tags": tags,
+        "comment": comment,
+    }
     try:
-        async for part in stream:
-            if not part.choices:
-                continue
+        get_store().record_feedback(fb)
+    except (OSError, RuntimeError) as exc:
+        import logging
 
-            # Handle new tool calls
-            if part.choices[0].delta.tool_calls:
-                for tool_call_delta in part.choices[0].delta.tool_calls:
-                    index = tool_call_delta.index
+        logging.getLogger(__name__).warning("Failed to record feedback: %s", exc)
 
-                    if index == len(cur_tool_calls):
-                        cur_tool_calls.append(tool_call_delta)
-                    else:
-                        # We are updating an existing tool call
-                        if tool_call_delta.id:
-                            cur_tool_calls[index].id = tool_call_delta.id
-                        if tool_call_delta.function.name:
-                            cur_tool_calls[index].function.name = (
-                                cur_tool_calls[index].function.name or ""
-                            ) + tool_call_delta.function.name
-                        if tool_call_delta.function.arguments:
-                            cur_tool_calls[index].function.arguments = (
-                                cur_tool_calls[index].function.arguments or ""
-                            ) + tool_call_delta.function.arguments
 
-            # Handle content
-            if part.choices[0].delta.content:
-                token = part.choices[0].delta.content
-                await msg.stream_token(token)
-    except json.JSONDecodeError:
-        # Albert API occasionally sends malformed SSE events; continue
-        # with whatever content was streamed so far.
-        pass
+# ---------------------------------------------------------------------------
+# Star rating callbacks (one per rating level)
+# ---------------------------------------------------------------------------
 
-    # We are done with the first stream
 
-    if cur_tool_calls:
-        # We have tool calls to execute
-        message_history.append(
-            {
-                "role": "assistant",
-                "tool_calls": [
-                    {
-                        "id": tool_call.id,
-                        "type": "function",
-                        "function": {
-                            "name": tool_call.function.name,
-                            "arguments": tool_call.function.arguments,
-                        },
-                    }
-                    for tool_call in cur_tool_calls
-                ],
-            }
-        )
+@cl.action_callback("star_1")
+async def on_star_1(action: cl.Action):
+    cl.user_session.set("pending_star", 1)
+    await _ask_sentiment(action.payload["trace_id"], 1)
 
-        # Execute tools
-        for tool_call in cur_tool_calls:
-            await call_tool(tool_call, message_history)
 
-        # Now we need to get the final response from the model (uses config values)
-        stream_post_tool = await client.chat.completions.create(
-            model=model,
-            messages=message_history,
-            **gen_params,
-        )
+@cl.action_callback("star_2")
+async def on_star_2(action: cl.Action):
+    cl.user_session.set("pending_star", 2)
+    await _ask_sentiment(action.payload["trace_id"], 2)
 
-        # Type ignore: SDK can't infer stream type when stream parameter is variable
-        async for part in stream_post_tool:  # type: ignore[union-attr]
-            if not part.choices:
-                continue
-            if part.choices[0].delta.content:
-                token = part.choices[0].delta.content
-                await msg.stream_token(token)
 
-    # Add assistant response to history for proper conversation continuity
-    message_history.append({"role": "assistant", "content": msg.content})
+@cl.action_callback("star_3")
+async def on_star_3(action: cl.Action):
+    cl.user_session.set("pending_star", 3)
+    await _ask_sentiment(action.payload["trace_id"], 3)
 
-    await msg.update()
+
+@cl.action_callback("star_4")
+async def on_star_4(action: cl.Action):
+    cl.user_session.set("pending_star", 4)
+    await _ask_sentiment(action.payload["trace_id"], 4)
+
+
+@cl.action_callback("star_5")
+async def on_star_5(action: cl.Action):
+    cl.user_session.set("pending_star", 5)
+    await _ask_sentiment(action.payload["trace_id"], 5)

--- a/.moon/templates/chainlit-chat/app.py
+++ b/.moon/templates/chainlit-chat/app.py
@@ -161,13 +161,21 @@ async def _ask_sentiment(trace_id: str, star: int) -> None:
     res = await cl.AskActionMessage(
         content="👍 Positive ou 👎 Négative ?",
         actions=[
-            cl.Action(name="positive", label="👍 Positive", value="positive"),
-            cl.Action(name="negative", label="👎 Négative", value="negative"),
+            cl.Action(
+                name="positive", label="👍 Positive", value="positive", payload={}
+            ),
+            cl.Action(
+                name="negative", label="👎 Négative", value="negative", payload={}
+            ),
         ],
         timeout=120,
     ).send()
     if res:
-        await _ask_tags(trace_id, star, res.get("value", ""))
+        sentiment = res.get("value") or res.get("name", "")
+        if sentiment in ("positive", "negative"):
+            await _ask_tags(trace_id, star, sentiment)
+        else:
+            await _ask_tags(trace_id, star, "")
 
 
 async def _ask_tags(trace_id: str, star: int, sentiment: str) -> None:
@@ -175,10 +183,16 @@ async def _ask_tags(trace_id: str, star: int, sentiment: str) -> None:
     tags_list = _POSITIVE_TAGS if sentiment == "positive" else _NEGATIVE_TAGS
     tag_res = await cl.AskActionMessage(
         content="Sélectionnez les étiquettes applicables :",
-        actions=[cl.Action(name=f"tag_{t}", label=t, value=t) for t in tags_list],
+        actions=[
+            cl.Action(name=f"tag_{t}", label=t, value=t, payload={}) for t in tags_list
+        ],
         timeout=120,
     ).send()
-    selected_tags = [tag_res["value"]] if tag_res else []
+    selected_tags = []
+    if tag_res:
+        tag_val = tag_res.get("value") or tag_res.get("name", "").replace("tag_", "")
+        if tag_val:
+            selected_tags.append(tag_val)
 
     comment_res = await cl.AskUserMessage(
         content="Commentaires (optionnel — appuyez sur Entrée pour ignorer) :",

--- a/.moon/templates/chainlit-chat/app.py
+++ b/.moon/templates/chainlit-chat/app.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from datetime import datetime, timezone
 from uuid import uuid4
@@ -216,41 +217,44 @@ def _persist_feedback(
     try:
         get_store().record_feedback(fb)
     except (OSError, RuntimeError) as exc:
-        import logging
-
         logging.getLogger(__name__).warning("Failed to record feedback: %s", exc)
 
 
 # ---------------------------------------------------------------------------
 # Star rating callbacks (one per rating level)
+#
+# Chainlit's @cl.action_callback only accepts a plain string name — no regex
+# support.  We register 5 thin callbacks that all delegate to one helper,
+# keeping the logic in a single place.
 # ---------------------------------------------------------------------------
+
+
+async def _on_star(action: cl.Action, rating: int) -> None:
+    """Shared handler for all star rating actions."""
+    cl.user_session.set("pending_star", rating)
+    await _ask_sentiment(action.payload["trace_id"], rating)
 
 
 @cl.action_callback("star_1")
 async def on_star_1(action: cl.Action):
-    cl.user_session.set("pending_star", 1)
-    await _ask_sentiment(action.payload["trace_id"], 1)
+    await _on_star(action, 1)
 
 
 @cl.action_callback("star_2")
 async def on_star_2(action: cl.Action):
-    cl.user_session.set("pending_star", 2)
-    await _ask_sentiment(action.payload["trace_id"], 2)
+    await _on_star(action, 2)
 
 
 @cl.action_callback("star_3")
 async def on_star_3(action: cl.Action):
-    cl.user_session.set("pending_star", 3)
-    await _ask_sentiment(action.payload["trace_id"], 3)
+    await _on_star(action, 3)
 
 
 @cl.action_callback("star_4")
 async def on_star_4(action: cl.Action):
-    cl.user_session.set("pending_star", 4)
-    await _ask_sentiment(action.payload["trace_id"], 4)
+    await _on_star(action, 4)
 
 
 @cl.action_callback("star_5")
 async def on_star_5(action: cl.Action):
-    cl.user_session.set("pending_star", 5)
-    await _ask_sentiment(action.payload["trace_id"], 5)
+    await _on_star(action, 5)

--- a/.moon/templates/chainlit-chat/pyproject.toml
+++ b/.moon/templates/chainlit-chat/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "{{ project_name }}"
-version = "0.15.0" # x-release-please-version
+version = "0.17.0" # x-release-please-version
 description = "{{ description }}"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/.moon/templates/context/pyproject.toml
+++ b/.moon/templates/context/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "context"
-version = "0.15.0" # x-release-please-version
+version = "0.17.0" # x-release-please-version
 description = "Context assembly - format retrieved chunks into LLM-ready context strings"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/.moon/templates/pipelines/pyproject.toml
+++ b/.moon/templates/pipelines/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelines"
-version = "0.15.0" # x-release-please-version
+version = "0.17.0" # x-release-please-version
 description = "RAG pipeline orchestration - coordinate ingestion, retrieval, and context assembly"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -12,6 +12,7 @@ dependencies = [
     "reranking",
     "retrieval",
     "storage",
+    "tracing",
 ]
 
 [tool.uv.sources]
@@ -22,6 +23,7 @@ rag-core = { workspace = true }
 reranking = { workspace = true }
 retrieval = { workspace = true }
 storage = { workspace = true }
+tracing = { workspace = true }
 
 [build-system]
 requires = ["hatchling"]

--- a/.moon/templates/pipelines/src/rag_facile/pipelines/__init__.py
+++ b/.moon/templates/pipelines/src/rag_facile/pipelines/__init__.py
@@ -1,8 +1,9 @@
 """Pipelines - RAG pipeline coordination for chat applications.
 
 Provides a unified :class:`RAGPipeline` interface that coordinates
-document ingestion and retrieval.  Chat apps depend on this package
-instead of importing from rag_facile.ingestion or rag_facile.retrieval directly.
+document ingestion, retrieval, LLM generation, and conversation tracing.
+Chat apps depend on this package instead of importing from individual
+phase packages directly.
 
 Pipeline selection is driven by ``ragfacile.toml``::
 
@@ -12,10 +13,16 @@ Pipeline selection is driven by ``ragfacile.toml``::
 
 Example usage::
 
-    from rag_facile.pipelines import get_pipeline
+    from rag_facile.pipelines import get_pipeline, stream_answer
 
     pipeline = get_pipeline()
+
+    # Upload a document
     context = pipeline.process_file("document.pdf")
+
+    # Full RAG turn — stream tokens from the LLM
+    async for token in stream_answer("Quels sont vos horaires ?", history):
+        print(token, end="", flush=True)
 
 Convenience functions are also available for simpler call sites::
 
@@ -26,9 +33,13 @@ from __future__ import annotations
 
 import threading
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, AsyncGenerator
 
 from rag_facile.pipelines._base import RAGPipeline
+
+
+if TYPE_CHECKING:
+    pass
 
 
 # ── Singleton pipeline cache ──
@@ -152,6 +163,47 @@ def get_accepted_mime_types() -> dict[str, list[str]]:
     return _get_or_create_pipeline().accepted_mime_types
 
 
+async def stream_answer(
+    question: str,
+    message_history: list[dict[str, Any]],
+    **kwargs: object,
+) -> AsyncGenerator[str, None]:
+    """Full RAG turn: retrieve context, stream LLM answer, record trace.
+
+    Convenience wrapper around :meth:`RAGPipeline.stream_answer` using
+    the singleton pipeline.
+
+    Args:
+        question: Current user question (raw, without context injection).
+        message_history: Previous conversation turns — must **not** include
+            the current turn.
+        **kwargs: Forwarded to the pipeline — e.g. ``collection_ids``,
+            ``trace_id``, ``session_id``.
+
+    Yields:
+        Token strings as they arrive from the LLM.
+
+    Example::
+
+        from rag_facile.pipelines import stream_answer
+
+        async for token in stream_answer(
+            "Quels sont vos horaires ?",
+            message_history,
+            trace_id=trace_id,
+            session_id=session_id,
+            collection_ids=[785],
+        ):
+            print(token, end="", flush=True)
+    """
+    async for token in _get_or_create_pipeline().stream_answer(
+        question,
+        message_history,
+        **kwargs,  # ty: ignore[invalid-argument-type]
+    ):
+        yield token
+
+
 __all__ = [
     "RAGPipeline",
     "get_accepted_mime_types",
@@ -159,4 +211,5 @@ __all__ = [
     "process_bytes",
     "process_file",
     "process_query",
+    "stream_answer",
 ]

--- a/.moon/templates/pipelines/src/rag_facile/pipelines/_base.py
+++ b/.moon/templates/pipelines/src/rag_facile/pipelines/_base.py
@@ -7,16 +7,30 @@ ingestion or retrieval packages directly.
 
 from __future__ import annotations
 
+import json
+import logging
+import os
+import time
 from abc import ABC, abstractmethod
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING, Any, AsyncGenerator
+from uuid import uuid4
+
+
+if TYPE_CHECKING:
+    from albert import AsyncAlbertClient
+    from rag_facile.core.schema import RetrievedChunk
+
+
+logger = logging.getLogger(__name__)
 
 
 class RAGPipeline(ABC):
     """Abstract RAG pipeline for chat applications.
 
-    Provides a unified interface for both upload-time (file processing)
-    and query-time (retrieval) operations.  Concrete implementations
-    decide how to coordinate ingestion and retrieval.
+    Provides a unified interface for upload-time (file processing),
+    query-time (retrieval), and generation (LLM streaming + tracing).
 
     Subclasses must implement:
       - :meth:`process_file` — parse a file and return formatted context
@@ -24,8 +38,11 @@ class RAGPipeline(ABC):
       - :attr:`supported_extensions` — file extensions this pipeline handles
       - :attr:`accepted_mime_types` — MIME type map for file picker dialogs
 
-    Optional override:
-      - :meth:`process_query` — retrieve context for a user query
+    Optional overrides:
+      - :meth:`retrieve_chunks` — return raw :class:`RetrievedChunk` list
+        (default: empty list — used by :class:`~.basic.BasicPipeline`)
+      - :meth:`process_query` — formatted context string
+        (default: calls ``retrieve_chunks`` + ``format_context``)
     """
 
     # ── Upload-time: file processing ──
@@ -58,24 +75,205 @@ class RAGPipeline(ABC):
             Formatted text ready for context injection.
         """
 
-    # ── Query-time: retrieval ──
+    # ── Query-time: raw chunk retrieval ──
+
+    def retrieve_chunks(self, query: str, **kwargs: object) -> list[RetrievedChunk]:
+        """Retrieve raw chunks for a query.
+
+        The default implementation returns an empty list — suitable for
+        context-stuffing pipelines that pre-load the full document into
+        the prompt.  The Albert pipeline overrides this to perform
+        search → optional rerank.
+
+        Args:
+            query: User query to retrieve chunks for.
+            **kwargs: Pipeline-specific options (e.g. ``collection_ids``).
+
+        Returns:
+            List of :class:`~rag_facile.core.schema.RetrievedChunk` dicts,
+            sorted by relevance score (descending).  Empty list when not
+            applicable.
+        """
+        return []
+
+    # ── Query-time: formatted context string ──
 
     def process_query(self, query: str, **kwargs: object) -> str:
-        """Retrieve relevant context for a user query.
+        """Retrieve relevant context for a user query as a formatted string.
 
-        The default implementation is a no-op — suitable for basic pipelines
-        that rely on context stuffing (the full document is already in the
-        prompt).  The Albert pipeline overrides this to perform
-        search → rerank → format.
+        Calls :meth:`retrieve_chunks` then formats the result via
+        :func:`~rag_facile.context.format_context`.  Override this method
+        only if you need custom formatting logic.
 
         Args:
             query: User query to retrieve context for.
-            **kwargs: Pipeline-specific options (e.g., ``collection_ids``).
+            **kwargs: Forwarded to :meth:`retrieve_chunks`.
 
         Returns:
-            Formatted context string.  Empty string when not applicable.
+            Formatted context string.  Empty string when no chunks found.
         """
-        return ""
+        from rag_facile.context import format_context
+
+        return format_context(self.retrieve_chunks(query, **kwargs))
+
+    # ── Full RAG turn: retrieve + generate + trace ──
+
+    async def stream_answer(
+        self,
+        question: str,
+        message_history: list[dict[str, Any]],
+        *,
+        trace_id: str | None = None,
+        session_id: str = "",
+        **kwargs: object,
+    ) -> AsyncGenerator[str, None]:
+        """Full RAG turn: retrieve context, assemble prompt, stream LLM answer,
+        and record a trace.
+
+        This is the primary entry point for chat applications.  Apps call
+        this method instead of managing the LLM client directly.
+
+        Internally orchestrates:
+
+        1. :meth:`retrieve_chunks` — pipeline-specific retrieval
+        2. Prompt assembly — injects context into user message
+        3. LLM streaming — yields tokens as they arrive
+        4. Trace recording — writes to SQLite after the stream completes
+           (only when ``tracing.enabled = true`` in config)
+
+        Args:
+            question: Current user question (raw, without context injection).
+            message_history: Previous conversation turns, e.g.::
+
+                [
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user",      "content": "Bonjour"},
+                    {"role": "assistant", "content": "Bonjour ! Comment puis-je vous aider ?"},
+                ]
+
+                Must **not** include the current turn.  This method appends
+                it internally with context injected.
+
+            trace_id: Optional pre-generated UUID4.  Auto-generated when
+                *None*.  Pre-generating lets the caller associate user
+                feedback with the trace before the stream completes.
+            session_id: Identifier grouping multiple turns by conversation.
+                Use the Chainlit session ID or Reflex ``client_token``.
+            **kwargs: Forwarded to :meth:`retrieve_chunks` — e.g.
+                ``collection_ids``.
+
+        Yields:
+            Token strings as they arrive from the LLM.
+
+        Side effects:
+            On completion, writes a :class:`~rag_facile.tracing.TraceRecord`
+            to ``.rag-facile/traces.db`` when tracing is enabled.
+        """
+        from rag_facile.context import format_context
+        from rag_facile.core import get_config
+
+        config = get_config()
+        t0 = time.monotonic()
+        effective_trace_id = trace_id or str(uuid4())
+
+        # Step 1 — Retrieval (subclass-specific)
+        chunks = self.retrieve_chunks(question, **kwargs)
+
+        # Step 2 — Prompt assembly
+        retrieved_context = format_context(chunks)
+        user_content = question
+        if retrieved_context:
+            user_content = (
+                "Use the following context to answer the user's question:\n\n"
+                f"{retrieved_context}\n\n"
+                f"Question: {question}"
+            )
+        messages = [*message_history, {"role": "user", "content": user_content}]
+
+        # Step 3 — LLM streaming
+        model_alias = os.getenv("OPENAI_MODEL") or config.generation.model
+        stream = await self._async_llm_client.chat.completions.create(  # ty: ignore[no-matching-overload]
+            model=model_alias,
+            messages=messages,
+            stream=True,
+            temperature=config.generation.temperature,
+            max_tokens=config.generation.max_tokens,
+        )
+
+        resolved_model: str | None = None
+        answer_tokens: list[str] = []
+
+        try:
+            async for chunk in stream:
+                if resolved_model is None and getattr(chunk, "model", None):
+                    resolved_model = chunk.model
+                if chunk.choices and chunk.choices[0].delta.content:
+                    token = chunk.choices[0].delta.content
+                    answer_tokens.append(token)
+                    yield token
+        except json.JSONDecodeError:
+            # Albert API occasionally sends malformed SSE events; continue
+            # with whatever content was streamed so far.
+            pass
+
+        # Step 4 — Trace recording (after stream fully consumed)
+        if config.tracing.enabled:
+            system_prompt = next(
+                (m["content"] for m in message_history if m.get("role") == "system"),
+                None,
+            )
+            pipeline_config_snapshot = {
+                "top_k": config.retrieval.top_k,
+                "top_n": config.reranking.top_n,
+                "retrieval_strategy": config.retrieval.strategy,
+                "reranking_enabled": config.reranking.enabled,
+                "temperature": config.generation.temperature,
+                "query_strategy": config.query.strategy,
+            }
+            try:
+                from rag_facile.tracing import get_store
+
+                store = get_store(config)
+                store.record_turn(
+                    {
+                        "trace_id": effective_trace_id,
+                        "session_id": session_id,
+                        "created_at": datetime.now(timezone.utc).isoformat(),
+                        "question": question,
+                        "chunks": (
+                            json.dumps(list(chunks))
+                            if config.tracing.capture_chunks and chunks
+                            else None
+                        ),
+                        "prompt_sent": (
+                            user_content if config.tracing.capture_prompt else None
+                        ),
+                        "system_prompt": system_prompt,
+                        "answer": "".join(answer_tokens),
+                        "model_alias": model_alias,
+                        "model_resolved": resolved_model,
+                        "preset": config.meta.preset,
+                        "pipeline_config": json.dumps(pipeline_config_snapshot),
+                        "latency_ms": int((time.monotonic() - t0) * 1000),
+                    }
+                )
+            except (OSError, RuntimeError) as exc:
+                # Tracing must never break the chat experience
+                logger.warning("Failed to record trace: %s", exc)
+
+    # ── Async LLM client ──
+
+    @property
+    def _async_llm_client(self) -> AsyncAlbertClient:
+        """Lazy async LLM client for generation, shared across all pipelines."""
+        if not hasattr(self, "_async_llm_client_cache"):
+            from albert import AsyncAlbertClient as _AsyncAlbertClient
+
+            self._async_llm_client_cache = _AsyncAlbertClient(
+                api_key=os.getenv("OPENAI_API_KEY"),
+                base_url=os.getenv("OPENAI_BASE_URL"),
+            )
+        return self._async_llm_client_cache
 
     # ── Capabilities (for UI file dialogs) ──
 
@@ -91,5 +289,5 @@ class RAGPipeline(ABC):
 
         Returns:
             Dict mapping MIME types to extensions, e.g.
-            ``{"application/pdf": [".pdf"]}``.
+            ``{"application/pdf": [".pdf"]}``
         """

--- a/.moon/templates/pipelines/src/rag_facile/pipelines/albert.py
+++ b/.moon/templates/pipelines/src/rag_facile/pipelines/albert.py
@@ -21,6 +21,7 @@ from ._base import RAGPipeline
 
 if TYPE_CHECKING:
     from albert import AlbertClient
+    from rag_facile.core.schema import RetrievedChunk
 
 
 logger = logging.getLogger(__name__)
@@ -31,11 +32,14 @@ class AlbertPipeline(RAGPipeline):
 
     Documents are uploaded to an auto-managed Albert collection on first
     file upload.  At query time, relevant chunks are retrieved via
-    search -> optional rerank -> context formatting.
+    search -> optional rerank.
 
     Collection management is delegated to the storage package.
-    Query-time retrieval orchestrates: search -> rerank -> format
-    using the retrieval, reranking, and context packages.
+    Query-time retrieval orchestrates: search -> rerank
+    using the retrieval and reranking packages.
+
+    Generation (LLM streaming) and tracing are handled by the base class
+    :meth:`~RAGPipeline.stream_answer` method.
     """
 
     def __init__(self, config: Any | None = None) -> None:
@@ -138,14 +142,14 @@ class AlbertPipeline(RAGPipeline):
         logger.info("Ingested '%s' into collection %s", filename, collection_id)
         return f"[Document indexed: {filename}]"
 
-    # ── Query-time: [expand ->] search -> [fuse ->] rerank -> format ──
+    # ── Query-time: raw chunk retrieval ──
 
-    def process_query(
+    def retrieve_chunks(
         self,
         query: str,
         **kwargs: object,
-    ) -> str:
-        """Retrieve relevant context from Albert collections.
+    ) -> list[RetrievedChunk]:
+        """Retrieve raw chunks from Albert collections.
 
         Orchestrates the full retrieval pipeline:
 
@@ -153,22 +157,21 @@ class AlbertPipeline(RAGPipeline):
         1. Search for relevant chunks — one call per expanded query (retrieval)
         2. Fuse multi-query results via RRF (retrieval) — only when expanded
         3. Rerank results using the original query (reranking)
-        4. Format chunks as LLM context (context)
 
         All parameters default to ragfacile.toml config values.
 
         Args:
-            query: User query to retrieve context for.
+            query: User query to retrieve chunks for.
             **kwargs: Pipeline options.
                 ``collection_ids``: Albert collection IDs to search.
                     Falls back to the auto-managed session collection.
                 ``client``: Optional pre-configured Albert client.
 
         Returns:
-            Formatted context string ready for LLM injection.
-            Empty string if no collection exists or no results found.
+            List of :class:`~rag_facile.core.schema.RetrievedChunk` dicts,
+            sorted by relevance score.  Empty list when no collections are
+            available or no results are found.
         """
-        from rag_facile.context import format_context
         from rag_facile.core import get_config
         from rag_facile.reranking import rerank_chunks
         from rag_facile.retrieval import fuse_results, search_chunks
@@ -196,13 +199,11 @@ class AlbertPipeline(RAGPipeline):
 
         if not ids:
             logger.info("No collection IDs to search — skipping retrieval")
-            return ""
+            return []
         collection_ids = list(ids)
         logger.info("Searching collections: %s", collection_ids)
 
         # Step 0: Query expansion (optional)
-        # When enabled, generates N query variants in formal French administrative
-        # language. Results are merged via RRF before reranking.
         if config.query.strategy != "none":
             from rag_facile.query import get_expander
 
@@ -240,9 +241,9 @@ class AlbertPipeline(RAGPipeline):
             )
 
         if not chunks:
-            return ""
+            return []
 
-        # Step 2 (was Step 2): Rerank — always uses the ORIGINAL query for precision
+        # Step 2: Rerank — always uses the ORIGINAL query for precision
         if config.reranking.enabled:
             chunks = rerank_chunks(
                 client,
@@ -252,8 +253,7 @@ class AlbertPipeline(RAGPipeline):
                 top_n=config.reranking.top_n,
             )
 
-        # Step 3 (was Step 3): Format as LLM context
-        return format_context(chunks)
+        return chunks
 
     # ── Collection management (delegated to storage) ──
 

--- a/.moon/templates/rag-core/pyproject.toml
+++ b/.moon/templates/rag-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rag-core"
-version = "0.15.0" # x-release-please-version
+version = "0.17.0" # x-release-please-version
 description = "Core library for RAG Facile - configuration, utils, and shared models"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/.moon/templates/rag-core/src/rag_facile/core/schema.py
+++ b/.moon/templates/rag-core/src/rag_facile/core/schema.py
@@ -494,6 +494,32 @@ class FormattingConfig(BaseModel):
 
 
 # ==============================================================================
+# TRACING
+# ==============================================================================
+
+
+class TracingConfig(BaseModel):
+    """Configuration for conversation tracing and user feedback collection."""
+
+    enabled: bool = Field(
+        default=True,
+        description="Log RAG turns to SQLite (.rag-facile/traces.db)",
+    )
+    db_path: str = Field(
+        default=".rag-facile/traces.db",
+        description="SQLite database path (relative to workspace root)",
+    )
+    capture_prompt: bool = Field(
+        default=True,
+        description="Store full prompt with injected context (disable for RGPD if needed)",
+    )
+    capture_chunks: bool = Field(
+        default=True,
+        description="Store raw retrieved chunks with relevance scores",
+    )
+
+
+# ==============================================================================
 # ROOT CONFIG
 # ==============================================================================
 
@@ -565,6 +591,10 @@ class RAGConfig(BaseModel):
     formatting: FormattingConfig = Field(
         default_factory=FormattingConfig,
         description="Answer formatting",
+    )
+    tracing: TracingConfig = Field(
+        default_factory=TracingConfig,
+        description="Conversation tracing and user feedback",
     )
 
     model_config = {
@@ -705,6 +735,13 @@ PIPELINE_STAGES: list[PipelineStage] = [
         description="Generate synthetic Q/A datasets to measure RAG pipeline quality.",
         emoji="\U0001f4ca",
         model=EvalConfig,
+    ),
+    PipelineStage(
+        key="tracing",
+        title="Conversation Tracing",
+        description="Log RAG turns (question, chunks, prompt, answer, model, config) to SQLite for quality analysis and user feedback collection.",
+        emoji="\U0001f4dd",
+        model=TracingConfig,
     ),
 ]
 

--- a/.moon/templates/reflex-chat/app/components/chat.py
+++ b/.moon/templates/reflex-chat/app/components/chat.py
@@ -5,7 +5,7 @@ from typing import cast
 from collections.abc import Sequence
 
 from rag_facile.pipelines import get_accepted_mime_types
-from {{ project_name | replace(from='-', to='_') }}.state import QA, State
+from {{ project_name | replace(from='-', to='_') }}.state import NEGATIVE_TAGS, POSITIVE_TAGS, QA, State
 
 
 def _get_upload_accept() -> dict[str, Sequence[str]]:
@@ -58,10 +58,188 @@ def message(qa: QA) -> rx.Component:
     )
 
 
+def star_button(i: int) -> rx.Component:
+    """A single star in the rating row."""
+    return rx.icon_button(
+        rx.icon(
+            rx.cond(State.feedback_star >= i, "star", "star"),
+            size=18,
+            color=rx.cond(
+                State.feedback_star >= i,
+                rx.color("yellow", 9),
+                rx.color("mauve", 8),
+            ),
+        ),
+        variant="ghost",
+        on_click=State.set_feedback_star(i),
+        cursor="pointer",
+        size="1",
+    )
+
+
+def tag_chip(tag: str) -> rx.Component:
+    """A toggleable quality tag chip."""
+    is_selected = State.feedback_tags.contains(tag)
+    return rx.badge(
+        tag,
+        variant=rx.cond(is_selected, "solid", "outline"),
+        color_scheme=rx.cond(
+            State.feedback_sentiment == "positive",
+            rx.cond(is_selected, "green", "gray"),
+            rx.cond(is_selected, "red", "gray"),
+        ),
+        cursor="pointer",
+        on_click=State.toggle_feedback_tag(tag),
+        size="1",
+    )
+
+
+def feedback_panel() -> rx.Component:
+    """Collapsible user feedback panel shown after each answer."""
+    return rx.cond(
+        State.feedback_visible,
+        rx.box(
+            rx.vstack(
+                # Header
+                rx.hstack(
+                    rx.text(
+                        "Comment évaluez-vous la réponse ?",
+                        font_size="0.9em",
+                        font_weight="600",
+                        color=rx.color("mauve", 12),
+                    ),
+                    rx.spacer(),
+                    rx.icon_button(
+                        rx.icon("chevron-up", size=14),
+                        variant="ghost",
+                        size="1",
+                        on_click=State.dismiss_feedback,
+                        cursor="pointer",
+                        color=rx.color("mauve", 10),
+                    ),
+                    width="100%",
+                    align_items="center",
+                ),
+                # Star rating row
+                rx.hstack(
+                    star_button(1),
+                    star_button(2),
+                    star_button(3),
+                    star_button(4),
+                    star_button(5),
+                    spacing="1",
+                ),
+                # Thumbs up/down row
+                rx.hstack(
+                    rx.icon_button(
+                        rx.icon("thumbs-up", size=16),
+                        variant=rx.cond(
+                            State.feedback_sentiment == "positive", "solid", "soft"
+                        ),
+                        color_scheme=rx.cond(
+                            State.feedback_sentiment == "positive", "green", "gray"
+                        ),
+                        on_click=State.set_feedback_sentiment("positive"),
+                        cursor="pointer",
+                        size="2",
+                    ),
+                    rx.flex(
+                        rx.foreach(
+                            POSITIVE_TAGS,
+                            lambda t: rx.cond(
+                                State.feedback_sentiment == "positive",
+                                tag_chip(t),
+                                rx.fragment(),
+                            ),
+                        ),
+                        wrap="wrap",
+                        gap="1",
+                    ),
+                    spacing="2",
+                    align_items="flex-start",
+                    width="100%",
+                ),
+                rx.hstack(
+                    rx.icon_button(
+                        rx.icon("thumbs-down", size=16),
+                        variant=rx.cond(
+                            State.feedback_sentiment == "negative", "solid", "soft"
+                        ),
+                        color_scheme=rx.cond(
+                            State.feedback_sentiment == "negative", "red", "gray"
+                        ),
+                        on_click=State.set_feedback_sentiment("negative"),
+                        cursor="pointer",
+                        size="2",
+                    ),
+                    rx.flex(
+                        rx.foreach(
+                            NEGATIVE_TAGS,
+                            lambda t: rx.cond(
+                                State.feedback_sentiment == "negative",
+                                tag_chip(t),
+                                rx.fragment(),
+                            ),
+                        ),
+                        wrap="wrap",
+                        gap="1",
+                    ),
+                    spacing="2",
+                    align_items="flex-start",
+                    width="100%",
+                ),
+                # Comment field
+                rx.vstack(
+                    rx.text(
+                        "Commentaires",
+                        font_size="0.8em",
+                        color=rx.color("mauve", 11),
+                    ),
+                    rx.text_area(
+                        placeholder="Entrez vos commentaires",
+                        value=State.feedback_comment,
+                        on_change=State.set_feedback_comment,
+                        width="100%",
+                        rows="3",
+                        resize="none",
+                        font_size="0.85em",
+                        border_color=rx.color("mauve", 6),
+                        border_radius="6px",
+                    ),
+                    width="100%",
+                    spacing="1",
+                ),
+                # Submit button
+                rx.hstack(
+                    rx.spacer(),
+                    rx.button(
+                        "Enregistrer",
+                        on_click=State.submit_feedback,
+                        color_scheme="blue",
+                        size="2",
+                        cursor="pointer",
+                    ),
+                    width="100%",
+                ),
+                spacing="3",
+                width="100%",
+                padding="16px",
+            ),
+            max_width="50em",
+            margin_inline="auto",
+            margin_block="8px",
+            border="1px solid var(--gray-a5)",
+            border_radius="12px",
+            background_color=rx.color("mauve", 2),
+        ),
+    )
+
+
 def chat() -> rx.Component:
     """List all the messages in a single conversation."""
     return rx.auto_scroll(
         rx.foreach(State.selected_chat, message),
+        rx.cond(State.feedback_visible, feedback_panel()),
         flex="1",
         padding="8px",
     )

--- a/.moon/templates/reflex-chat/app/state.py
+++ b/.moon/templates/reflex-chat/app/state.py
@@ -1,14 +1,14 @@
 import os
-import json
+from datetime import datetime, timezone
 from typing import Any, TypedDict
+from uuid import uuid4
 
 import reflex as rx
-from rag_facile.pipelines import process_bytes, process_query
 from dotenv import load_dotenv
-
-from albert import AlbertClient, ChatCompletionMessageParam
 from rag_facile.core import get_config
 from rag_facile.core.mediatech import get_collection_name
+from rag_facile.pipelines import process_bytes, stream_answer
+from rag_facile.tracing import FeedbackRecord, get_store
 
 
 # Load .env file
@@ -23,6 +23,21 @@ if not os.getenv("OPENAI_API_KEY"):
 
 if not os.getenv("OPENAI_BASE_URL"):
     raise Exception("Please set OPENAI_BASE_URL environment variable for Albert API.")
+
+
+# ---------------------------------------------------------------------------
+# Feedback tag taxonomy
+# ---------------------------------------------------------------------------
+
+POSITIVE_TAGS = ["Pertinent", "Complet", "Clair", "Utile", "Précis"]
+NEGATIVE_TAGS = [
+    "Non pertinent",
+    "Incomplet",
+    "Confus",
+    "Éléments faux",
+    "Sources manquantes",
+    "Sources erronées / obsolètes",
+]
 
 
 class QA(TypedDict):
@@ -63,11 +78,21 @@ class State(rx.State):
         str(col_id): True for col_id in rag_config.storage.collections
     }
 
+    # ── Feedback state ──
+    last_trace_id: str = ""
+    feedback_star: int = 0  # 0 = unrated
+    feedback_sentiment: str = ""  # "" | "positive" | "negative"
+    feedback_tags: list[str] = []
+    feedback_comment: str = ""
+    feedback_submitted: bool = False
+    feedback_visible: bool = False  # controls panel visibility
+
+    # ── Collection management ──
+
     @rx.event
     def toggle_collection(self, col_id: str):
         """Toggle a collection on/off for RAG retrieval."""
         self.active_collections[col_id] = not self.active_collections.get(col_id, True)
-        # Force state refresh
         self.active_collections = self.active_collections
 
     @rx.var
@@ -83,6 +108,8 @@ class State(rx.State):
             name = get_collection_name(int(col_id_str)) or f"Collection {col_id_str}"
             items.append({"id": col_id_str, "name": name, "enabled": str(enabled)})
         return items
+
+    # ── File upload ──
 
     async def handle_upload(self, files: list[rx.UploadFile]):
         """Upload files to Albert collection for RAG retrieval."""
@@ -100,14 +127,14 @@ class State(rx.State):
         """Clear an attached file from the UI list."""
         if filename in self.attached_files:
             self.attached_files.remove(filename)
-
         if not self.attached_files:
             self.has_indexed_docs = False
+
+    # ── Chat management ──
 
     @rx.event
     def create_chat(self, form_data: dict[str, Any]):
         """Create a new chat."""
-        # Add the new chat to the list of chats.
         new_chat_name = form_data["new_chat_name"]
         self.current_chat = new_chat_name
         self._chats[new_chat_name] = []
@@ -115,20 +142,12 @@ class State(rx.State):
 
     @rx.event
     def set_is_modal_open(self, is_open: bool):
-        """Set the new chat modal open state.
-
-        Args:
-            is_open: Whether the modal is open.
-        """
+        """Set the new chat modal open state."""
         self.is_modal_open = is_open
 
     @rx.var
     def selected_chat(self) -> list[QA]:
-        """Get the list of questions and answers for the current chat.
-
-        Returns:
-            The list of questions and answers.
-        """
+        """Get the list of questions and answers for the current chat."""
         return (
             self._chats[self.current_chat] if self.current_chat in self._chats else []
         )
@@ -140,130 +159,149 @@ class State(rx.State):
             return
         del self._chats[chat_name]
         if len(self._chats) == 0:
-            self._chats = {
-                "Intros": [],
-            }
+            self._chats = {"Intros": []}
         if self.current_chat not in self._chats:
             self.current_chat = list(self._chats.keys())[0]
 
     @rx.event
     def set_chat(self, chat_name: str):
-        """Set the name of the current chat.
-
-        Args:
-            chat_name: The name of the chat.
-        """
+        """Set the name of the current chat."""
         self.current_chat = chat_name
 
     @rx.event
     def set_new_chat_name(self, new_chat_name: str):
-        """Set the name of the new chat.
-
-        Args:
-            new_chat_name: The name of the new chat.
-        """
+        """Set the name of the new chat."""
         self.new_chat_name = new_chat_name
 
     @rx.var
     def chat_titles(self) -> list[str]:
-        """Get the list of chat titles.
-
-        Returns:
-            The list of chat names.
-        """
+        """Get the list of chat titles."""
         return list(self._chats.keys())
+
+    # ── Question processing ──
 
     @rx.event
     async def process_question(self, form_data: dict[str, Any]):
-        # Get the question from the form
         question = form_data["question"]
-
-        # Check if the question is empty
         if not question:
             return
-
         async for value in self.openai_process_question(question):
             yield value
 
     @rx.event
     async def openai_process_question(self, question: str):
-        """Get the response from the API.
-
-        Args:
-            form_data: A dict with the current question.
-        """
-
-        # Add the question to the list of questions.
+        """Get the response from the pipeline (retrieve + stream + trace)."""
+        # Add the question to the list of questions
         qa = QA(question=question, answer="")
         self._chats[self.current_chat].append(qa)
 
-        # Clear the input and start the processing.
+        # Reset feedback state for this new turn
+        trace_id = str(uuid4())
+        self.last_trace_id = trace_id
+        self.feedback_star = 0
+        self.feedback_sentiment = ""
+        self.feedback_tags = []
+        self.feedback_comment = ""
+        self.feedback_submitted = False
+        self.feedback_visible = False
+
         self.processing = True
         yield
 
-        # Build the messages (uses config system prompt)
-        messages: list[ChatCompletionMessageParam] = [
-            {
-                "role": "system",
-                "content": rag_config.generation.system_prompt,
-            }
+        # Build message history (system prompt + previous turns, NOT current)
+        messages: list[dict[str, str]] = [
+            {"role": "system", "content": rag_config.generation.system_prompt}
         ]
-
-        for qa in self._chats[self.current_chat]:
+        for qa in self._chats[self.current_chat][:-1]:  # exclude current (last) turn
             messages.append({"role": "user", "content": qa["question"]})
             messages.append({"role": "assistant", "content": qa["answer"]})
 
-        # Remove the last mock answer.
-        messages = messages[:-1]
-
-        # Retrieve relevant context via RAG pipeline (search -> rerank -> format)
-        # Combine context with the current question to avoid accumulating
-        # system messages in the conversation history.
-        retrieved_context = process_query(
-            question, collection_ids=self.enabled_collection_ids
-        )
-        if retrieved_context:
-            messages[-1]["content"] = (
-                "Use the following context to answer the user's question:\n\n"
-                f"{retrieved_context}\n\n"
-                f"Question: {question}"
-            )
-
-        # Start a new session to answer the question (uses config values)
-        # Model comes from config with env var override
-        model = os.getenv("OPENAI_MODEL") or rag_config.generation.model
-        gen_params = {
-            "stream": rag_config.generation.streaming,
-            "temperature": rag_config.generation.temperature,
-            "max_tokens": rag_config.generation.max_tokens,
-        }
-        session = AlbertClient(
-            base_url=os.getenv("OPENAI_BASE_URL"),
-        ).chat.completions.create(
-            model=model,
-            messages=messages,
-            **gen_params,
-        )
-
-        # Stream the results, yielding after every word.
+        # Stream tokens from the pipeline (retrieve → prompt → LLM → trace)
         try:
-            for item in session:
-                if item.choices and hasattr(item.choices[0].delta, "content"):
-                    answer_text = item.choices[0].delta.content
-                    # Ensure answer_text is not None before concatenation
-                    if answer_text is not None:
-                        self._chats[self.current_chat][-1]["answer"] += answer_text
-                    else:
-                        # Handle the case where answer_text is None,
-                        # perhaps log it or assign a default value.
-                        answer_text = ""
-                        self._chats[self.current_chat][-1]["answer"] += answer_text
-                    self._chats = self._chats
-                    yield
-        except json.JSONDecodeError:
-            # Albert API occasionally sends malformed SSE events; continue
-            # with whatever content was streamed so far.
-            pass
+            async for token in stream_answer(
+                question,
+                messages,
+                trace_id=trace_id,
+                session_id=self.router.session.client_token,
+                collection_ids=self.enabled_collection_ids,
+            ):
+                self._chats[self.current_chat][-1]["answer"] += token
+                self._chats = self._chats
+                yield
+        except Exception as exc:  # noqa: BLE001 — broad catch to avoid breaking chat
+            import logging
 
-        # Toggle the processing flag.
+            logging.getLogger(__name__).error("stream_answer error: %s", exc)
+
         self.processing = False
+        # Show feedback panel after answer is complete
+        if rag_config.tracing.enabled:
+            self.feedback_visible = True
+        yield
+
+    # ── Feedback events ──
+
+    @rx.event
+    def set_feedback_star(self, rating: int):
+        """Set the star rating."""
+        self.feedback_star = rating
+
+    @rx.event
+    def set_feedback_sentiment(self, sentiment: str):
+        """Set the sentiment (positive/negative) and reset tags."""
+        self.feedback_sentiment = sentiment
+        self.feedback_tags = []
+
+    @rx.event
+    def toggle_feedback_tag(self, tag: str):
+        """Toggle a quality tag on/off."""
+        if tag in self.feedback_tags:
+            self.feedback_tags = [t for t in self.feedback_tags if t != tag]
+        else:
+            self.feedback_tags = [*self.feedback_tags, tag]
+
+    @rx.event
+    def set_feedback_comment(self, comment: str):
+        """Update the free-text comment."""
+        self.feedback_comment = comment
+
+    @rx.event
+    def submit_feedback(self):
+        """Persist the feedback record to SQLite."""
+        if not self.last_trace_id:
+            return
+
+        fb: FeedbackRecord = {
+            "feedback_id": str(uuid4()),
+            "trace_id": self.last_trace_id,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "star_rating": self.feedback_star or None,
+            "sentiment": self.feedback_sentiment or None,
+            "tags": self.feedback_tags,
+            "comment": self.feedback_comment.strip() or None,
+        }
+        try:
+            get_store().record_feedback(fb)
+        except (OSError, RuntimeError) as exc:
+            import logging
+
+            logging.getLogger(__name__).warning("Failed to record feedback: %s", exc)
+
+        self.feedback_submitted = True
+        self.feedback_visible = False
+
+    @rx.event
+    def dismiss_feedback(self):
+        """Dismiss the feedback panel without submitting."""
+        self.feedback_visible = False
+
+    # ── Computed vars for feedback UI ──
+
+    @rx.var
+    def current_tags(self) -> list[str]:
+        """Tags appropriate for the current sentiment selection."""
+        if self.feedback_sentiment == "positive":
+            return POSITIVE_TAGS
+        if self.feedback_sentiment == "negative":
+            return NEGATIVE_TAGS
+        return []

--- a/.moon/templates/reflex-chat/app/state.py
+++ b/.moon/templates/reflex-chat/app/state.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from datetime import datetime, timezone
 from typing import Any, TypedDict
@@ -229,8 +230,6 @@ class State(rx.State):
                 self._chats = self._chats
                 yield
         except Exception as exc:  # noqa: BLE001 — broad catch to avoid breaking chat
-            import logging
-
             logging.getLogger(__name__).error("stream_answer error: %s", exc)
 
         self.processing = False
@@ -283,8 +282,6 @@ class State(rx.State):
         try:
             get_store().record_feedback(fb)
         except (OSError, RuntimeError) as exc:
-            import logging
-
             logging.getLogger(__name__).warning("Failed to record feedback: %s", exc)
 
         self.feedback_submitted = True

--- a/.moon/templates/reflex-chat/pyproject.toml
+++ b/.moon/templates/reflex-chat/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "{{ project_name }}"
-version = "0.15.0" # x-release-please-version
+version = "0.17.0" # x-release-please-version
 description = "{{ description }}"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/.moon/templates/reranking/pyproject.toml
+++ b/.moon/templates/reranking/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "reranking"
-version = "0.15.0" # x-release-please-version
+version = "0.17.0" # x-release-please-version
 description = "Reranking - re-score retrieved chunks with a cross-encoder for higher precision"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/.moon/templates/retrieval/pyproject.toml
+++ b/.moon/templates/retrieval/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "retrieval"
-version = "0.15.0" # x-release-please-version
+version = "0.17.0" # x-release-please-version
 description = "Unified retrieval package - basic context injection and Albert RAG"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/.moon/templates/storage/pyproject.toml
+++ b/.moon/templates/storage/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "storage"
-version = "0.15.0" # x-release-please-version
+version = "0.17.0" # x-release-please-version
 description = "Vector storage and collection management for the RAG pipeline"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/.moon/templates/tracing/README.md
+++ b/.moon/templates/tracing/README.md
@@ -1,0 +1,5 @@
+# tracing
+
+RAG conversation tracing and user feedback collection for rag-facile.
+
+Logs every RAG turn (question, retrieved chunks, prompt, answer, model, pipeline config) to a local SQLite database and stores user feedback (star rating, quality tags, free-text comment).

--- a/.moon/templates/tracing/pyproject.toml
+++ b/.moon/templates/tracing/pyproject.toml
@@ -1,16 +1,14 @@
 [project]
-name = "ingestion"
+name = "tracing"
 version = "0.17.0" # x-release-please-version
-description = "Document ingestion - parse and extract text from files (PDF, Markdown, HTML)"
+description = "RAG conversation tracing — log turns to SQLite and collect user feedback"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "albert-client",
     "rag-core",
 ]
 
 [tool.uv.sources]
-albert-client = { workspace = true }
 rag-core = { workspace = true }
 
 [build-system]

--- a/.moon/templates/tracing/src/rag_facile/tracing/__init__.py
+++ b/.moon/templates/tracing/src/rag_facile/tracing/__init__.py
@@ -1,0 +1,76 @@
+"""Tracing — RAG conversation logging and user feedback collection.
+
+Records every RAG turn (question, retrieved chunks, injected prompt, LLM
+answer, resolved model name, pipeline config, latency) to a local SQLite
+database.  User feedback (star rating, quality tags, free-text comment) is
+stored in a linked ``feedback`` table.
+
+The database is created automatically at ``.rag-facile/traces.db`` in the
+workspace root on first use.
+
+Basic usage::
+
+    from rag_facile.tracing import get_store
+
+    store = get_store()
+    store.record_turn({...})          # called by the pipeline
+    store.record_feedback({...})      # called by the UI feedback handler
+
+Export for RAGAS evaluation::
+
+    samples = store.export_ragas(limit=200)
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from ._models import FeedbackRecord, TraceRecord
+from ._store import TraceStore
+
+
+if TYPE_CHECKING:
+    pass
+
+
+# ── Singleton store cache ──
+
+_store: TraceStore | None = None
+_lock = threading.Lock()
+
+
+def get_store(config: Any | None = None) -> TraceStore:
+    """Return the singleton :class:`TraceStore`, creating it on first call.
+
+    The database path is taken from ``config.tracing.db_path``
+    (default: ``.rag-facile/traces.db`` relative to the working directory).
+
+    Args:
+        config: Optional ``RAGConfig`` instance.  Loaded from
+            ``ragfacile.toml`` if *None*.
+
+    Returns:
+        The shared :class:`TraceStore` instance.
+    """
+    global _store  # noqa: PLW0603
+    if _store is None:
+        with _lock:
+            if _store is None:
+                if config is None:
+                    from rag_facile.core import get_config
+
+                    config = get_config()
+                db_path = Path(config.tracing.db_path)
+                _store = TraceStore(db_path)
+    assert _store is not None
+    return _store
+
+
+__all__ = [
+    "FeedbackRecord",
+    "TraceRecord",
+    "TraceStore",
+    "get_store",
+]

--- a/.moon/templates/tracing/src/rag_facile/tracing/_models.py
+++ b/.moon/templates/tracing/src/rag_facile/tracing/_models.py
@@ -1,0 +1,76 @@
+"""TypedDicts for trace and feedback records."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class TraceRecord(TypedDict):
+    """A single RAG turn trace record stored in SQLite."""
+
+    trace_id: str
+    """UUID4 identifying this trace."""
+
+    session_id: str
+    """Chainlit/Reflex session token — groups turns by conversation."""
+
+    created_at: str
+    """ISO-8601 UTC timestamp, e.g. ``"2026-02-20T17:30:00.000000+00:00"``."""
+
+    question: str
+    """Raw user question before context injection."""
+
+    chunks: str | None
+    """JSON-serialised ``list[RetrievedChunk]`` or ``None`` when
+    ``tracing.capture_chunks = false``."""
+
+    prompt_sent: str | None
+    """Full user message with injected context or ``None`` when
+    ``tracing.capture_prompt = false``."""
+
+    system_prompt: str | None
+    """System prompt used for this turn."""
+
+    answer: str
+    """Complete LLM response (all streamed tokens joined)."""
+
+    model_alias: str
+    """Model alias sent to the API, e.g. ``"openweight-large"``."""
+
+    model_resolved: str | None
+    """Actual model ID from the API response, e.g.
+    ``"meta-llama/Llama-3.3-70B-Instruct"``."""
+
+    preset: str | None
+    """Active preset name from ``config.meta.preset``."""
+
+    pipeline_config: str
+    """JSON snapshot of key pipeline parameters (top_k, top_n, strategy, …)."""
+
+    latency_ms: int | None
+    """End-to-end latency from question received to last token yielded."""
+
+
+class FeedbackRecord(TypedDict):
+    """User evaluation attached to a trace."""
+
+    feedback_id: str
+    """UUID4."""
+
+    trace_id: str
+    """FK → ``traces.trace_id``."""
+
+    created_at: str
+    """ISO-8601 UTC timestamp."""
+
+    star_rating: int | None
+    """1–5 star rating, or ``None`` if the user skipped rating."""
+
+    sentiment: str | None
+    """``"positive"`` | ``"negative"`` | ``None``."""
+
+    tags: list[str]
+    """Selected quality tags, e.g. ``["Pertinent", "Complet"]``."""
+
+    comment: str | None
+    """Free-text comment, or ``None``."""

--- a/.moon/templates/tracing/src/rag_facile/tracing/_store.py
+++ b/.moon/templates/tracing/src/rag_facile/tracing/_store.py
@@ -1,0 +1,304 @@
+"""SQLite-backed trace and feedback store.
+
+All storage is handled by a single ``.db`` file in the workspace's
+``.rag-facile/`` directory.  No external dependencies — uses the
+Python standard-library ``sqlite3`` module exclusively.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from ._models import FeedbackRecord, TraceRecord
+
+
+if TYPE_CHECKING:
+    pass
+
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# DDL
+# ---------------------------------------------------------------------------
+
+_DDL = """
+CREATE TABLE IF NOT EXISTS traces (
+    trace_id        TEXT PRIMARY KEY,
+    session_id      TEXT NOT NULL,
+    created_at      TEXT NOT NULL,
+    question        TEXT NOT NULL,
+    chunks          TEXT,
+    prompt_sent     TEXT,
+    system_prompt   TEXT,
+    answer          TEXT NOT NULL,
+    model_alias     TEXT NOT NULL,
+    model_resolved  TEXT,
+    preset          TEXT,
+    pipeline_config TEXT NOT NULL,
+    latency_ms      INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS feedback (
+    feedback_id TEXT PRIMARY KEY,
+    trace_id    TEXT NOT NULL REFERENCES traces(trace_id),
+    created_at  TEXT NOT NULL,
+    star_rating INTEGER,
+    sentiment   TEXT,
+    tags        TEXT,
+    comment     TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_traces_session  ON traces(session_id);
+CREATE INDEX IF NOT EXISTS idx_traces_created  ON traces(created_at);
+CREATE INDEX IF NOT EXISTS idx_feedback_trace  ON feedback(trace_id);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS traces_fts USING fts5(
+    question, answer,
+    content=traces, content_rowid=rowid
+);
+
+CREATE VIEW IF NOT EXISTS ragas_export AS
+SELECT
+    t.trace_id,
+    t.question           AS user_input,
+    t.chunks             AS retrieved_contexts_json,
+    t.answer             AS response,
+    json_object(
+        'model_resolved', t.model_resolved,
+        'model_alias',    t.model_alias,
+        'preset',         t.preset,
+        'pipeline_config', json(t.pipeline_config),
+        'star_rating',    f.star_rating,
+        'sentiment',      f.sentiment,
+        'tags',           json(f.tags)
+    )                    AS _metadata
+FROM traces t
+LEFT JOIN feedback f ON f.trace_id = t.trace_id;
+"""
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+
+class TraceStore:
+    """SQLite-backed store for RAG turn traces and user feedback.
+
+    Creates the database file and schema automatically on first use.
+    Thread-safe for single-writer / multi-reader workloads (SQLite WAL mode).
+
+    Args:
+        db_path: Path to the SQLite database file.
+    """
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._db_path = Path(db_path)
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+
+    # ── Initialisation ──
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        return conn
+
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(_DDL)
+
+    # ── Write ──
+
+    def record_turn(self, record: TraceRecord) -> str:
+        """Insert a trace record and return its ``trace_id``.
+
+        Args:
+            record: Completed RAG turn data.
+
+        Returns:
+            The ``trace_id`` of the inserted record.
+        """
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO traces (
+                    trace_id, session_id, created_at,
+                    question, chunks, prompt_sent, system_prompt,
+                    answer, model_alias, model_resolved,
+                    preset, pipeline_config, latency_ms
+                ) VALUES (
+                    :trace_id, :session_id, :created_at,
+                    :question, :chunks, :prompt_sent, :system_prompt,
+                    :answer, :model_alias, :model_resolved,
+                    :preset, :pipeline_config, :latency_ms
+                )
+                """,
+                record,
+            )
+        logger.debug(
+            "Recorded trace %s (latency=%sms)", record["trace_id"], record["latency_ms"]
+        )
+        return record["trace_id"]
+
+    def record_feedback(self, fb: FeedbackRecord) -> None:
+        """Insert or replace a feedback record.
+
+        Args:
+            fb: User evaluation data linked to a trace.
+        """
+        # Serialise tags list → JSON string for storage
+        row: dict[str, Any] = {**fb, "tags": json.dumps(fb["tags"])}
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO feedback (
+                    feedback_id, trace_id, created_at,
+                    star_rating, sentiment, tags, comment
+                ) VALUES (
+                    :feedback_id, :trace_id, :created_at,
+                    :star_rating, :sentiment, :tags, :comment
+                )
+                """,
+                row,
+            )
+        logger.debug(
+            "Recorded feedback %s for trace %s", fb["feedback_id"], fb["trace_id"]
+        )
+
+    # ── Read ──
+
+    def recent(self, n: int = 20) -> list[dict[str, Any]]:
+        """Return the *n* most recent traces (newest first).
+
+        Each row includes any linked feedback fields (NULL when absent).
+
+        Args:
+            n: Maximum number of rows to return.
+
+        Returns:
+            List of dicts with combined trace + feedback fields.
+        """
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT
+                    t.trace_id, t.session_id, t.created_at,
+                    t.question, t.answer,
+                    t.model_alias, t.model_resolved,
+                    t.preset, t.latency_ms,
+                    f.star_rating, f.sentiment, f.tags
+                FROM traces t
+                LEFT JOIN feedback f ON f.trace_id = t.trace_id
+                ORDER BY t.created_at DESC
+                LIMIT ?
+                """,
+                (n,),
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    def export_ragas(self, limit: int = 1000) -> list[dict[str, Any]]:
+        """Export traces in RAGAS ``SingleTurnSample``-compatible format.
+
+        Maps directly to the ``ragas_export`` view defined in the schema.
+
+        Args:
+            limit: Maximum number of rows to export.
+
+        Returns:
+            List of dicts with ``user_input``, ``retrieved_contexts``,
+            ``response``, and ``_metadata``.
+        """
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM ragas_export ORDER BY trace_id LIMIT ?", (limit,)
+            ).fetchall()
+
+        results = []
+        for row in rows:
+            d = dict(row)
+            # Deserialise JSON columns
+            chunks_raw = d.pop("retrieved_contexts_json", None)
+            d["retrieved_contexts"] = (
+                [c["content"] for c in json.loads(chunks_raw)] if chunks_raw else []
+            )
+            d["_metadata"] = json.loads(d["_metadata"]) if d.get("_metadata") else {}
+            results.append(d)
+        return results
+
+    def stats(self) -> dict[str, Any]:
+        """Return summary statistics over all stored traces/feedback.
+
+        Returns:
+            Dict with ``total_traces``, ``total_feedback``, ``avg_star``,
+            ``top_tags``.
+        """
+        with self._connect() as conn:
+            total_traces = conn.execute("SELECT COUNT(*) FROM traces").fetchone()[0]
+            total_feedback = conn.execute("SELECT COUNT(*) FROM feedback").fetchone()[0]
+            avg_star = conn.execute(
+                "SELECT AVG(star_rating) FROM feedback WHERE star_rating IS NOT NULL"
+            ).fetchone()[0]
+            tags_rows = conn.execute(
+                "SELECT tags FROM feedback WHERE tags IS NOT NULL AND tags != '[]'"
+            ).fetchall()
+
+        # Tally individual tags
+        tag_counts: dict[str, int] = {}
+        for row in tags_rows:
+            for tag in json.loads(row[0]):
+                tag_counts[tag] = tag_counts.get(tag, 0) + 1
+        top_tags = sorted(tag_counts.items(), key=lambda x: x[1], reverse=True)[:10]
+
+        return {
+            "total_traces": total_traces,
+            "total_feedback": total_feedback,
+            "avg_star": round(avg_star, 2) if avg_star is not None else None,
+            "top_tags": top_tags,
+        }
+
+    def prune(self, older_than_days: int) -> int:
+        """Delete traces (and their feedback) older than *older_than_days* days.
+
+        Args:
+            older_than_days: Retention period in days.
+
+        Returns:
+            Number of traces deleted.
+        """
+        from datetime import datetime, timedelta, timezone
+
+        cutoff = (
+            datetime.now(timezone.utc) - timedelta(days=older_than_days)
+        ).isoformat()
+        with self._connect() as conn:
+            # feedback rows are deleted via ON DELETE CASCADE logic
+            # (SQLite doesn't cascade by default — delete in order)
+            old_ids = [
+                r[0]
+                for r in conn.execute(
+                    "SELECT trace_id FROM traces WHERE created_at < ?", (cutoff,)
+                ).fetchall()
+            ]
+            if old_ids:
+                placeholders = ",".join("?" * len(old_ids))
+                conn.execute(
+                    f"DELETE FROM feedback WHERE trace_id IN ({placeholders})",
+                    old_ids,  # noqa: S608
+                )
+                conn.execute(
+                    f"DELETE FROM traces WHERE trace_id IN ({placeholders})",
+                    old_ids,  # noqa: S608
+                )
+        if old_ids:
+            logger.info(
+                "Pruned %d traces older than %d days", len(old_ids), older_than_days
+            )
+        return len(old_ids)

--- a/.moon/templates/tracing/src/rag_facile/tracing/_store.py
+++ b/.moon/templates/tracing/src/rag_facile/tracing/_store.py
@@ -45,7 +45,7 @@ CREATE TABLE IF NOT EXISTS traces (
 
 CREATE TABLE IF NOT EXISTS feedback (
     feedback_id TEXT PRIMARY KEY,
-    trace_id    TEXT NOT NULL REFERENCES traces(trace_id),
+    trace_id    TEXT NOT NULL REFERENCES traces(trace_id) ON DELETE CASCADE,
     created_at  TEXT NOT NULL,
     star_rating INTEGER,
     sentiment   TEXT,
@@ -279,26 +279,10 @@ class TraceStore:
             datetime.now(timezone.utc) - timedelta(days=older_than_days)
         ).isoformat()
         with self._connect() as conn:
-            # feedback rows are deleted via ON DELETE CASCADE logic
-            # (SQLite doesn't cascade by default — delete in order)
-            old_ids = [
-                r[0]
-                for r in conn.execute(
-                    "SELECT trace_id FROM traces WHERE created_at < ?", (cutoff,)
-                ).fetchall()
-            ]
-            if old_ids:
-                placeholders = ",".join("?" * len(old_ids))
-                conn.execute(
-                    f"DELETE FROM feedback WHERE trace_id IN ({placeholders})",
-                    old_ids,  # noqa: S608
-                )
-                conn.execute(
-                    f"DELETE FROM traces WHERE trace_id IN ({placeholders})",
-                    old_ids,  # noqa: S608
-                )
-        if old_ids:
-            logger.info(
-                "Pruned %d traces older than %d days", len(old_ids), older_than_days
-            )
-        return len(old_ids)
+            # ON DELETE CASCADE on the feedback FK ensures feedback rows are
+            # removed automatically when their parent trace is deleted.
+            cursor = conn.execute("DELETE FROM traces WHERE created_at < ?", (cutoff,))
+            deleted = cursor.rowcount
+        if deleted:
+            logger.info("Pruned %d traces older than %d days", deleted, older_than_days)
+        return deleted

--- a/.moon/templates/tracing/template.yml
+++ b/.moon/templates/tracing/template.yml
@@ -1,0 +1,4 @@
+title: Tracing
+description: Tracing package
+destination: packages/tracing
+variables: {}

--- a/apps/chainlit-chat/app.py
+++ b/apps/chainlit-chat/app.py
@@ -1,17 +1,16 @@
-import ast
-import json
 import os
+from datetime import datetime, timezone
+from uuid import uuid4
 
 import chainlit as cl
 import engineio
 import engineio.payload
 from chainlit.input_widget import Switch
-from rag_facile.pipelines import get_accepted_mime_types, process_file, process_query
 from dotenv import load_dotenv
-
-from albert import AsyncAlbertClient
 from rag_facile.core import get_config
 from rag_facile.core.mediatech import get_collection_name
+from rag_facile.pipelines import get_accepted_mime_types, process_file, stream_answer
+from rag_facile.tracing import FeedbackRecord, get_store
 
 
 # Increase the number of packets allowed in a single payload to prevent "Too
@@ -24,63 +23,35 @@ load_dotenv()
 # Load RAG configuration
 rag_config = get_config()
 
-# Configure OpenAI (API credentials still from env vars)
-api_key = os.getenv("OPENAI_API_KEY")
-base_url = os.getenv("OPENAI_BASE_URL")
-# Model comes from config with env var override
-model = os.getenv("OPENAI_MODEL") or rag_config.generation.model
 
-client = AsyncAlbertClient(api_key=api_key, base_url=base_url)
+# ---------------------------------------------------------------------------
+# Feedback tag taxonomy
+# ---------------------------------------------------------------------------
 
-
-# Example dummy function
-def get_current_weather(location, unit="fahrenheit"):
-    """Get the current weather in a given location"""
-    if "paris" in location.lower():
-        return json.dumps({"location": "Paris", "temperature": "22", "unit": "celsius"})
-    elif "london" in location.lower():
-        return json.dumps(
-            {"location": "London", "temperature": "18", "unit": "celsius"}
-        )
-    elif "new york" in location.lower():
-        return json.dumps(
-            {"location": "New York", "temperature": "72", "unit": "fahrenheit"}
-        )
-    else:
-        return json.dumps({"location": location, "temperature": "unknown"})
-
-
-tools = [
-    {
-        "type": "function",
-        "function": {
-            "name": "get_current_weather",
-            "description": "Get the current weather in a given location",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "location": {
-                        "type": "string",
-                        "description": "The city and state, e.g. San Francisco, CA",
-                    },
-                    "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
-                },
-                "required": ["location"],
-            },
-        },
-    }
+_POSITIVE_TAGS = ["Pertinent", "Complet", "Clair", "Utile", "Précis"]
+_NEGATIVE_TAGS = [
+    "Non pertinent",
+    "Incomplet",
+    "Confus",
+    "Éléments faux",
+    "Sources manquantes",
+    "Sources erronées / obsolètes",
 ]
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle hooks
+# ---------------------------------------------------------------------------
 
 
 @cl.on_chat_start
 async def start_chat():
-    # Use system prompt from config
     cl.user_session.set(
         "message_history",
         [{"role": "system", "content": rag_config.generation.system_prompt}],
     )
 
-    # Initialize active collections from config
+    # Initialise active collections from config
     active_collections = list(rag_config.storage.collections)
     cl.user_session.set("active_collections", active_collections)
 
@@ -104,34 +75,15 @@ async def on_settings_update(settings: dict) -> None:
     cl.user_session.set("active_collections", active)
 
 
-@cl.step(type="tool")
-async def call_tool(tool_call, message_history):
-    function_name = tool_call.function.name
-    arguments = ast.literal_eval(tool_call.function.arguments)
-
-    if function_name == "get_current_weather":
-        current_weather = get_current_weather(
-            location=arguments.get("location"),
-            unit=arguments.get("unit"),
-        )
-
-        message_history.append(
-            {
-                "role": "tool",
-                "tool_call_id": tool_call.id,
-                "name": function_name,
-                "content": current_weather,
-            }
-        )
-
-        return current_weather
-    else:
-        return "Function not found"
+# ---------------------------------------------------------------------------
+# Main message handler
+# ---------------------------------------------------------------------------
 
 
 @cl.on_message
 async def main(message: cl.Message):
     message_history = cl.user_session.get("message_history")
+    active_collections: list[int] = cl.user_session.get("active_collections") or []
 
     # Handle attachments — ingest into Albert collection for RAG retrieval
     if message.elements:
@@ -150,128 +102,155 @@ async def main(message: cl.Message):
                 try:
                     status = process_file(element.path, element.name)
                     await cl.Message(content=status).send()
-                except Exception as e:
+                except (OSError, ValueError) as e:
                     await cl.Message(
                         content=f"Error indexing '{element.name}': {e!s}"
                     ).send()
 
-    # Retrieve relevant context using active collections
-    active_collections: list[int] = cl.user_session.get("active_collections") or []
-    retrieved_context = process_query(
-        message.content, collection_ids=active_collections
-    )
-
-    user_content = message.content
-    if retrieved_context:
-        user_content = (
-            "Use the following context to answer the user's question:\n\n"
-            f"{retrieved_context}\n\n"
-            f"Question: {message.content}"
-        )
-
-    message_history.append({"role": "user", "content": user_content})
+    # Pre-generate trace_id so we can attach feedback before stream ends
+    trace_id = str(uuid4())
+    cl.user_session.set("last_trace_id", trace_id)
 
     msg = cl.Message(content="")
-
-    # Send an empty message to start the stream UI
     await msg.send()
 
-    # Common generation parameters from config
-    gen_params = {
-        "stream": rag_config.generation.streaming,
-        "temperature": rag_config.generation.temperature,
-        "max_tokens": rag_config.generation.max_tokens,
-    }
+    # Full RAG turn: retrieve → prompt → stream → trace (all inside stream_answer)
+    async for token in stream_answer(
+        message.content,
+        message_history,
+        trace_id=trace_id,
+        session_id=cl.user_session.get("id", ""),
+        collection_ids=active_collections,
+    ):
+        await msg.stream_token(token)
 
-    # TODO: OpenAI SDK can't infer correct return type when stream parameter is a variable
-    # This causes ty to report no-matching-overload error. Need to either:
-    # 1. Split into separate streaming/non-streaming code paths with literal True/False
-    # 2. Wait for OpenAI SDK to improve overload inference with runtime booleans
-    stream = await client.chat.completions.create(  # ty: ignore[no-matching-overload]
-        model=model,
-        messages=message_history,
-        tools=tools,
-        tool_choice="auto",
-        **gen_params,
+    # Append clean question + answer to history (no injected context)
+    message_history.append({"role": "user", "content": message.content})
+    message_history.append({"role": "assistant", "content": msg.content})
+    await msg.update()
+
+    # Feedback UI — created OUTSIDE any cl.Step to avoid issue #1202
+    if rag_config.tracing.enabled:
+        await _show_feedback_ui(trace_id)
+
+
+# ---------------------------------------------------------------------------
+# Feedback UI helpers
+# ---------------------------------------------------------------------------
+
+
+async def _show_feedback_ui(trace_id: str) -> None:
+    """Send star-rating action row for the last answer."""
+    await cl.Message(
+        content="**Comment évaluez-vous la réponse ?**",
+        actions=[
+            cl.Action(
+                name=f"star_{i}",
+                value=str(i),
+                label="⭐" * i,
+                payload={"trace_id": trace_id},
+            )
+            for i in range(1, 6)
+        ],
+    ).send()
+
+
+async def _ask_sentiment(trace_id: str, star: int) -> None:
+    """Prompt thumbs up/down after a star rating."""
+    res = await cl.AskActionMessage(
+        content="👍 Positive ou 👎 Négative ?",
+        actions=[
+            cl.Action(name="positive", label="👍 Positive", value="positive"),
+            cl.Action(name="negative", label="👎 Négative", value="negative"),
+        ],
+        timeout=120,
+    ).send()
+    if res:
+        await _ask_tags(trace_id, star, res.get("value", ""))
+
+
+async def _ask_tags(trace_id: str, star: int, sentiment: str) -> None:
+    """Prompt quality tags, then free-text comment, then persist."""
+    tags_list = _POSITIVE_TAGS if sentiment == "positive" else _NEGATIVE_TAGS
+    tag_res = await cl.AskActionMessage(
+        content="Sélectionnez les étiquettes applicables :",
+        actions=[cl.Action(name=f"tag_{t}", label=t, value=t) for t in tags_list],
+        timeout=120,
+    ).send()
+    selected_tags = [tag_res["value"]] if tag_res else []
+
+    comment_res = await cl.AskUserMessage(
+        content="Commentaires (optionnel — appuyez sur Entrée pour ignorer) :",
+        timeout=120,
+    ).send()
+    comment = comment_res["output"].strip() if comment_res else None
+    if not comment:
+        comment = None
+
+    _persist_feedback(
+        trace_id=trace_id,
+        star=star,
+        sentiment=sentiment,
+        tags=selected_tags,
+        comment=comment,
     )
 
-    cur_tool_calls = []
 
+def _persist_feedback(
+    trace_id: str,
+    star: int | None,
+    sentiment: str | None,
+    tags: list[str],
+    comment: str | None,
+) -> None:
+    """Write feedback record to the trace store."""
+    fb: FeedbackRecord = {
+        "feedback_id": str(uuid4()),
+        "trace_id": trace_id,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "star_rating": star,
+        "sentiment": sentiment,
+        "tags": tags,
+        "comment": comment,
+    }
     try:
-        async for part in stream:
-            if not part.choices:
-                continue
+        get_store().record_feedback(fb)
+    except (OSError, RuntimeError) as exc:
+        import logging
 
-            # Handle new tool calls
-            if part.choices[0].delta.tool_calls:
-                for tool_call_delta in part.choices[0].delta.tool_calls:
-                    index = tool_call_delta.index
+        logging.getLogger(__name__).warning("Failed to record feedback: %s", exc)
 
-                    if index == len(cur_tool_calls):
-                        cur_tool_calls.append(tool_call_delta)
-                    else:
-                        # We are updating an existing tool call
-                        if tool_call_delta.id:
-                            cur_tool_calls[index].id = tool_call_delta.id
-                        if tool_call_delta.function.name:
-                            cur_tool_calls[index].function.name = (
-                                cur_tool_calls[index].function.name or ""
-                            ) + tool_call_delta.function.name
-                        if tool_call_delta.function.arguments:
-                            cur_tool_calls[index].function.arguments = (
-                                cur_tool_calls[index].function.arguments or ""
-                            ) + tool_call_delta.function.arguments
 
-            # Handle content
-            if part.choices[0].delta.content:
-                token = part.choices[0].delta.content
-                await msg.stream_token(token)
-    except json.JSONDecodeError:
-        # Albert API occasionally sends malformed SSE events; continue
-        # with whatever content was streamed so far.
-        pass
+# ---------------------------------------------------------------------------
+# Star rating callbacks (one per rating level)
+# ---------------------------------------------------------------------------
 
-    # We are done with the first stream
 
-    if cur_tool_calls:
-        # We have tool calls to execute
-        message_history.append(
-            {
-                "role": "assistant",
-                "tool_calls": [
-                    {
-                        "id": tool_call.id,
-                        "type": "function",
-                        "function": {
-                            "name": tool_call.function.name,
-                            "arguments": tool_call.function.arguments,
-                        },
-                    }
-                    for tool_call in cur_tool_calls
-                ],
-            }
-        )
+@cl.action_callback("star_1")
+async def on_star_1(action: cl.Action):
+    cl.user_session.set("pending_star", 1)
+    await _ask_sentiment(action.payload["trace_id"], 1)
 
-        # Execute tools
-        for tool_call in cur_tool_calls:
-            await call_tool(tool_call, message_history)
 
-        # Now we need to get the final response from the model (uses config values)
-        stream_post_tool = await client.chat.completions.create(
-            model=model,
-            messages=message_history,
-            **gen_params,
-        )
+@cl.action_callback("star_2")
+async def on_star_2(action: cl.Action):
+    cl.user_session.set("pending_star", 2)
+    await _ask_sentiment(action.payload["trace_id"], 2)
 
-        # Type ignore: SDK can't infer stream type when stream parameter is variable
-        async for part in stream_post_tool:  # type: ignore[union-attr]
-            if not part.choices:
-                continue
-            if part.choices[0].delta.content:
-                token = part.choices[0].delta.content
-                await msg.stream_token(token)
 
-    # Add assistant response to history for proper conversation continuity
-    message_history.append({"role": "assistant", "content": msg.content})
+@cl.action_callback("star_3")
+async def on_star_3(action: cl.Action):
+    cl.user_session.set("pending_star", 3)
+    await _ask_sentiment(action.payload["trace_id"], 3)
 
-    await msg.update()
+
+@cl.action_callback("star_4")
+async def on_star_4(action: cl.Action):
+    cl.user_session.set("pending_star", 4)
+    await _ask_sentiment(action.payload["trace_id"], 4)
+
+
+@cl.action_callback("star_5")
+async def on_star_5(action: cl.Action):
+    cl.user_session.set("pending_star", 5)
+    await _ask_sentiment(action.payload["trace_id"], 5)

--- a/apps/chainlit-chat/app.py
+++ b/apps/chainlit-chat/app.py
@@ -161,13 +161,21 @@ async def _ask_sentiment(trace_id: str, star: int) -> None:
     res = await cl.AskActionMessage(
         content="👍 Positive ou 👎 Négative ?",
         actions=[
-            cl.Action(name="positive", label="👍 Positive", value="positive"),
-            cl.Action(name="negative", label="👎 Négative", value="negative"),
+            cl.Action(
+                name="positive", label="👍 Positive", value="positive", payload={}
+            ),
+            cl.Action(
+                name="negative", label="👎 Négative", value="negative", payload={}
+            ),
         ],
         timeout=120,
     ).send()
     if res:
-        await _ask_tags(trace_id, star, res.get("value", ""))
+        sentiment = res.get("value") or res.get("name", "")
+        if sentiment in ("positive", "negative"):
+            await _ask_tags(trace_id, star, sentiment)
+        else:
+            await _ask_tags(trace_id, star, "")
 
 
 async def _ask_tags(trace_id: str, star: int, sentiment: str) -> None:
@@ -175,10 +183,16 @@ async def _ask_tags(trace_id: str, star: int, sentiment: str) -> None:
     tags_list = _POSITIVE_TAGS if sentiment == "positive" else _NEGATIVE_TAGS
     tag_res = await cl.AskActionMessage(
         content="Sélectionnez les étiquettes applicables :",
-        actions=[cl.Action(name=f"tag_{t}", label=t, value=t) for t in tags_list],
+        actions=[
+            cl.Action(name=f"tag_{t}", label=t, value=t, payload={}) for t in tags_list
+        ],
         timeout=120,
     ).send()
-    selected_tags = [tag_res["value"]] if tag_res else []
+    selected_tags = []
+    if tag_res:
+        tag_val = tag_res.get("value") or tag_res.get("name", "").replace("tag_", "")
+        if tag_val:
+            selected_tags.append(tag_val)
 
     comment_res = await cl.AskUserMessage(
         content="Commentaires (optionnel — appuyez sur Entrée pour ignorer) :",

--- a/apps/chainlit-chat/app.py
+++ b/apps/chainlit-chat/app.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from datetime import datetime, timezone
 from uuid import uuid4
@@ -216,41 +217,44 @@ def _persist_feedback(
     try:
         get_store().record_feedback(fb)
     except (OSError, RuntimeError) as exc:
-        import logging
-
         logging.getLogger(__name__).warning("Failed to record feedback: %s", exc)
 
 
 # ---------------------------------------------------------------------------
 # Star rating callbacks (one per rating level)
+#
+# Chainlit's @cl.action_callback only accepts a plain string name — no regex
+# support.  We register 5 thin callbacks that all delegate to one helper,
+# keeping the logic in a single place.
 # ---------------------------------------------------------------------------
+
+
+async def _on_star(action: cl.Action, rating: int) -> None:
+    """Shared handler for all star rating actions."""
+    cl.user_session.set("pending_star", rating)
+    await _ask_sentiment(action.payload["trace_id"], rating)
 
 
 @cl.action_callback("star_1")
 async def on_star_1(action: cl.Action):
-    cl.user_session.set("pending_star", 1)
-    await _ask_sentiment(action.payload["trace_id"], 1)
+    await _on_star(action, 1)
 
 
 @cl.action_callback("star_2")
 async def on_star_2(action: cl.Action):
-    cl.user_session.set("pending_star", 2)
-    await _ask_sentiment(action.payload["trace_id"], 2)
+    await _on_star(action, 2)
 
 
 @cl.action_callback("star_3")
 async def on_star_3(action: cl.Action):
-    cl.user_session.set("pending_star", 3)
-    await _ask_sentiment(action.payload["trace_id"], 3)
+    await _on_star(action, 3)
 
 
 @cl.action_callback("star_4")
 async def on_star_4(action: cl.Action):
-    cl.user_session.set("pending_star", 4)
-    await _ask_sentiment(action.payload["trace_id"], 4)
+    await _on_star(action, 4)
 
 
 @cl.action_callback("star_5")
 async def on_star_5(action: cl.Action):
-    cl.user_session.set("pending_star", 5)
-    await _ask_sentiment(action.payload["trace_id"], 5)
+    await _on_star(action, 5)

--- a/apps/cli/src/cli/commands/__init__.py
+++ b/apps/cli/src/cli/commands/__init__.py
@@ -1,6 +1,24 @@
 """CLI commands."""
 
-from . import collections, config, generate_dataset, setup, uninstall, upgrade
+from . import (
+    chat,
+    collections,
+    config,
+    generate_dataset,
+    setup,
+    traces,
+    uninstall,
+    upgrade,
+)
 
 
-__all__ = ["collections", "config", "generate_dataset", "setup", "uninstall", "upgrade"]
+__all__ = [
+    "chat",
+    "collections",
+    "config",
+    "generate_dataset",
+    "setup",
+    "traces",
+    "uninstall",
+    "upgrade",
+]

--- a/apps/cli/src/cli/commands/chat/agent.py
+++ b/apps/cli/src/cli/commands/chat/agent.py
@@ -267,7 +267,7 @@ def start_chat(debug: bool = False) -> None:
         skill_injected = True  # content already in agent context this turn
         console.print(f"[dim]{ui['skill_loaded'].format(name=skill_name)}[/dim]")
 
-    def _wrap_activate_skill(tool_obj):  # type: ignore[no-untyped-def]
+    def _wrap_activate_skill(tool_obj):  # noqa: ANN001
         """Extend _with_notification to also persist skill state."""
         _original_forward = tool_obj.forward
 

--- a/apps/cli/src/cli/commands/traces.py
+++ b/apps/cli/src/cli/commands/traces.py
@@ -1,0 +1,186 @@
+"""CLI commands for inspecting and exporting conversation traces."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Annotated, Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from rag_facile.tracing import get_store
+
+
+console = Console()
+
+
+def show(
+    n: Annotated[
+        int, typer.Option("--n", "-n", help="Number of traces to display")
+    ] = 20,
+    db: Annotated[
+        Optional[Path],
+        typer.Option("--db", help="Path to traces.db (default: .rag-facile/traces.db)"),
+    ] = None,
+) -> None:
+    """Show the most recent RAG conversation traces."""
+    store = _get_store(db)
+    rows = store.recent(n=n)
+
+    if not rows:
+        console.print("[yellow]No traces found.[/yellow] Run a conversation first.")
+        raise typer.Exit()
+
+    table = Table(
+        title=f"Last {min(n, len(rows))} traces",
+        show_header=True,
+        header_style="bold cyan",
+        expand=True,
+    )
+    table.add_column("Created", style="dim", min_width=20, no_wrap=True)
+    table.add_column("Question", ratio=3)
+    table.add_column("Model", min_width=18, no_wrap=True)
+    table.add_column("Latency", min_width=8, no_wrap=True)
+    table.add_column("⭐", min_width=5, no_wrap=True)
+    table.add_column("Sentiment", min_width=10, no_wrap=True)
+
+    for row in rows:
+        created = (row.get("created_at") or "")[:19].replace("T", " ")
+        question = (row.get("question") or "")[:80]
+        model = row.get("model_resolved") or row.get("model_alias") or "—"
+        # Shorten model names for display
+        model = model.split("/")[-1] if "/" in model else model
+        latency = (
+            f"{row['latency_ms']} ms" if row.get("latency_ms") is not None else "—"
+        )
+        star = "⭐" * int(row["star_rating"]) if row.get("star_rating") else "—"
+        sentiment = row.get("sentiment") or "—"
+        sentiment_styled = (
+            f"[green]{sentiment}[/green]"
+            if sentiment == "positive"
+            else f"[red]{sentiment}[/red]"
+            if sentiment == "negative"
+            else "—"
+        )
+        table.add_row(created, question, model, latency, star, sentiment_styled)
+
+    console.print(table)
+    stats = store.stats()
+    console.print(
+        f"\n[dim]Total traces: {stats['total_traces']} | "
+        f"Feedback: {stats['total_feedback']} | "
+        f"Avg ⭐: {stats['avg_star'] or '—'}[/dim]"
+    )
+
+
+def export(
+    output: Annotated[
+        Optional[Path],
+        typer.Option("--output", "-o", help="Output file (default: stdout)"),
+    ] = None,
+    fmt: Annotated[
+        str,
+        typer.Option("--format", "-f", help="Export format: jsonl | ragas"),
+    ] = "jsonl",
+    limit: Annotated[
+        int, typer.Option("--limit", help="Maximum number of traces")
+    ] = 1000,
+    db: Annotated[
+        Optional[Path],
+        typer.Option("--db", help="Path to traces.db (default: .rag-facile/traces.db)"),
+    ] = None,
+) -> None:
+    """Export traces as JSONL or in RAGAS-compatible format."""
+    store = _get_store(db)
+
+    if fmt == "ragas":
+        rows = store.export_ragas(limit=limit)
+    else:
+        raw = store.recent(n=limit)
+        rows = raw
+
+    lines = [json.dumps(r, ensure_ascii=False, default=str) for r in rows]
+    content = "\n".join(lines)
+
+    if output:
+        output.write_text(content + "\n", encoding="utf-8")
+        console.print(
+            f"[green]✓[/green] Exported {len(lines)} traces to [bold]{output}[/bold]"
+        )
+    else:
+        console.print(content)
+
+
+def stats(
+    db: Annotated[
+        Optional[Path],
+        typer.Option("--db", help="Path to traces.db (default: .rag-facile/traces.db)"),
+    ] = None,
+) -> None:
+    """Show quality statistics over all recorded traces."""
+    store = _get_store(db)
+    s = store.stats()
+
+    console.print("\n[bold]📊 Trace Statistics[/bold]\n")
+    console.print(f"  Total traces:   [cyan]{s['total_traces']}[/cyan]")
+    console.print(f"  With feedback:  [cyan]{s['total_feedback']}[/cyan]")
+
+    coverage = (
+        f"{100 * s['total_feedback'] / s['total_traces']:.0f}%"
+        if s["total_traces"] > 0
+        else "—"
+    )
+    console.print(f"  Coverage:       [cyan]{coverage}[/cyan]")
+
+    avg = s["avg_star"]
+    console.print(f"  Avg ⭐ rating:  [cyan]{avg if avg is not None else '—'}[/cyan]")
+
+    if s["top_tags"]:
+        console.print("\n  [bold]Top quality tags:[/bold]")
+        for tag, count in s["top_tags"]:
+            bar = "█" * min(count, 20)
+            console.print(f"    {tag:<35} {bar} {count}")
+    console.print()
+
+
+def prune(
+    older_than: Annotated[
+        int,
+        typer.Option("--older-than", help="Delete traces older than N days"),
+    ] = 365,
+    db: Annotated[
+        Optional[Path],
+        typer.Option("--db", help="Path to traces.db (default: .rag-facile/traces.db)"),
+    ] = None,
+    yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip confirmation")] = False,
+) -> None:
+    """Delete traces older than N days (RGPD data retention)."""
+    if not yes:
+        typer.confirm(
+            f"Delete all traces older than {older_than} days?",
+            abort=True,
+        )
+    store = _get_store(db)
+    deleted = store.prune(older_than_days=older_than)
+    if deleted:
+        console.print(
+            f"[green]✓[/green] Deleted {deleted} traces older than {older_than} days."
+        )
+    else:
+        console.print(f"[dim]No traces older than {older_than} days found.[/dim]")
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_store(db: Path | None):
+    """Return a TraceStore, optionally at a custom db path."""
+    if db is not None:
+        from rag_facile.tracing._store import TraceStore
+
+        return TraceStore(db)
+    return get_store()

--- a/apps/cli/src/cli/main.py
+++ b/apps/cli/src/cli/main.py
@@ -12,6 +12,7 @@ from cli.commands import (
     config,
     generate_dataset,
     setup,
+    traces,
     uninstall,
     upgrade,
 )
@@ -143,6 +144,24 @@ app.command(
     help="Generate synthetic Q/A evaluation dataset from documents",
     rich_help_panel=_PANEL_ADVANCED_TOOLS,
 )(generate_dataset.run)
+
+# Traces command group
+traces_app = typer.Typer(
+    name="traces",
+    help="Inspect and export RAG conversation traces",
+    no_args_is_help=True,
+)
+traces_app.command("show", help="Show recent conversation traces")(traces.show)
+traces_app.command("export", help="Export traces as JSONL or RAGAS format")(
+    traces.export
+)
+traces_app.command("stats", help="Show quality statistics over all traces")(
+    traces.stats
+)
+traces_app.command("prune", help="Delete old traces (RGPD data retention)")(
+    traces.prune
+)
+app.add_typer(traces_app, name="traces", rich_help_panel=_PANEL_ADVANCED_TOOLS)
 
 
 if __name__ == "__main__":

--- a/apps/reflex-chat/reflex_chat/components/chat.py
+++ b/apps/reflex-chat/reflex_chat/components/chat.py
@@ -5,7 +5,7 @@ from typing import cast
 from collections.abc import Sequence
 
 from rag_facile.pipelines import get_accepted_mime_types
-from reflex_chat.state import QA, State
+from reflex_chat.state import NEGATIVE_TAGS, POSITIVE_TAGS, QA, State
 
 
 def _get_upload_accept() -> dict[str, Sequence[str]]:
@@ -58,10 +58,188 @@ def message(qa: QA) -> rx.Component:
     )
 
 
+def star_button(i: int) -> rx.Component:
+    """A single star in the rating row."""
+    return rx.icon_button(
+        rx.icon(
+            rx.cond(State.feedback_star >= i, "star", "star"),
+            size=18,
+            color=rx.cond(
+                State.feedback_star >= i,
+                rx.color("yellow", 9),
+                rx.color("mauve", 8),
+            ),
+        ),
+        variant="ghost",
+        on_click=State.set_feedback_star(i),
+        cursor="pointer",
+        size="1",
+    )
+
+
+def tag_chip(tag: str) -> rx.Component:
+    """A toggleable quality tag chip."""
+    is_selected = State.feedback_tags.contains(tag)
+    return rx.badge(
+        tag,
+        variant=rx.cond(is_selected, "solid", "outline"),
+        color_scheme=rx.cond(
+            State.feedback_sentiment == "positive",
+            rx.cond(is_selected, "green", "gray"),
+            rx.cond(is_selected, "red", "gray"),
+        ),
+        cursor="pointer",
+        on_click=State.toggle_feedback_tag(tag),
+        size="1",
+    )
+
+
+def feedback_panel() -> rx.Component:
+    """Collapsible user feedback panel shown after each answer."""
+    return rx.cond(
+        State.feedback_visible,
+        rx.box(
+            rx.vstack(
+                # Header
+                rx.hstack(
+                    rx.text(
+                        "Comment évaluez-vous la réponse ?",
+                        font_size="0.9em",
+                        font_weight="600",
+                        color=rx.color("mauve", 12),
+                    ),
+                    rx.spacer(),
+                    rx.icon_button(
+                        rx.icon("chevron-up", size=14),
+                        variant="ghost",
+                        size="1",
+                        on_click=State.dismiss_feedback,
+                        cursor="pointer",
+                        color=rx.color("mauve", 10),
+                    ),
+                    width="100%",
+                    align_items="center",
+                ),
+                # Star rating row
+                rx.hstack(
+                    star_button(1),
+                    star_button(2),
+                    star_button(3),
+                    star_button(4),
+                    star_button(5),
+                    spacing="1",
+                ),
+                # Thumbs up/down row
+                rx.hstack(
+                    rx.icon_button(
+                        rx.icon("thumbs-up", size=16),
+                        variant=rx.cond(
+                            State.feedback_sentiment == "positive", "solid", "soft"
+                        ),
+                        color_scheme=rx.cond(
+                            State.feedback_sentiment == "positive", "green", "gray"
+                        ),
+                        on_click=State.set_feedback_sentiment("positive"),
+                        cursor="pointer",
+                        size="2",
+                    ),
+                    rx.flex(
+                        rx.foreach(
+                            POSITIVE_TAGS,
+                            lambda t: rx.cond(
+                                State.feedback_sentiment == "positive",
+                                tag_chip(t),
+                                rx.fragment(),
+                            ),
+                        ),
+                        wrap="wrap",
+                        gap="1",
+                    ),
+                    spacing="2",
+                    align_items="flex-start",
+                    width="100%",
+                ),
+                rx.hstack(
+                    rx.icon_button(
+                        rx.icon("thumbs-down", size=16),
+                        variant=rx.cond(
+                            State.feedback_sentiment == "negative", "solid", "soft"
+                        ),
+                        color_scheme=rx.cond(
+                            State.feedback_sentiment == "negative", "red", "gray"
+                        ),
+                        on_click=State.set_feedback_sentiment("negative"),
+                        cursor="pointer",
+                        size="2",
+                    ),
+                    rx.flex(
+                        rx.foreach(
+                            NEGATIVE_TAGS,
+                            lambda t: rx.cond(
+                                State.feedback_sentiment == "negative",
+                                tag_chip(t),
+                                rx.fragment(),
+                            ),
+                        ),
+                        wrap="wrap",
+                        gap="1",
+                    ),
+                    spacing="2",
+                    align_items="flex-start",
+                    width="100%",
+                ),
+                # Comment field
+                rx.vstack(
+                    rx.text(
+                        "Commentaires",
+                        font_size="0.8em",
+                        color=rx.color("mauve", 11),
+                    ),
+                    rx.text_area(
+                        placeholder="Entrez vos commentaires",
+                        value=State.feedback_comment,
+                        on_change=State.set_feedback_comment,
+                        width="100%",
+                        rows="3",
+                        resize="none",
+                        font_size="0.85em",
+                        border_color=rx.color("mauve", 6),
+                        border_radius="6px",
+                    ),
+                    width="100%",
+                    spacing="1",
+                ),
+                # Submit button
+                rx.hstack(
+                    rx.spacer(),
+                    rx.button(
+                        "Enregistrer",
+                        on_click=State.submit_feedback,
+                        color_scheme="blue",
+                        size="2",
+                        cursor="pointer",
+                    ),
+                    width="100%",
+                ),
+                spacing="3",
+                width="100%",
+                padding="16px",
+            ),
+            max_width="50em",
+            margin_inline="auto",
+            margin_block="8px",
+            border="1px solid var(--gray-a5)",
+            border_radius="12px",
+            background_color=rx.color("mauve", 2),
+        ),
+    )
+
+
 def chat() -> rx.Component:
     """List all the messages in a single conversation."""
     return rx.auto_scroll(
         rx.foreach(State.selected_chat, message),
+        rx.cond(State.feedback_visible, feedback_panel()),
         flex="1",
         padding="8px",
     )

--- a/apps/reflex-chat/reflex_chat/state.py
+++ b/apps/reflex-chat/reflex_chat/state.py
@@ -1,14 +1,14 @@
 import os
-import json
+from datetime import datetime, timezone
 from typing import Any, TypedDict
+from uuid import uuid4
 
 import reflex as rx
-from rag_facile.pipelines import process_bytes, process_query
 from dotenv import load_dotenv
-
-from albert import AlbertClient, ChatCompletionMessageParam
 from rag_facile.core import get_config
 from rag_facile.core.mediatech import get_collection_name
+from rag_facile.pipelines import process_bytes, stream_answer
+from rag_facile.tracing import FeedbackRecord, get_store
 
 
 # Load .env file
@@ -23,6 +23,21 @@ if not os.getenv("OPENAI_API_KEY"):
 
 if not os.getenv("OPENAI_BASE_URL"):
     raise Exception("Please set OPENAI_BASE_URL environment variable for Albert API.")
+
+
+# ---------------------------------------------------------------------------
+# Feedback tag taxonomy
+# ---------------------------------------------------------------------------
+
+POSITIVE_TAGS = ["Pertinent", "Complet", "Clair", "Utile", "Précis"]
+NEGATIVE_TAGS = [
+    "Non pertinent",
+    "Incomplet",
+    "Confus",
+    "Éléments faux",
+    "Sources manquantes",
+    "Sources erronées / obsolètes",
+]
 
 
 class QA(TypedDict):
@@ -63,11 +78,21 @@ class State(rx.State):
         str(col_id): True for col_id in rag_config.storage.collections
     }
 
+    # ── Feedback state ──
+    last_trace_id: str = ""
+    feedback_star: int = 0  # 0 = unrated
+    feedback_sentiment: str = ""  # "" | "positive" | "negative"
+    feedback_tags: list[str] = []
+    feedback_comment: str = ""
+    feedback_submitted: bool = False
+    feedback_visible: bool = False  # controls panel visibility
+
+    # ── Collection management ──
+
     @rx.event
     def toggle_collection(self, col_id: str):
         """Toggle a collection on/off for RAG retrieval."""
         self.active_collections[col_id] = not self.active_collections.get(col_id, True)
-        # Force state refresh
         self.active_collections = self.active_collections
 
     @rx.var
@@ -83,6 +108,8 @@ class State(rx.State):
             name = get_collection_name(int(col_id_str)) or f"Collection {col_id_str}"
             items.append({"id": col_id_str, "name": name, "enabled": str(enabled)})
         return items
+
+    # ── File upload ──
 
     async def handle_upload(self, files: list[rx.UploadFile]):
         """Upload files to Albert collection for RAG retrieval."""
@@ -100,14 +127,14 @@ class State(rx.State):
         """Clear an attached file from the UI list."""
         if filename in self.attached_files:
             self.attached_files.remove(filename)
-
         if not self.attached_files:
             self.has_indexed_docs = False
+
+    # ── Chat management ──
 
     @rx.event
     def create_chat(self, form_data: dict[str, Any]):
         """Create a new chat."""
-        # Add the new chat to the list of chats.
         new_chat_name = form_data["new_chat_name"]
         self.current_chat = new_chat_name
         self._chats[new_chat_name] = []
@@ -115,20 +142,12 @@ class State(rx.State):
 
     @rx.event
     def set_is_modal_open(self, is_open: bool):
-        """Set the new chat modal open state.
-
-        Args:
-            is_open: Whether the modal is open.
-        """
+        """Set the new chat modal open state."""
         self.is_modal_open = is_open
 
     @rx.var
     def selected_chat(self) -> list[QA]:
-        """Get the list of questions and answers for the current chat.
-
-        Returns:
-            The list of questions and answers.
-        """
+        """Get the list of questions and answers for the current chat."""
         return (
             self._chats[self.current_chat] if self.current_chat in self._chats else []
         )
@@ -140,130 +159,149 @@ class State(rx.State):
             return
         del self._chats[chat_name]
         if len(self._chats) == 0:
-            self._chats = {
-                "Intros": [],
-            }
+            self._chats = {"Intros": []}
         if self.current_chat not in self._chats:
             self.current_chat = list(self._chats.keys())[0]
 
     @rx.event
     def set_chat(self, chat_name: str):
-        """Set the name of the current chat.
-
-        Args:
-            chat_name: The name of the chat.
-        """
+        """Set the name of the current chat."""
         self.current_chat = chat_name
 
     @rx.event
     def set_new_chat_name(self, new_chat_name: str):
-        """Set the name of the new chat.
-
-        Args:
-            new_chat_name: The name of the new chat.
-        """
+        """Set the name of the new chat."""
         self.new_chat_name = new_chat_name
 
     @rx.var
     def chat_titles(self) -> list[str]:
-        """Get the list of chat titles.
-
-        Returns:
-            The list of chat names.
-        """
+        """Get the list of chat titles."""
         return list(self._chats.keys())
+
+    # ── Question processing ──
 
     @rx.event
     async def process_question(self, form_data: dict[str, Any]):
-        # Get the question from the form
         question = form_data["question"]
-
-        # Check if the question is empty
         if not question:
             return
-
         async for value in self.openai_process_question(question):
             yield value
 
     @rx.event
     async def openai_process_question(self, question: str):
-        """Get the response from the API.
-
-        Args:
-            form_data: A dict with the current question.
-        """
-
-        # Add the question to the list of questions.
+        """Get the response from the pipeline (retrieve + stream + trace)."""
+        # Add the question to the list of questions
         qa = QA(question=question, answer="")
         self._chats[self.current_chat].append(qa)
 
-        # Clear the input and start the processing.
+        # Reset feedback state for this new turn
+        trace_id = str(uuid4())
+        self.last_trace_id = trace_id
+        self.feedback_star = 0
+        self.feedback_sentiment = ""
+        self.feedback_tags = []
+        self.feedback_comment = ""
+        self.feedback_submitted = False
+        self.feedback_visible = False
+
         self.processing = True
         yield
 
-        # Build the messages (uses config system prompt)
-        messages: list[ChatCompletionMessageParam] = [
-            {
-                "role": "system",
-                "content": rag_config.generation.system_prompt,
-            }
+        # Build message history (system prompt + previous turns, NOT current)
+        messages: list[dict[str, str]] = [
+            {"role": "system", "content": rag_config.generation.system_prompt}
         ]
-
-        for qa in self._chats[self.current_chat]:
+        for qa in self._chats[self.current_chat][:-1]:  # exclude current (last) turn
             messages.append({"role": "user", "content": qa["question"]})
             messages.append({"role": "assistant", "content": qa["answer"]})
 
-        # Remove the last mock answer.
-        messages = messages[:-1]
-
-        # Retrieve relevant context via RAG pipeline (search -> rerank -> format)
-        # Combine context with the current question to avoid accumulating
-        # system messages in the conversation history.
-        retrieved_context = process_query(
-            question, collection_ids=self.enabled_collection_ids
-        )
-        if retrieved_context:
-            messages[-1]["content"] = (
-                "Use the following context to answer the user's question:\n\n"
-                f"{retrieved_context}\n\n"
-                f"Question: {question}"
-            )
-
-        # Start a new session to answer the question (uses config values)
-        # Model comes from config with env var override
-        model = os.getenv("OPENAI_MODEL") or rag_config.generation.model
-        gen_params = {
-            "stream": rag_config.generation.streaming,
-            "temperature": rag_config.generation.temperature,
-            "max_tokens": rag_config.generation.max_tokens,
-        }
-        session = AlbertClient(
-            base_url=os.getenv("OPENAI_BASE_URL"),
-        ).chat.completions.create(
-            model=model,
-            messages=messages,
-            **gen_params,
-        )
-
-        # Stream the results, yielding after every word.
+        # Stream tokens from the pipeline (retrieve → prompt → LLM → trace)
         try:
-            for item in session:
-                if item.choices and hasattr(item.choices[0].delta, "content"):
-                    answer_text = item.choices[0].delta.content
-                    # Ensure answer_text is not None before concatenation
-                    if answer_text is not None:
-                        self._chats[self.current_chat][-1]["answer"] += answer_text
-                    else:
-                        # Handle the case where answer_text is None,
-                        # perhaps log it or assign a default value.
-                        answer_text = ""
-                        self._chats[self.current_chat][-1]["answer"] += answer_text
-                    self._chats = self._chats
-                    yield
-        except json.JSONDecodeError:
-            # Albert API occasionally sends malformed SSE events; continue
-            # with whatever content was streamed so far.
-            pass
+            async for token in stream_answer(
+                question,
+                messages,
+                trace_id=trace_id,
+                session_id=self.router.session.client_token,
+                collection_ids=self.enabled_collection_ids,
+            ):
+                self._chats[self.current_chat][-1]["answer"] += token
+                self._chats = self._chats
+                yield
+        except Exception as exc:  # noqa: BLE001 — broad catch to avoid breaking chat
+            import logging
 
-        # Toggle the processing flag.
+            logging.getLogger(__name__).error("stream_answer error: %s", exc)
+
         self.processing = False
+        # Show feedback panel after answer is complete
+        if rag_config.tracing.enabled:
+            self.feedback_visible = True
+        yield
+
+    # ── Feedback events ──
+
+    @rx.event
+    def set_feedback_star(self, rating: int):
+        """Set the star rating."""
+        self.feedback_star = rating
+
+    @rx.event
+    def set_feedback_sentiment(self, sentiment: str):
+        """Set the sentiment (positive/negative) and reset tags."""
+        self.feedback_sentiment = sentiment
+        self.feedback_tags = []
+
+    @rx.event
+    def toggle_feedback_tag(self, tag: str):
+        """Toggle a quality tag on/off."""
+        if tag in self.feedback_tags:
+            self.feedback_tags = [t for t in self.feedback_tags if t != tag]
+        else:
+            self.feedback_tags = [*self.feedback_tags, tag]
+
+    @rx.event
+    def set_feedback_comment(self, comment: str):
+        """Update the free-text comment."""
+        self.feedback_comment = comment
+
+    @rx.event
+    def submit_feedback(self):
+        """Persist the feedback record to SQLite."""
+        if not self.last_trace_id:
+            return
+
+        fb: FeedbackRecord = {
+            "feedback_id": str(uuid4()),
+            "trace_id": self.last_trace_id,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "star_rating": self.feedback_star or None,
+            "sentiment": self.feedback_sentiment or None,
+            "tags": self.feedback_tags,
+            "comment": self.feedback_comment.strip() or None,
+        }
+        try:
+            get_store().record_feedback(fb)
+        except (OSError, RuntimeError) as exc:
+            import logging
+
+            logging.getLogger(__name__).warning("Failed to record feedback: %s", exc)
+
+        self.feedback_submitted = True
+        self.feedback_visible = False
+
+    @rx.event
+    def dismiss_feedback(self):
+        """Dismiss the feedback panel without submitting."""
+        self.feedback_visible = False
+
+    # ── Computed vars for feedback UI ──
+
+    @rx.var
+    def current_tags(self) -> list[str]:
+        """Tags appropriate for the current sentiment selection."""
+        if self.feedback_sentiment == "positive":
+            return POSITIVE_TAGS
+        if self.feedback_sentiment == "negative":
+            return NEGATIVE_TAGS
+        return []

--- a/apps/reflex-chat/reflex_chat/state.py
+++ b/apps/reflex-chat/reflex_chat/state.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from datetime import datetime, timezone
 from typing import Any, TypedDict
@@ -229,8 +230,6 @@ class State(rx.State):
                 self._chats = self._chats
                 yield
         except Exception as exc:  # noqa: BLE001 — broad catch to avoid breaking chat
-            import logging
-
             logging.getLogger(__name__).error("stream_answer error: %s", exc)
 
         self.processing = False
@@ -283,8 +282,6 @@ class State(rx.State):
         try:
             get_store().record_feedback(fb)
         except (OSError, RuntimeError) as exc:
-            import logging
-
             logging.getLogger(__name__).warning("Failed to record feedback: %s", exc)
 
         self.feedback_submitted = True

--- a/packages/pipelines/pyproject.toml
+++ b/packages/pipelines/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "reranking",
     "retrieval",
     "storage",
+    "tracing",
 ]
 
 [tool.uv.sources]
@@ -22,6 +23,7 @@ rag-core = { workspace = true }
 reranking = { workspace = true }
 retrieval = { workspace = true }
 storage = { workspace = true }
+tracing = { workspace = true }
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/pipelines/src/rag_facile/pipelines/__init__.py
+++ b/packages/pipelines/src/rag_facile/pipelines/__init__.py
@@ -1,8 +1,9 @@
 """Pipelines - RAG pipeline coordination for chat applications.
 
 Provides a unified :class:`RAGPipeline` interface that coordinates
-document ingestion and retrieval.  Chat apps depend on this package
-instead of importing from rag_facile.ingestion or rag_facile.retrieval directly.
+document ingestion, retrieval, LLM generation, and conversation tracing.
+Chat apps depend on this package instead of importing from individual
+phase packages directly.
 
 Pipeline selection is driven by ``ragfacile.toml``::
 
@@ -12,10 +13,16 @@ Pipeline selection is driven by ``ragfacile.toml``::
 
 Example usage::
 
-    from rag_facile.pipelines import get_pipeline
+    from rag_facile.pipelines import get_pipeline, stream_answer
 
     pipeline = get_pipeline()
+
+    # Upload a document
     context = pipeline.process_file("document.pdf")
+
+    # Full RAG turn — stream tokens from the LLM
+    async for token in stream_answer("Quels sont vos horaires ?", history):
+        print(token, end="", flush=True)
 
 Convenience functions are also available for simpler call sites::
 
@@ -26,9 +33,13 @@ from __future__ import annotations
 
 import threading
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, AsyncGenerator
 
 from rag_facile.pipelines._base import RAGPipeline
+
+
+if TYPE_CHECKING:
+    pass
 
 
 # ── Singleton pipeline cache ──
@@ -152,6 +163,47 @@ def get_accepted_mime_types() -> dict[str, list[str]]:
     return _get_or_create_pipeline().accepted_mime_types
 
 
+async def stream_answer(
+    question: str,
+    message_history: list[dict[str, Any]],
+    **kwargs: object,
+) -> AsyncGenerator[str, None]:
+    """Full RAG turn: retrieve context, stream LLM answer, record trace.
+
+    Convenience wrapper around :meth:`RAGPipeline.stream_answer` using
+    the singleton pipeline.
+
+    Args:
+        question: Current user question (raw, without context injection).
+        message_history: Previous conversation turns — must **not** include
+            the current turn.
+        **kwargs: Forwarded to the pipeline — e.g. ``collection_ids``,
+            ``trace_id``, ``session_id``.
+
+    Yields:
+        Token strings as they arrive from the LLM.
+
+    Example::
+
+        from rag_facile.pipelines import stream_answer
+
+        async for token in stream_answer(
+            "Quels sont vos horaires ?",
+            message_history,
+            trace_id=trace_id,
+            session_id=session_id,
+            collection_ids=[785],
+        ):
+            print(token, end="", flush=True)
+    """
+    async for token in _get_or_create_pipeline().stream_answer(
+        question,
+        message_history,
+        **kwargs,  # ty: ignore[invalid-argument-type]
+    ):
+        yield token
+
+
 __all__ = [
     "RAGPipeline",
     "get_accepted_mime_types",
@@ -159,4 +211,5 @@ __all__ = [
     "process_bytes",
     "process_file",
     "process_query",
+    "stream_answer",
 ]

--- a/packages/pipelines/src/rag_facile/pipelines/_base.py
+++ b/packages/pipelines/src/rag_facile/pipelines/_base.py
@@ -7,16 +7,30 @@ ingestion or retrieval packages directly.
 
 from __future__ import annotations
 
+import json
+import logging
+import os
+import time
 from abc import ABC, abstractmethod
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING, Any, AsyncGenerator
+from uuid import uuid4
+
+
+if TYPE_CHECKING:
+    from albert import AsyncAlbertClient
+    from rag_facile.core.schema import RetrievedChunk
+
+
+logger = logging.getLogger(__name__)
 
 
 class RAGPipeline(ABC):
     """Abstract RAG pipeline for chat applications.
 
-    Provides a unified interface for both upload-time (file processing)
-    and query-time (retrieval) operations.  Concrete implementations
-    decide how to coordinate ingestion and retrieval.
+    Provides a unified interface for upload-time (file processing),
+    query-time (retrieval), and generation (LLM streaming + tracing).
 
     Subclasses must implement:
       - :meth:`process_file` — parse a file and return formatted context
@@ -24,8 +38,11 @@ class RAGPipeline(ABC):
       - :attr:`supported_extensions` — file extensions this pipeline handles
       - :attr:`accepted_mime_types` — MIME type map for file picker dialogs
 
-    Optional override:
-      - :meth:`process_query` — retrieve context for a user query
+    Optional overrides:
+      - :meth:`retrieve_chunks` — return raw :class:`RetrievedChunk` list
+        (default: empty list — used by :class:`~.basic.BasicPipeline`)
+      - :meth:`process_query` — formatted context string
+        (default: calls ``retrieve_chunks`` + ``format_context``)
     """
 
     # ── Upload-time: file processing ──
@@ -58,24 +75,205 @@ class RAGPipeline(ABC):
             Formatted text ready for context injection.
         """
 
-    # ── Query-time: retrieval ──
+    # ── Query-time: raw chunk retrieval ──
+
+    def retrieve_chunks(self, query: str, **kwargs: object) -> list[RetrievedChunk]:
+        """Retrieve raw chunks for a query.
+
+        The default implementation returns an empty list — suitable for
+        context-stuffing pipelines that pre-load the full document into
+        the prompt.  The Albert pipeline overrides this to perform
+        search → optional rerank.
+
+        Args:
+            query: User query to retrieve chunks for.
+            **kwargs: Pipeline-specific options (e.g. ``collection_ids``).
+
+        Returns:
+            List of :class:`~rag_facile.core.schema.RetrievedChunk` dicts,
+            sorted by relevance score (descending).  Empty list when not
+            applicable.
+        """
+        return []
+
+    # ── Query-time: formatted context string ──
 
     def process_query(self, query: str, **kwargs: object) -> str:
-        """Retrieve relevant context for a user query.
+        """Retrieve relevant context for a user query as a formatted string.
 
-        The default implementation is a no-op — suitable for basic pipelines
-        that rely on context stuffing (the full document is already in the
-        prompt).  The Albert pipeline overrides this to perform
-        search → rerank → format.
+        Calls :meth:`retrieve_chunks` then formats the result via
+        :func:`~rag_facile.context.format_context`.  Override this method
+        only if you need custom formatting logic.
 
         Args:
             query: User query to retrieve context for.
-            **kwargs: Pipeline-specific options (e.g., ``collection_ids``).
+            **kwargs: Forwarded to :meth:`retrieve_chunks`.
 
         Returns:
-            Formatted context string.  Empty string when not applicable.
+            Formatted context string.  Empty string when no chunks found.
         """
-        return ""
+        from rag_facile.context import format_context
+
+        return format_context(self.retrieve_chunks(query, **kwargs))
+
+    # ── Full RAG turn: retrieve + generate + trace ──
+
+    async def stream_answer(
+        self,
+        question: str,
+        message_history: list[dict[str, Any]],
+        *,
+        trace_id: str | None = None,
+        session_id: str = "",
+        **kwargs: object,
+    ) -> AsyncGenerator[str, None]:
+        """Full RAG turn: retrieve context, assemble prompt, stream LLM answer,
+        and record a trace.
+
+        This is the primary entry point for chat applications.  Apps call
+        this method instead of managing the LLM client directly.
+
+        Internally orchestrates:
+
+        1. :meth:`retrieve_chunks` — pipeline-specific retrieval
+        2. Prompt assembly — injects context into user message
+        3. LLM streaming — yields tokens as they arrive
+        4. Trace recording — writes to SQLite after the stream completes
+           (only when ``tracing.enabled = true`` in config)
+
+        Args:
+            question: Current user question (raw, without context injection).
+            message_history: Previous conversation turns, e.g.::
+
+                [
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user",      "content": "Bonjour"},
+                    {"role": "assistant", "content": "Bonjour ! Comment puis-je vous aider ?"},
+                ]
+
+                Must **not** include the current turn.  This method appends
+                it internally with context injected.
+
+            trace_id: Optional pre-generated UUID4.  Auto-generated when
+                *None*.  Pre-generating lets the caller associate user
+                feedback with the trace before the stream completes.
+            session_id: Identifier grouping multiple turns by conversation.
+                Use the Chainlit session ID or Reflex ``client_token``.
+            **kwargs: Forwarded to :meth:`retrieve_chunks` — e.g.
+                ``collection_ids``.
+
+        Yields:
+            Token strings as they arrive from the LLM.
+
+        Side effects:
+            On completion, writes a :class:`~rag_facile.tracing.TraceRecord`
+            to ``.rag-facile/traces.db`` when tracing is enabled.
+        """
+        from rag_facile.context import format_context
+        from rag_facile.core import get_config
+
+        config = get_config()
+        t0 = time.monotonic()
+        effective_trace_id = trace_id or str(uuid4())
+
+        # Step 1 — Retrieval (subclass-specific)
+        chunks = self.retrieve_chunks(question, **kwargs)
+
+        # Step 2 — Prompt assembly
+        retrieved_context = format_context(chunks)
+        user_content = question
+        if retrieved_context:
+            user_content = (
+                "Use the following context to answer the user's question:\n\n"
+                f"{retrieved_context}\n\n"
+                f"Question: {question}"
+            )
+        messages = [*message_history, {"role": "user", "content": user_content}]
+
+        # Step 3 — LLM streaming
+        model_alias = os.getenv("OPENAI_MODEL") or config.generation.model
+        stream = await self._async_llm_client.chat.completions.create(  # ty: ignore[no-matching-overload]
+            model=model_alias,
+            messages=messages,
+            stream=True,
+            temperature=config.generation.temperature,
+            max_tokens=config.generation.max_tokens,
+        )
+
+        resolved_model: str | None = None
+        answer_tokens: list[str] = []
+
+        try:
+            async for chunk in stream:
+                if resolved_model is None and getattr(chunk, "model", None):
+                    resolved_model = chunk.model
+                if chunk.choices and chunk.choices[0].delta.content:
+                    token = chunk.choices[0].delta.content
+                    answer_tokens.append(token)
+                    yield token
+        except json.JSONDecodeError:
+            # Albert API occasionally sends malformed SSE events; continue
+            # with whatever content was streamed so far.
+            pass
+
+        # Step 4 — Trace recording (after stream fully consumed)
+        if config.tracing.enabled:
+            system_prompt = next(
+                (m["content"] for m in message_history if m.get("role") == "system"),
+                None,
+            )
+            pipeline_config_snapshot = {
+                "top_k": config.retrieval.top_k,
+                "top_n": config.reranking.top_n,
+                "retrieval_strategy": config.retrieval.strategy,
+                "reranking_enabled": config.reranking.enabled,
+                "temperature": config.generation.temperature,
+                "query_strategy": config.query.strategy,
+            }
+            try:
+                from rag_facile.tracing import get_store
+
+                store = get_store(config)
+                store.record_turn(
+                    {
+                        "trace_id": effective_trace_id,
+                        "session_id": session_id,
+                        "created_at": datetime.now(timezone.utc).isoformat(),
+                        "question": question,
+                        "chunks": (
+                            json.dumps(list(chunks))
+                            if config.tracing.capture_chunks and chunks
+                            else None
+                        ),
+                        "prompt_sent": (
+                            user_content if config.tracing.capture_prompt else None
+                        ),
+                        "system_prompt": system_prompt,
+                        "answer": "".join(answer_tokens),
+                        "model_alias": model_alias,
+                        "model_resolved": resolved_model,
+                        "preset": config.meta.preset,
+                        "pipeline_config": json.dumps(pipeline_config_snapshot),
+                        "latency_ms": int((time.monotonic() - t0) * 1000),
+                    }
+                )
+            except (OSError, RuntimeError) as exc:
+                # Tracing must never break the chat experience
+                logger.warning("Failed to record trace: %s", exc)
+
+    # ── Async LLM client ──
+
+    @property
+    def _async_llm_client(self) -> AsyncAlbertClient:
+        """Lazy async LLM client for generation, shared across all pipelines."""
+        if not hasattr(self, "_async_llm_client_cache"):
+            from albert import AsyncAlbertClient as _AsyncAlbertClient
+
+            self._async_llm_client_cache = _AsyncAlbertClient(
+                api_key=os.getenv("OPENAI_API_KEY"),
+                base_url=os.getenv("OPENAI_BASE_URL"),
+            )
+        return self._async_llm_client_cache
 
     # ── Capabilities (for UI file dialogs) ──
 
@@ -91,5 +289,5 @@ class RAGPipeline(ABC):
 
         Returns:
             Dict mapping MIME types to extensions, e.g.
-            ``{"application/pdf": [".pdf"]}``.
+            ``{"application/pdf": [".pdf"]}``
         """

--- a/packages/pipelines/src/rag_facile/pipelines/albert.py
+++ b/packages/pipelines/src/rag_facile/pipelines/albert.py
@@ -21,6 +21,7 @@ from ._base import RAGPipeline
 
 if TYPE_CHECKING:
     from albert import AlbertClient
+    from rag_facile.core.schema import RetrievedChunk
 
 
 logger = logging.getLogger(__name__)
@@ -31,11 +32,14 @@ class AlbertPipeline(RAGPipeline):
 
     Documents are uploaded to an auto-managed Albert collection on first
     file upload.  At query time, relevant chunks are retrieved via
-    search -> optional rerank -> context formatting.
+    search -> optional rerank.
 
     Collection management is delegated to the storage package.
-    Query-time retrieval orchestrates: search -> rerank -> format
-    using the retrieval, reranking, and context packages.
+    Query-time retrieval orchestrates: search -> rerank
+    using the retrieval and reranking packages.
+
+    Generation (LLM streaming) and tracing are handled by the base class
+    :meth:`~RAGPipeline.stream_answer` method.
     """
 
     def __init__(self, config: Any | None = None) -> None:
@@ -138,14 +142,14 @@ class AlbertPipeline(RAGPipeline):
         logger.info("Ingested '%s' into collection %s", filename, collection_id)
         return f"[Document indexed: {filename}]"
 
-    # ── Query-time: [expand ->] search -> [fuse ->] rerank -> format ──
+    # ── Query-time: raw chunk retrieval ──
 
-    def process_query(
+    def retrieve_chunks(
         self,
         query: str,
         **kwargs: object,
-    ) -> str:
-        """Retrieve relevant context from Albert collections.
+    ) -> list[RetrievedChunk]:
+        """Retrieve raw chunks from Albert collections.
 
         Orchestrates the full retrieval pipeline:
 
@@ -153,22 +157,21 @@ class AlbertPipeline(RAGPipeline):
         1. Search for relevant chunks — one call per expanded query (retrieval)
         2. Fuse multi-query results via RRF (retrieval) — only when expanded
         3. Rerank results using the original query (reranking)
-        4. Format chunks as LLM context (context)
 
         All parameters default to ragfacile.toml config values.
 
         Args:
-            query: User query to retrieve context for.
+            query: User query to retrieve chunks for.
             **kwargs: Pipeline options.
                 ``collection_ids``: Albert collection IDs to search.
                     Falls back to the auto-managed session collection.
                 ``client``: Optional pre-configured Albert client.
 
         Returns:
-            Formatted context string ready for LLM injection.
-            Empty string if no collection exists or no results found.
+            List of :class:`~rag_facile.core.schema.RetrievedChunk` dicts,
+            sorted by relevance score.  Empty list when no collections are
+            available or no results are found.
         """
-        from rag_facile.context import format_context
         from rag_facile.core import get_config
         from rag_facile.reranking import rerank_chunks
         from rag_facile.retrieval import fuse_results, search_chunks
@@ -196,13 +199,11 @@ class AlbertPipeline(RAGPipeline):
 
         if not ids:
             logger.info("No collection IDs to search — skipping retrieval")
-            return ""
+            return []
         collection_ids = list(ids)
         logger.info("Searching collections: %s", collection_ids)
 
         # Step 0: Query expansion (optional)
-        # When enabled, generates N query variants in formal French administrative
-        # language. Results are merged via RRF before reranking.
         if config.query.strategy != "none":
             from rag_facile.query import get_expander
 
@@ -240,9 +241,9 @@ class AlbertPipeline(RAGPipeline):
             )
 
         if not chunks:
-            return ""
+            return []
 
-        # Step 2 (was Step 2): Rerank — always uses the ORIGINAL query for precision
+        # Step 2: Rerank — always uses the ORIGINAL query for precision
         if config.reranking.enabled:
             chunks = rerank_chunks(
                 client,
@@ -252,8 +253,7 @@ class AlbertPipeline(RAGPipeline):
                 top_n=config.reranking.top_n,
             )
 
-        # Step 3 (was Step 3): Format as LLM context
-        return format_context(chunks)
+        return chunks
 
     # ── Collection management (delegated to storage) ──
 

--- a/packages/rag-core/src/rag_facile/core/schema.py
+++ b/packages/rag-core/src/rag_facile/core/schema.py
@@ -494,6 +494,32 @@ class FormattingConfig(BaseModel):
 
 
 # ==============================================================================
+# TRACING
+# ==============================================================================
+
+
+class TracingConfig(BaseModel):
+    """Configuration for conversation tracing and user feedback collection."""
+
+    enabled: bool = Field(
+        default=True,
+        description="Log RAG turns to SQLite (.rag-facile/traces.db)",
+    )
+    db_path: str = Field(
+        default=".rag-facile/traces.db",
+        description="SQLite database path (relative to workspace root)",
+    )
+    capture_prompt: bool = Field(
+        default=True,
+        description="Store full prompt with injected context (disable for RGPD if needed)",
+    )
+    capture_chunks: bool = Field(
+        default=True,
+        description="Store raw retrieved chunks with relevance scores",
+    )
+
+
+# ==============================================================================
 # ROOT CONFIG
 # ==============================================================================
 
@@ -565,6 +591,10 @@ class RAGConfig(BaseModel):
     formatting: FormattingConfig = Field(
         default_factory=FormattingConfig,
         description="Answer formatting",
+    )
+    tracing: TracingConfig = Field(
+        default_factory=TracingConfig,
+        description="Conversation tracing and user feedback",
     )
 
     model_config = {
@@ -705,6 +735,13 @@ PIPELINE_STAGES: list[PipelineStage] = [
         description="Generate synthetic Q/A datasets to measure RAG pipeline quality.",
         emoji="\U0001f4ca",
         model=EvalConfig,
+    ),
+    PipelineStage(
+        key="tracing",
+        title="Conversation Tracing",
+        description="Log RAG turns (question, chunks, prompt, answer, model, config) to SQLite for quality analysis and user feedback collection.",
+        emoji="\U0001f4dd",
+        model=TracingConfig,
     ),
 ]
 

--- a/packages/rag-facile-lib/pyproject.toml
+++ b/packages/rag-facile-lib/pyproject.toml
@@ -46,3 +46,4 @@ packages = []
 "../reranking/src/rag_facile/reranking" = "rag_facile/reranking"
 "../retrieval/src/rag_facile/retrieval" = "rag_facile/retrieval"
 "../storage/src/rag_facile/storage" = "rag_facile/storage"
+"../tracing/src/rag_facile/tracing" = "rag_facile/tracing"

--- a/packages/tracing/README.md
+++ b/packages/tracing/README.md
@@ -1,0 +1,5 @@
+# tracing
+
+RAG conversation tracing and user feedback collection for rag-facile.
+
+Logs every RAG turn (question, retrieved chunks, prompt, answer, model, pipeline config) to a local SQLite database and stores user feedback (star rating, quality tags, free-text comment).

--- a/packages/tracing/pyproject.toml
+++ b/packages/tracing/pyproject.toml
@@ -1,16 +1,14 @@
 [project]
-name = "ingestion"
+name = "tracing"
 version = "0.17.0" # x-release-please-version
-description = "Document ingestion - parse and extract text from files (PDF, Markdown, HTML)"
+description = "RAG conversation tracing — log turns to SQLite and collect user feedback"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "albert-client",
     "rag-core",
 ]
 
 [tool.uv.sources]
-albert-client = { workspace = true }
 rag-core = { workspace = true }
 
 [build-system]

--- a/packages/tracing/src/rag_facile/tracing/__init__.py
+++ b/packages/tracing/src/rag_facile/tracing/__init__.py
@@ -1,0 +1,76 @@
+"""Tracing — RAG conversation logging and user feedback collection.
+
+Records every RAG turn (question, retrieved chunks, injected prompt, LLM
+answer, resolved model name, pipeline config, latency) to a local SQLite
+database.  User feedback (star rating, quality tags, free-text comment) is
+stored in a linked ``feedback`` table.
+
+The database is created automatically at ``.rag-facile/traces.db`` in the
+workspace root on first use.
+
+Basic usage::
+
+    from rag_facile.tracing import get_store
+
+    store = get_store()
+    store.record_turn({...})          # called by the pipeline
+    store.record_feedback({...})      # called by the UI feedback handler
+
+Export for RAGAS evaluation::
+
+    samples = store.export_ragas(limit=200)
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from ._models import FeedbackRecord, TraceRecord
+from ._store import TraceStore
+
+
+if TYPE_CHECKING:
+    pass
+
+
+# ── Singleton store cache ──
+
+_store: TraceStore | None = None
+_lock = threading.Lock()
+
+
+def get_store(config: Any | None = None) -> TraceStore:
+    """Return the singleton :class:`TraceStore`, creating it on first call.
+
+    The database path is taken from ``config.tracing.db_path``
+    (default: ``.rag-facile/traces.db`` relative to the working directory).
+
+    Args:
+        config: Optional ``RAGConfig`` instance.  Loaded from
+            ``ragfacile.toml`` if *None*.
+
+    Returns:
+        The shared :class:`TraceStore` instance.
+    """
+    global _store  # noqa: PLW0603
+    if _store is None:
+        with _lock:
+            if _store is None:
+                if config is None:
+                    from rag_facile.core import get_config
+
+                    config = get_config()
+                db_path = Path(config.tracing.db_path)
+                _store = TraceStore(db_path)
+    assert _store is not None
+    return _store
+
+
+__all__ = [
+    "FeedbackRecord",
+    "TraceRecord",
+    "TraceStore",
+    "get_store",
+]

--- a/packages/tracing/src/rag_facile/tracing/_models.py
+++ b/packages/tracing/src/rag_facile/tracing/_models.py
@@ -1,0 +1,76 @@
+"""TypedDicts for trace and feedback records."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class TraceRecord(TypedDict):
+    """A single RAG turn trace record stored in SQLite."""
+
+    trace_id: str
+    """UUID4 identifying this trace."""
+
+    session_id: str
+    """Chainlit/Reflex session token — groups turns by conversation."""
+
+    created_at: str
+    """ISO-8601 UTC timestamp, e.g. ``"2026-02-20T17:30:00.000000+00:00"``."""
+
+    question: str
+    """Raw user question before context injection."""
+
+    chunks: str | None
+    """JSON-serialised ``list[RetrievedChunk]`` or ``None`` when
+    ``tracing.capture_chunks = false``."""
+
+    prompt_sent: str | None
+    """Full user message with injected context or ``None`` when
+    ``tracing.capture_prompt = false``."""
+
+    system_prompt: str | None
+    """System prompt used for this turn."""
+
+    answer: str
+    """Complete LLM response (all streamed tokens joined)."""
+
+    model_alias: str
+    """Model alias sent to the API, e.g. ``"openweight-large"``."""
+
+    model_resolved: str | None
+    """Actual model ID from the API response, e.g.
+    ``"meta-llama/Llama-3.3-70B-Instruct"``."""
+
+    preset: str | None
+    """Active preset name from ``config.meta.preset``."""
+
+    pipeline_config: str
+    """JSON snapshot of key pipeline parameters (top_k, top_n, strategy, …)."""
+
+    latency_ms: int | None
+    """End-to-end latency from question received to last token yielded."""
+
+
+class FeedbackRecord(TypedDict):
+    """User evaluation attached to a trace."""
+
+    feedback_id: str
+    """UUID4."""
+
+    trace_id: str
+    """FK → ``traces.trace_id``."""
+
+    created_at: str
+    """ISO-8601 UTC timestamp."""
+
+    star_rating: int | None
+    """1–5 star rating, or ``None`` if the user skipped rating."""
+
+    sentiment: str | None
+    """``"positive"`` | ``"negative"`` | ``None``."""
+
+    tags: list[str]
+    """Selected quality tags, e.g. ``["Pertinent", "Complet"]``."""
+
+    comment: str | None
+    """Free-text comment, or ``None``."""

--- a/packages/tracing/src/rag_facile/tracing/_store.py
+++ b/packages/tracing/src/rag_facile/tracing/_store.py
@@ -1,0 +1,304 @@
+"""SQLite-backed trace and feedback store.
+
+All storage is handled by a single ``.db`` file in the workspace's
+``.rag-facile/`` directory.  No external dependencies — uses the
+Python standard-library ``sqlite3`` module exclusively.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from ._models import FeedbackRecord, TraceRecord
+
+
+if TYPE_CHECKING:
+    pass
+
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# DDL
+# ---------------------------------------------------------------------------
+
+_DDL = """
+CREATE TABLE IF NOT EXISTS traces (
+    trace_id        TEXT PRIMARY KEY,
+    session_id      TEXT NOT NULL,
+    created_at      TEXT NOT NULL,
+    question        TEXT NOT NULL,
+    chunks          TEXT,
+    prompt_sent     TEXT,
+    system_prompt   TEXT,
+    answer          TEXT NOT NULL,
+    model_alias     TEXT NOT NULL,
+    model_resolved  TEXT,
+    preset          TEXT,
+    pipeline_config TEXT NOT NULL,
+    latency_ms      INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS feedback (
+    feedback_id TEXT PRIMARY KEY,
+    trace_id    TEXT NOT NULL REFERENCES traces(trace_id),
+    created_at  TEXT NOT NULL,
+    star_rating INTEGER,
+    sentiment   TEXT,
+    tags        TEXT,
+    comment     TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_traces_session  ON traces(session_id);
+CREATE INDEX IF NOT EXISTS idx_traces_created  ON traces(created_at);
+CREATE INDEX IF NOT EXISTS idx_feedback_trace  ON feedback(trace_id);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS traces_fts USING fts5(
+    question, answer,
+    content=traces, content_rowid=rowid
+);
+
+CREATE VIEW IF NOT EXISTS ragas_export AS
+SELECT
+    t.trace_id,
+    t.question           AS user_input,
+    t.chunks             AS retrieved_contexts_json,
+    t.answer             AS response,
+    json_object(
+        'model_resolved', t.model_resolved,
+        'model_alias',    t.model_alias,
+        'preset',         t.preset,
+        'pipeline_config', json(t.pipeline_config),
+        'star_rating',    f.star_rating,
+        'sentiment',      f.sentiment,
+        'tags',           json(f.tags)
+    )                    AS _metadata
+FROM traces t
+LEFT JOIN feedback f ON f.trace_id = t.trace_id;
+"""
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+
+class TraceStore:
+    """SQLite-backed store for RAG turn traces and user feedback.
+
+    Creates the database file and schema automatically on first use.
+    Thread-safe for single-writer / multi-reader workloads (SQLite WAL mode).
+
+    Args:
+        db_path: Path to the SQLite database file.
+    """
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._db_path = Path(db_path)
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+
+    # ── Initialisation ──
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        return conn
+
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(_DDL)
+
+    # ── Write ──
+
+    def record_turn(self, record: TraceRecord) -> str:
+        """Insert a trace record and return its ``trace_id``.
+
+        Args:
+            record: Completed RAG turn data.
+
+        Returns:
+            The ``trace_id`` of the inserted record.
+        """
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO traces (
+                    trace_id, session_id, created_at,
+                    question, chunks, prompt_sent, system_prompt,
+                    answer, model_alias, model_resolved,
+                    preset, pipeline_config, latency_ms
+                ) VALUES (
+                    :trace_id, :session_id, :created_at,
+                    :question, :chunks, :prompt_sent, :system_prompt,
+                    :answer, :model_alias, :model_resolved,
+                    :preset, :pipeline_config, :latency_ms
+                )
+                """,
+                record,
+            )
+        logger.debug(
+            "Recorded trace %s (latency=%sms)", record["trace_id"], record["latency_ms"]
+        )
+        return record["trace_id"]
+
+    def record_feedback(self, fb: FeedbackRecord) -> None:
+        """Insert or replace a feedback record.
+
+        Args:
+            fb: User evaluation data linked to a trace.
+        """
+        # Serialise tags list → JSON string for storage
+        row: dict[str, Any] = {**fb, "tags": json.dumps(fb["tags"])}
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO feedback (
+                    feedback_id, trace_id, created_at,
+                    star_rating, sentiment, tags, comment
+                ) VALUES (
+                    :feedback_id, :trace_id, :created_at,
+                    :star_rating, :sentiment, :tags, :comment
+                )
+                """,
+                row,
+            )
+        logger.debug(
+            "Recorded feedback %s for trace %s", fb["feedback_id"], fb["trace_id"]
+        )
+
+    # ── Read ──
+
+    def recent(self, n: int = 20) -> list[dict[str, Any]]:
+        """Return the *n* most recent traces (newest first).
+
+        Each row includes any linked feedback fields (NULL when absent).
+
+        Args:
+            n: Maximum number of rows to return.
+
+        Returns:
+            List of dicts with combined trace + feedback fields.
+        """
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT
+                    t.trace_id, t.session_id, t.created_at,
+                    t.question, t.answer,
+                    t.model_alias, t.model_resolved,
+                    t.preset, t.latency_ms,
+                    f.star_rating, f.sentiment, f.tags
+                FROM traces t
+                LEFT JOIN feedback f ON f.trace_id = t.trace_id
+                ORDER BY t.created_at DESC
+                LIMIT ?
+                """,
+                (n,),
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    def export_ragas(self, limit: int = 1000) -> list[dict[str, Any]]:
+        """Export traces in RAGAS ``SingleTurnSample``-compatible format.
+
+        Maps directly to the ``ragas_export`` view defined in the schema.
+
+        Args:
+            limit: Maximum number of rows to export.
+
+        Returns:
+            List of dicts with ``user_input``, ``retrieved_contexts``,
+            ``response``, and ``_metadata``.
+        """
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM ragas_export ORDER BY trace_id LIMIT ?", (limit,)
+            ).fetchall()
+
+        results = []
+        for row in rows:
+            d = dict(row)
+            # Deserialise JSON columns
+            chunks_raw = d.pop("retrieved_contexts_json", None)
+            d["retrieved_contexts"] = (
+                [c["content"] for c in json.loads(chunks_raw)] if chunks_raw else []
+            )
+            d["_metadata"] = json.loads(d["_metadata"]) if d.get("_metadata") else {}
+            results.append(d)
+        return results
+
+    def stats(self) -> dict[str, Any]:
+        """Return summary statistics over all stored traces/feedback.
+
+        Returns:
+            Dict with ``total_traces``, ``total_feedback``, ``avg_star``,
+            ``top_tags``.
+        """
+        with self._connect() as conn:
+            total_traces = conn.execute("SELECT COUNT(*) FROM traces").fetchone()[0]
+            total_feedback = conn.execute("SELECT COUNT(*) FROM feedback").fetchone()[0]
+            avg_star = conn.execute(
+                "SELECT AVG(star_rating) FROM feedback WHERE star_rating IS NOT NULL"
+            ).fetchone()[0]
+            tags_rows = conn.execute(
+                "SELECT tags FROM feedback WHERE tags IS NOT NULL AND tags != '[]'"
+            ).fetchall()
+
+        # Tally individual tags
+        tag_counts: dict[str, int] = {}
+        for row in tags_rows:
+            for tag in json.loads(row[0]):
+                tag_counts[tag] = tag_counts.get(tag, 0) + 1
+        top_tags = sorted(tag_counts.items(), key=lambda x: x[1], reverse=True)[:10]
+
+        return {
+            "total_traces": total_traces,
+            "total_feedback": total_feedback,
+            "avg_star": round(avg_star, 2) if avg_star is not None else None,
+            "top_tags": top_tags,
+        }
+
+    def prune(self, older_than_days: int) -> int:
+        """Delete traces (and their feedback) older than *older_than_days* days.
+
+        Args:
+            older_than_days: Retention period in days.
+
+        Returns:
+            Number of traces deleted.
+        """
+        from datetime import datetime, timedelta, timezone
+
+        cutoff = (
+            datetime.now(timezone.utc) - timedelta(days=older_than_days)
+        ).isoformat()
+        with self._connect() as conn:
+            # feedback rows are deleted via ON DELETE CASCADE logic
+            # (SQLite doesn't cascade by default — delete in order)
+            old_ids = [
+                r[0]
+                for r in conn.execute(
+                    "SELECT trace_id FROM traces WHERE created_at < ?", (cutoff,)
+                ).fetchall()
+            ]
+            if old_ids:
+                placeholders = ",".join("?" * len(old_ids))
+                conn.execute(
+                    f"DELETE FROM feedback WHERE trace_id IN ({placeholders})",
+                    old_ids,  # noqa: S608
+                )
+                conn.execute(
+                    f"DELETE FROM traces WHERE trace_id IN ({placeholders})",
+                    old_ids,  # noqa: S608
+                )
+        if old_ids:
+            logger.info(
+                "Pruned %d traces older than %d days", len(old_ids), older_than_days
+            )
+        return len(old_ids)

--- a/packages/tracing/src/rag_facile/tracing/_store.py
+++ b/packages/tracing/src/rag_facile/tracing/_store.py
@@ -45,7 +45,7 @@ CREATE TABLE IF NOT EXISTS traces (
 
 CREATE TABLE IF NOT EXISTS feedback (
     feedback_id TEXT PRIMARY KEY,
-    trace_id    TEXT NOT NULL REFERENCES traces(trace_id),
+    trace_id    TEXT NOT NULL REFERENCES traces(trace_id) ON DELETE CASCADE,
     created_at  TEXT NOT NULL,
     star_rating INTEGER,
     sentiment   TEXT,
@@ -279,26 +279,10 @@ class TraceStore:
             datetime.now(timezone.utc) - timedelta(days=older_than_days)
         ).isoformat()
         with self._connect() as conn:
-            # feedback rows are deleted via ON DELETE CASCADE logic
-            # (SQLite doesn't cascade by default — delete in order)
-            old_ids = [
-                r[0]
-                for r in conn.execute(
-                    "SELECT trace_id FROM traces WHERE created_at < ?", (cutoff,)
-                ).fetchall()
-            ]
-            if old_ids:
-                placeholders = ",".join("?" * len(old_ids))
-                conn.execute(
-                    f"DELETE FROM feedback WHERE trace_id IN ({placeholders})",
-                    old_ids,  # noqa: S608
-                )
-                conn.execute(
-                    f"DELETE FROM traces WHERE trace_id IN ({placeholders})",
-                    old_ids,  # noqa: S608
-                )
-        if old_ids:
-            logger.info(
-                "Pruned %d traces older than %d days", len(old_ids), older_than_days
-            )
-        return len(old_ids)
+            # ON DELETE CASCADE on the feedback FK ensures feedback rows are
+            # removed automatically when their parent trace is deleted.
+            cursor = conn.execute("DELETE FROM traces WHERE created_at < ?", (cutoff,))
+            deleted = cursor.rowcount
+        if deleted:
+            logger.info("Pruned %d traces older than %d days", deleted, older_than_days)
+        return deleted

--- a/packages/tracing/tests/test_store.py
+++ b/packages/tracing/tests/test_store.py
@@ -1,0 +1,175 @@
+"""Tests for the SQLite trace store."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from rag_facile.tracing._models import FeedbackRecord, TraceRecord
+from rag_facile.tracing._store import TraceStore
+
+
+def _make_trace(trace_id: str | None = None, session_id: str = "sess-1") -> TraceRecord:
+    return {
+        "trace_id": trace_id or str(uuid4()),
+        "session_id": session_id,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "question": "Quels sont les droits des fonctionnaires ?",
+        "chunks": json.dumps(
+            [
+                {
+                    "content": "Art. 1...",
+                    "score": 0.9,
+                    "source_file": "loi.pdf",
+                    "page": 1,
+                    "collection_id": 42,
+                    "document_id": 1,
+                    "chunk_id": 10,
+                }
+            ]
+        ),
+        "prompt_sent": "Use the following context...\nQuestion: ...",
+        "system_prompt": "You are a helpful assistant.",
+        "answer": "Les fonctionnaires ont droit à...",
+        "model_alias": "openweight-large",
+        "model_resolved": "meta-llama/Llama-3.3-70B-Instruct",
+        "preset": "balanced",
+        "pipeline_config": json.dumps({"top_k": 10, "top_n": 5}),
+        "latency_ms": 1234,
+    }
+
+
+def _make_feedback(trace_id: str) -> FeedbackRecord:
+    return {
+        "feedback_id": str(uuid4()),
+        "trace_id": trace_id,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "star_rating": 4,
+        "sentiment": "positive",
+        "tags": ["Pertinent", "Clair"],
+        "comment": "Très bonne réponse.",
+    }
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> TraceStore:
+    return TraceStore(tmp_path / "traces.db")
+
+
+# ── Basic CRUD ──
+
+
+def test_record_turn_returns_trace_id(store: TraceStore) -> None:
+    trace = _make_trace()
+    result = store.record_turn(trace)
+    assert result == trace["trace_id"]
+
+
+def test_record_feedback(store: TraceStore) -> None:
+    trace = _make_trace()
+    store.record_turn(trace)
+    fb = _make_feedback(trace["trace_id"])
+    store.record_feedback(fb)  # must not raise
+
+
+def test_recent_returns_traces(store: TraceStore) -> None:
+    for _ in range(5):
+        store.record_turn(_make_trace())
+    rows = store.recent(n=3)
+    assert len(rows) == 3
+
+
+def test_recent_includes_feedback(store: TraceStore) -> None:
+    trace = _make_trace()
+    store.record_turn(trace)
+    store.record_feedback(_make_feedback(trace["trace_id"]))
+    rows = store.recent(n=1)
+    assert rows[0]["star_rating"] == 4
+    assert rows[0]["sentiment"] == "positive"
+
+
+def test_recent_null_feedback_for_unrated(store: TraceStore) -> None:
+    store.record_turn(_make_trace())
+    rows = store.recent(n=1)
+    assert rows[0]["star_rating"] is None
+
+
+# ── RAGAS export ──
+
+
+def test_export_ragas(store: TraceStore) -> None:
+    trace = _make_trace()
+    store.record_turn(trace)
+    store.record_feedback(_make_feedback(trace["trace_id"]))
+    samples = store.export_ragas(limit=10)
+    assert len(samples) == 1
+    s = samples[0]
+    assert s["user_input"] == trace["question"]
+    assert s["response"] == trace["answer"]
+    assert isinstance(s["retrieved_contexts"], list)
+    assert s["retrieved_contexts"][0] == "Art. 1..."
+    assert s["_metadata"]["star_rating"] == 4
+
+
+def test_export_ragas_empty_chunks(store: TraceStore) -> None:
+    trace = _make_trace()
+    trace["chunks"] = None
+    store.record_turn(trace)
+    samples = store.export_ragas()
+    assert samples[0]["retrieved_contexts"] == []
+
+
+# ── Stats ──
+
+
+def test_stats(store: TraceStore) -> None:
+    for _ in range(3):
+        trace = _make_trace()
+        store.record_turn(trace)
+        store.record_feedback(_make_feedback(trace["trace_id"]))
+    s = store.stats()
+    assert s["total_traces"] == 3
+    assert s["total_feedback"] == 3
+    assert s["avg_star"] == 4.0
+    assert any(tag == "Pertinent" for tag, _ in s["top_tags"])
+
+
+# ── Prune ──
+
+
+def test_prune_old_traces(store: TraceStore) -> None:
+    old = _make_trace()
+    old["created_at"] = "2020-01-01T00:00:00+00:00"
+    store.record_turn(old)
+    store.record_turn(_make_trace())  # recent
+    deleted = store.prune(older_than_days=30)
+    assert deleted == 1
+    assert len(store.recent(n=100)) == 1
+
+
+def test_prune_also_deletes_feedback(store: TraceStore) -> None:
+    old = _make_trace()
+    old["created_at"] = "2020-01-01T00:00:00+00:00"
+    store.record_turn(old)
+    store.record_feedback(_make_feedback(old["trace_id"]))
+    store.prune(older_than_days=30)
+    s = store.stats()
+    assert s["total_feedback"] == 0
+
+
+# ── Idempotency ──
+
+
+def test_record_feedback_replace_on_duplicate(store: TraceStore) -> None:
+    trace = _make_trace()
+    store.record_turn(trace)
+    fb = _make_feedback(trace["trace_id"])
+    store.record_feedback(fb)
+    fb["star_rating"] = 2  # update rating
+    store.record_feedback(fb)  # same feedback_id → replace
+    rows = store.recent(n=1)
+    assert rows[0]["star_rating"] == 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "retrieval",
     "reflex-chat",
     "storage",
+    "tracing",
 ]
 
 [tool.uv.sources]
@@ -34,6 +35,7 @@ reranking = { workspace = true }
 retrieval = { workspace = true }
 reflex-chat = { workspace = true }
 storage = { workspace = true }
+tracing = { workspace = true }
 
 [dependency-groups]
 dev = [
@@ -54,6 +56,7 @@ members = ["apps/*", "packages/*"]
 exclude = [
     ".moon/templates",
     "apps/chainlit-chat/app.py",
+    "apps/reflex-chat/reflex_chat/components/chat.py",
     "apps/reflex-chat/reflex_chat/state.py",
 ]
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,7 +19,8 @@
 				"packages/reranking/pyproject.toml",
 				"packages/retrieval/pyproject.toml",
 				"packages/rag-facile-lib/pyproject.toml",
-			"packages/storage/pyproject.toml"
+			"packages/storage/pyproject.toml",
+			"packages/tracing/pyproject.toml"
 			]
 		}
 	}

--- a/tools/generate_templates.py
+++ b/tools/generate_templates.py
@@ -504,6 +504,7 @@ def main():
             "reranking",
             "retrieval",
             "storage",
+            "tracing",
         ],
         help="Generate a specific template",
     )
@@ -540,6 +541,7 @@ def main():
             "reranking",
             "retrieval",
             "storage",
+            "tracing",
         ]
     else:
         templates_to_generate = [args.template]
@@ -616,6 +618,14 @@ def main():
             result = generate_package_template(
                 "storage",
                 REPO_ROOT / "packages" / "storage",
+                force=args.force,
+            )
+            if result is False:
+                success = False
+        elif template == "tracing":
+            result = generate_package_template(
+                "tracing",
+                REPO_ROOT / "packages" / "tracing",
                 force=args.force,
             )
             if result is False:

--- a/uv.lock
+++ b/uv.lock
@@ -23,6 +23,7 @@ members = [
     "reranking",
     "retrieval",
     "storage",
+    "tracing",
 ]
 
 [[package]]
@@ -2047,6 +2048,7 @@ dependencies = [
     { name = "reranking" },
     { name = "retrieval" },
     { name = "storage" },
+    { name = "tracing" },
 ]
 
 [package.metadata]
@@ -2058,6 +2060,7 @@ requires-dist = [
     { name = "reranking", editable = "packages/reranking" },
     { name = "retrieval", editable = "packages/retrieval" },
     { name = "storage", editable = "packages/storage" },
+    { name = "tracing", editable = "packages/tracing" },
 ]
 
 [[package]]
@@ -2498,6 +2501,7 @@ dependencies = [
     { name = "reranking" },
     { name = "retrieval" },
     { name = "storage" },
+    { name = "tracing" },
 ]
 
 [package.dev-dependencies]
@@ -2527,6 +2531,7 @@ requires-dist = [
     { name = "reranking", editable = "packages/reranking" },
     { name = "retrieval", editable = "packages/retrieval" },
     { name = "storage", editable = "packages/storage" },
+    { name = "tracing", editable = "packages/tracing" },
 ]
 
 [package.metadata.requires-dev]
@@ -3110,6 +3115,17 @@ sdist = { url = "https://files.pythonhosted.org/packages/79/a9/54792db1f9f472e88
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/49/6b88371489dfc1e89ade57cfb3f9ffb7e5ec27a4dcd7a104cfb183fc2483/traceloop_sdk-0.52.2-py3-none-any.whl", hash = "sha256:dc31068404d7f120965d752112115dd1f0fc1b3c9ffb6d87e1eb99cdae521f6e", size = 74380, upload-time = "2026-02-08T10:06:37.085Z" },
 ]
+
+[[package]]
+name = "tracing"
+version = "0.17.0"
+source = { editable = "packages/tracing" }
+dependencies = [
+    { name = "rag-core" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "rag-core", editable = "packages/rag-core" }]
 
 [[package]]
 name = "ty"


### PR DESCRIPTION
## Summary

- **New `packages/tracing/`** (`rag_facile.tracing`): SQLite-backed store recording every RAG turn (question, retrieved chunks, injected prompt, LLM answer, resolved model, pipeline config snapshot, latency) with a linked `feedback` table (star rating 1–5, sentiment, quality tags, free-text comment). Zero new runtime dependencies — pure stdlib `sqlite3`.
- **Pipeline refactor**: LLM generation moves from `app.py` into `RAGPipeline.stream_answer()` — a new concrete base-class method that owns the full RAG turn. `retrieve_chunks()` is extracted from `AlbertPipeline.process_query()` as a proper public method. Apps become thin display layers.
- **Chainlit feedback UI**: star rating → thumbs sentiment → quality tags → comment → persist. Built outside `cl.Step` (avoids issue #1202). 10 quality tags in French.
- **Reflex feedback panel**: collapsible panel with stars, thumbs, tag chips, comment field, Enregistrer button.
- **CLI**: `rag-facile traces show|export|stats|prune` — inspect traces, export JSONL/RAGAS, view quality stats, enforce data retention.
- **Config**: `[tracing]` section in `ragfacile.toml` — `enabled = true` (opt-out), `db_path`, `capture_prompt`, `capture_chunks`.

## Test plan

- [ ] `uv run python -m pytest packages/tracing/tests/` — 11 tests (store CRUD, export, stats, prune)
- [ ] `uv run python -m pytest apps/cli/tests/` — 226/227 passing (1 pre-existing failure unrelated)
- [ ] `uv run ruff check . && uv run ruff format .` — clean
- [ ] `uv run ty check .` — clean
- [ ] Start Chainlit (`just run chainlit`), send a message, verify star rating panel appears after reply, select tags, submit — check `.rag-facile/traces.db` was created
- [ ] `rag-facile traces show` — verify traces table displays
- [ ] `rag-facile traces stats` — verify feedback coverage and tag counts
- [ ] `rag-facile traces export --format ragas -o /tmp/eval.jsonl` — verify RAGAS format
- [ ] `rag-facile traces prune --older-than 0 --yes` — verify old traces deleted

👾 Generated with [Letta Code](https://letta.com)