### PR TITLE
fix: install scripts now default to latest release tag instead of main

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -9,9 +9,28 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-# Use environment variable if set, otherwise use parameter, otherwise default to main
+# Determine which ref to install from:
+# - If -Branch parameter is set, use it
+# - If RAG_FACILE_BRANCH env var is set, use it (for testing pre-release branches)
+# - Otherwise, fetch the latest release tag from GitHub API (stable release)
 if ([string]::IsNullOrEmpty($Branch)) {
-    $Branch = if ($env:RAG_FACILE_BRANCH) { $env:RAG_FACILE_BRANCH } else { "main" }
+    if ($env:RAG_FACILE_BRANCH) {
+        $Branch = $env:RAG_FACILE_BRANCH
+        $BranchSource = "RAG_FACILE_BRANCH env var"
+    } else {
+        try {
+            Write-Host "Fetching latest release tag..." -ForegroundColor Yellow
+            $releaseInfo = Invoke-RestMethod -Uri "https://api.github.com/repos/etalab-ia/rag-facile/releases/latest" -ErrorAction Stop
+            $Branch = $releaseInfo.tag_name
+            $BranchSource = "latest stable release"
+        } catch {
+            Write-Host "WARNING: Could not fetch latest release tag, falling back to 'main'" -ForegroundColor Yellow
+            $Branch = "main"
+            $BranchSource = "fallback"
+        }
+    }
+} else {
+    $BranchSource = "-Branch parameter"
 }
 
 Write-Host "==> Installing RAG Facile CLI (Windows PowerShell)" -ForegroundColor Green
@@ -213,6 +232,7 @@ Write-Host ""
 
 # 5. Install rag-facile CLI via uv
 Write-Host "Installing RAG Facile CLI..." -ForegroundColor Yellow
+Write-Host "Using ref: $Branch ($BranchSource)" -ForegroundColor Cyan
 try {
     $gitUrl = "git+https://github.com/etalab-ia/rag-facile.git@${Branch}#subdirectory=apps/cli"
     uv tool install rag-facile-cli --force --from $gitUrl

--- a/install.sh
+++ b/install.sh
@@ -339,7 +339,7 @@ if [[ -n "${RAG_FACILE_BRANCH:-}" ]]; then
     echo "Using branch/ref: $REF (from RAG_FACILE_BRANCH)"
 else
     echo "Fetching latest release tag..."
-    LATEST_TAG=$(curl -fsSL "https://api.github.com/repos/etalab-ia/rag-facile/releases/latest" 2>/dev/null | grep '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
+    LATEST_TAG=$(curl -fsSL "https://api.github.com/repos/etalab-ia/rag-facile/releases/latest" 2>/dev/null | sed -n -E 's/.*"tag_name": *"([^"]+)".*/\1/p')
     if [[ -z "$LATEST_TAG" ]]; then
         echo "WARNING: Could not fetch latest release tag, falling back to 'main'"
         REF="main"

--- a/install.sh
+++ b/install.sh
@@ -330,9 +330,26 @@ fi
 # 6. Install rag-facile CLI via uv
 echo ""
 echo "Installing RAG Facile CLI..."
-BRANCH="${RAG_FACILE_BRANCH:-main}"
 
-if ! uv tool install rag-facile-cli --force --from "git+https://github.com/etalab-ia/rag-facile.git@${BRANCH}#subdirectory=apps/cli"; then
+# Determine which ref to install from:
+# - If RAG_FACILE_BRANCH is set, use it (for testing pre-release branches)
+# - Otherwise, fetch the latest release tag from GitHub API (stable release)
+if [[ -n "${RAG_FACILE_BRANCH:-}" ]]; then
+    REF="$RAG_FACILE_BRANCH"
+    echo "Using branch/ref: $REF (from RAG_FACILE_BRANCH)"
+else
+    echo "Fetching latest release tag..."
+    LATEST_TAG=$(curl -fsSL "https://api.github.com/repos/etalab-ia/rag-facile/releases/latest" 2>/dev/null | grep '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
+    if [[ -z "$LATEST_TAG" ]]; then
+        echo "WARNING: Could not fetch latest release tag, falling back to 'main'"
+        REF="main"
+    else
+        REF="$LATEST_TAG"
+        echo "Installing stable release: $REF"
+    fi
+fi
+
+if ! uv tool install rag-facile-cli --force --from "git+https://github.com/etalab-ia/rag-facile.git@${REF}#subdirectory=apps/cli"; then
     echo "ERROR: rag-facile installation failed"
     exit 1
 fi


### PR DESCRIPTION
## Summary

- Install scripts (`install.sh`, `install.ps1`) were defaulting to the `main` branch
- This caused users to install unreleased code that references packages not yet bundled in the CLI distribution
- **Root cause**: `rag_facile.tracing` was added to main after v0.17.0 but the install script pulled from main, not the release

## Changes

- **install.sh**: Fetch latest release tag via GitHub API (`/releases/latest`), fall back to `main` if API call fails
- **install.ps1**: Same behavior using PowerShell's `Invoke-RestMethod`
- Both scripts now display which ref is being installed and why (e.g., "Installing stable release: v0.17.0")
- `RAG_FACILE_BRANCH` env var still works for testing pre-release branches

## Test plan

- [x] Run `bash <(curl -fsSL https://raw.githubusercontent.com/.../install.sh)` — should show "Installing stable release: v0.17.0"
- [x] Run `RAG_FACILE_BRANCH=main bash <(curl ...)` — should show "Using branch/ref: main (from RAG_FACILE_BRANCH)"
- [x] Verify `rag-facile --version` shows v0.17.0 after install

👾 Generated with [Letta Code](https://letta.com)