### PR TITLE
fix(ci): build and upload workspace zip on every release

### DIFF
--- a/.github/workflows/build-release-asset.yml
+++ b/.github/workflows/build-release-asset.yml
@@ -2,9 +2,22 @@ name: Build Release Asset
 
 # Triggered when a GitHub Release is published (by release-please or manually).
 # Generates the standalone Chainlit workspace zip and uploads it to the release.
+#
+# NOTE: This workflow will NOT fire automatically when release-please creates a
+# release using GITHUB_TOKEN (GitHub blocks downstream events from GITHUB_TOKEN
+# to prevent infinite loops). The release.yml workflow handles that case by
+# running a build job directly after release-please succeeds.
+#
+# Use this workflow for manual re-runs (e.g. if the build job in release.yml
+# fails, or to patch an existing release's asset).
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to build asset for (e.g. v0.18.0)'
+        required: true
 
 permissions:
   contents: write  # needed to upload release assets
@@ -16,7 +29,18 @@ jobs:
     name: "Build & upload workspace zip"
 
     steps:
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
 
       - name: Setup proto
         uses: moonrepo/setup-proto@v1
@@ -30,13 +54,13 @@ jobs:
         run: uv sync
 
       - name: Build release asset
-        run: uv run python tools/build_release_asset.py --version "${{ github.event.release.tag_name }}"
+        run: uv run python tools/build_release_asset.py --version "${{ steps.tag.outputs.tag }}"
 
       - name: Upload asset to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="${{ github.event.release.tag_name }}"
+          TAG="${{ steps.tag.outputs.tag }}"
           ASSET="dist/rag-facile-workspace-${TAG}.zip"
           if [ ! -f "$ASSET" ]; then
             echo "❌ Asset not found: $ASSET"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,59 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  # Build and upload the workspace zip whenever a new release is created.
+  #
+  # We run this as a dependent job here rather than relying on the
+  # "build-release-asset" workflow's `on: release: published` trigger, because
+  # GitHub blocks downstream workflow events triggered by GITHUB_TOKEN (used by
+  # release-please above) to prevent infinite loops.
+  build-release-asset:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    name: "Build & upload workspace zip"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - name: Setup proto
+        uses: moonrepo/setup-proto@v1
+        with:
+          proto-version: latest
+
+      - name: Install uv
+        run: proto install uv
+
+      - name: Install workspace dependencies
+        run: uv sync
+
+      - name: Build release asset
+        run: uv run python tools/build_release_asset.py --version "${{ needs.release-please.outputs.tag_name }}"
+
+      - name: Upload asset to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ needs.release-please.outputs.tag_name }}"
+          ASSET="dist/rag-facile-workspace-${TAG}.zip"
+          if [ ! -f "$ASSET" ]; then
+            echo "❌ Asset not found: $ASSET"
+            ls dist/ || echo "(dist/ is empty)"
+            exit 1
+          fi
+          gh release upload "${TAG}" "${ASSET}" --clobber
+          echo "✅ Uploaded ${ASSET} to release ${TAG}"


### PR DESCRIPTION
## Summary

- **Root cause**: `build-release-asset.yml` triggers on `on: release: types: [published]`, but release-please uses `GITHUB_TOKEN`. GitHub intentionally blocks downstream workflow events triggered by `GITHUB_TOKEN` to prevent infinite loops — so the workflow **never fired** for v0.18.0, and the workspace zip was never attached.
- **Fix**: Add a `build-release-asset` job directly in `release.yml` that runs after release-please when `release_created == 'true'`. This sidesteps the event-blocking problem entirely.
- **Escape hatch**: Add `workflow_dispatch` to `build-release-asset.yml` so any future broken release can be patched manually without a new commit.

## What changed

| File | Change |
|------|--------|
| `release.yml` | Add `build-release-asset` job with `needs: release-please` + `if: release_created == 'true'`. Captures `release_created` and `tag_name` as job outputs from the release-please step. |
| `build-release-asset.yml` | Add `workflow_dispatch` input (`tag`). Resolve tag from either the dispatch input or the release event. Checkout the specific tag before building. Add explanatory comment about why auto-trigger doesn't work. |

## Hotfix already applied

The v0.18.0 zip was built locally and uploaded manually:
```
gh release upload v0.18.0 dist/rag-facile-workspace-v0.18.0.zip
```

## Test plan

- [ ] Merge this PR
- [ ] Merge any subsequent `feat:` or `fix:` commit to trigger a new release-please PR
- [ ] Merge the release-please PR → confirm the `build-release-asset` job appears and succeeds in the Actions tab
- [ ] Verify the new release has `rag-facile-workspace-vX.Y.Z.zip` attached
- [ ] Run `curl -fsSL https://raw.githubusercontent.com/etalab-ia/rag-facile/main/install.sh | bash` end-to-end

👾 Generated with [Letta Code](https://letta.com)