### PR TITLE
chore: add worktrunk project config (.config/wt.toml)

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,0 +1,10 @@
+# Worktrunk Project Configuration
+# See: https://worktrunk.dev/config/
+
+[post-create]
+# Install Python dependencies after worktree creation (blocking)
+deps = "uv sync"
+
+[post-start]
+# Copy gitignored files (.env, .letta, .venv, caches) from main worktree (background)
+copy = "wt step copy-ignored"

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -10,6 +10,3 @@
 
 # Agent memory & config
 .rag-facile
-
-# Moon build cache (speeds up repeated tasks)
-.moon/cache

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,15 @@
+# Files copied by `wt step copy-ignored` when creating a new worktree.
+# Only files that are BOTH gitignored AND listed here are copied.
+# See: https://worktrunk.dev
+
+# Secrets
+.env
+
+# Letta Code settings
+.letta
+
+# Agent memory & config
+.rag-facile
+
+# Moon build cache (speeds up repeated tasks)
+.moon/cache


### PR DESCRIPTION
## Summary

- Adds `.config/wt.toml` (committed, shared with team) to configure worktree lifecycle hooks for the [worktrunk](https://worktrunk.dev) (`wt`) tool
- `post-create`: runs `uv sync` (blocking) after worktree creation so deps are ready immediately
- `post-start`: runs `wt step copy-ignored` (background) to copy gitignored files (`.env`, `.letta`, `.venv`, Moon/ruff/pytest caches) from `main/` into the new worktree

## Context

This accompanies a workspace reorganisation:
- All worktrees now live under `.worktrees/` (e.g., `.worktrees/feat-my-feature`) instead of scattered namespace dirs (`feat/`, `fix/`, `hotfix/`, `chore/`, `docs/`) at the workspace root
- `main/` is now the **source of truth** for shared gitignored files (`.env`, `.letta/`) — new worktrees get them automatically via `wt step copy-ignored`
- Removed extraneous workspace-root files: `.env`, `.envrc`, empty scaffold dirs

## Test plan

- [x] `wt switch --create feat/test-wt-hooks` creates worktree at `.worktrees/feat-test-wt-hooks`
- [x] `.venv` is present (from `uv sync` post-create hook)
- [x] `.env` is present (from `wt step copy-ignored` post-start hook)
- [x] `.letta/` is present

👾 Generated with [Letta Code](https://letta.com)