### PR TITLE
chore: add just upgrade command using uv-upx interactive mode

### DIFF
--- a/justfile
+++ b/justfile
@@ -16,6 +16,10 @@ sync:
     uv sync
     uv run pre-commit install
 
+# Interactively upgrade dependencies in pyproject.toml (uses uv-upx)
+upgrade:
+    uvx --from uv-upx uv-upgrade --interactive
+
 # Format code (write changes)
 format:
     moon run tools:format


### PR DESCRIPTION
## Summary

- Adds `just upgrade` recipe to the root justfile
- Runs `uv-upgrade --interactive` via `uvx --from uv-upx` — no permanent install needed, uvx fetches and caches ephemerally
- Lets you accept or reject each proposed dependency bump in `pyproject.toml` one by one

## Test plan

- [x] `just upgrade` launches uv-upx interactive mode
- [x] `just --list` shows the new recipe with correct description
- [x] Pre-commit hooks pass (ruff, ty, templates — all skipped cleanly as expected for a justfile-only change)

👾 Generated with [Letta Code](https://letta.com)