### PR TITLE
chore: prevent premature 1.0.0 — add bump-minor-pre-major to release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,8 @@
 			"release-type": "python",
 			"changelog-path": "CHANGELOG.md",
 			"version-file": "pyproject.toml",
+			"bump-minor-pre-major": true,
+			"bump-patch-for-minor-pre-major": true,
 			"extra-files": [
 				"apps/cli/pyproject.toml",
 				"apps/chainlit-chat/pyproject.toml",
@@ -19,9 +21,9 @@
 				"packages/reranking/pyproject.toml",
 				"packages/retrieval/pyproject.toml",
 				"packages/rag-facile-lib/pyproject.toml",
-			"packages/storage/pyproject.toml",
-			"packages/tracing/pyproject.toml",
-			"packages/evaluation/pyproject.toml"
+				"packages/storage/pyproject.toml",
+				"packages/tracing/pyproject.toml",
+				"packages/evaluation/pyproject.toml"
 			]
 		}
 	}


### PR DESCRIPTION
## Summary

- Adds `bump-minor-pre-major: true` to release-please config so breaking changes (`feat!:`) bump `0.x → 0.x+1` instead of jumping to `1.0.0`
- Adds `bump-patch-for-minor-pre-major: true` so `feat:` bumps minor and `fix:` bumps patch while on 0.x
- Fixes indentation for `storage` and `tracing` entries in `extra-files`

**Context**: PR #139 proposed a 1.0.0 release triggered by `feat!: new install flow` (commit 9ab8c7a). We're not ready for 1.0.0 until the product is minimally feature-complete. Once this merges, release-please will re-evaluate and update #139 to `0.18.0`.

## Test plan

- [ ] Merge this PR to main
- [ ] Verify release-please updates PR #139 from `1.0.0` → `0.18.0`

👾 Generated with [Letta Code](https://letta.com)