### PR TITLE
chore: remove .envrc files from codebase

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,0 @@
-# 1. Pull in the global config
-source_up
-
-# 2. Local specific overrides or layouts
-layout node
-dotenv

--- a/.moon/templates/chainlit-chat/.envrc
+++ b/.moon/templates/chainlit-chat/.envrc
@@ -1,5 +1,0 @@
-# direnv configuration for RAG Facile workspace
-# Automatically loads .env file when entering this directory
-# Install direnv: https://direnv.net/
-
-dotenv_if_exists .env

--- a/.moon/templates/reflex-chat/.envrc
+++ b/.moon/templates/reflex-chat/.envrc
@@ -1,5 +1,0 @@
-# direnv configuration for RAG Facile workspace
-# Automatically loads .env file when entering this directory
-# Install direnv: https://direnv.net/
-
-dotenv_if_exists .env

--- a/apps/chainlit-chat/.envrc
+++ b/apps/chainlit-chat/.envrc
@@ -1,5 +1,0 @@
-# direnv configuration for RAG Facile workspace
-# Automatically loads .env file when entering this directory
-# Install direnv: https://direnv.net/
-
-dotenv_if_exists .env

--- a/apps/cli/src/cli/commands/setup.py
+++ b/apps/cli/src/cli/commands/setup.py
@@ -448,7 +448,6 @@ package = true
     # Copy and render app files from template
     files_to_copy = [
         ".env.template",
-        ".envrc",
         "README.md",
         "justfile",
     ]

--- a/apps/reflex-chat/.envrc
+++ b/apps/reflex-chat/.envrc
@@ -1,5 +1,0 @@
-# direnv configuration for RAG Facile workspace
-# Automatically loads .env file when entering this directory
-# Install direnv: https://direnv.net/
-
-dotenv_if_exists .env


### PR DESCRIPTION
## Summary

- Deletes all 5 `.envrc` files: project root, `apps/chainlit-chat/`, `apps/reflex-chat/`, and both `.moon/templates/` equivalents
- Removes `.envrc` from the `files_to_copy` list in `setup.py` so it is no longer written to generated standalone projects

## Test plan

- [ ] `ruff check` + `ruff format` — all pass ✅
- [ ] `pytest apps/cli/tests/` — 156 passed, 1 pre-existing failure (`test_generate_letta_requires_env_vars`, unrelated)
- [ ] Verify `rag-facile setup` no longer creates a `.envrc` in the generated project
- [ ] Confirm no `.envrc` files remain in the repo (`find . -name ".envrc"` returns empty)

👾 Generated with [Letta Code](https://letta.com)