### PR TITLE
fix: disable session memory and conversation logging in learn command

### DIFF
--- a/apps/cli/src/cli/commands/learn/agent.py
+++ b/apps/cli/src/cli/commands/learn/agent.py
@@ -26,11 +26,8 @@ from cli.commands.learn.skills import (
     load_skill,
 )
 from cli.commands.learn.memory import (
-    append_turn,
-    git_commit_session,
     increment_session_count,
     load_context,
-    update_memory,
 )
 from cli.commands.learn.tools import (
     activate_skill,
@@ -330,7 +327,7 @@ def start_chat(debug: bool = False) -> None:
         max_steps=5,
     )
 
-    session_turns: list[tuple[str, str]] = []  # accumulated for post-session update
+    _first_turn = True  # used to inject profile context once on the first turn
 
     # Welcome
     workspace_line = (
@@ -424,12 +421,12 @@ def start_chat(debug: bool = False) -> None:
         # Build effective_input — layer memory (first turn) + skill (on load) + message
         effective_input = user_input
 
-        # Inject memory on first turn of the session
-        if memory_context and not session_turns:
+        # Inject profile on first turn of the session
+        if memory_context and _first_turn:
             effective_input = (
-                f"[Mémoire des sessions précédentes]\n{memory_context}\n\n---\n\n"
-                f"{effective_input}"
+                f"[Profil utilisateur]\n{memory_context}\n\n---\n\n{effective_input}"
             )
+            _first_turn = False
 
         # Inject skill content the first time a skill becomes active
         if active_skill_content and not skill_injected:
@@ -478,18 +475,3 @@ def start_chat(debug: bool = False) -> None:
         console.print("[bold green]Assistant[/bold green]:")
         console.print(Markdown(str(response)))
         console.print()
-
-        # Log turn to today's conversation file
-        if workspace:
-            append_turn(workspace, "user", user_input)
-            append_turn(workspace, "assistant", str(response))
-            session_turns.append((user_input, str(response)))
-
-    # ── Post-session: update memory + git commit ──────────────────────────────
-    if workspace and session_turns:
-        session_log = "\n\n".join(
-            f"Vous: {u}\nAssistant: {a}" for u, a in session_turns
-        )
-        with console.status("[dim]Mise à jour de la mémoire...[/dim]", spinner="dots"):
-            update_memory(workspace, session_log)
-            git_commit_session(workspace)

--- a/apps/cli/src/cli/commands/learn/agent.py
+++ b/apps/cli/src/cli/commands/learn/agent.py
@@ -269,7 +269,7 @@ def start_chat(debug: bool = False) -> None:
     # Load persistent memory — injected into the first user turn (not system prompt)
     # so the model pays full attention to it rather than losing it at the end of
     # smolagents' long built-in system prompt.
-    memory_context = load_context(workspace) if workspace else ""
+    profile_context = load_context(workspace) if workspace else ""
 
     # Increment session count (best-effort — workspace may be None)
     if workspace:
@@ -422,9 +422,9 @@ def start_chat(debug: bool = False) -> None:
         effective_input = user_input
 
         # Inject profile on first turn of the session
-        if memory_context and _first_turn:
+        if profile_context and _first_turn:
             effective_input = (
-                f"[Profil utilisateur]\n{memory_context}\n\n---\n\n{effective_input}"
+                f"[Profil utilisateur]\n{profile_context}\n\n---\n\n{effective_input}"
             )
             _first_turn = False
 

--- a/apps/cli/src/cli/commands/learn/init.py
+++ b/apps/cli/src/cli/commands/learn/init.py
@@ -1,8 +1,8 @@
 """First-run initialization wizard for the rag-facile chat assistant.
 
 Called automatically by start_chat() when .rag-facile/ is absent from the workspace.
-Creates the directory structure and initial memory files that the agent uses
-to personalise responses and track learning progress across sessions.
+Creates the directory structure and profile file that the agent uses
+to personalise responses across sessions.
 """
 
 import subprocess
@@ -19,7 +19,6 @@ console = Console()
 # ── Directory / file layout ───────────────────────────────────────────────────
 
 _AGENT_DIR = Path(".rag-facile") / "agent"
-_MEMORY_FILE = _AGENT_DIR / "MEMORY.md"
 _PROFILE_FILE = _AGENT_DIR / "profile.md"
 _SKILLS_DIR = Path(".rag-facile") / "skills"
 
@@ -51,31 +50,6 @@ _LANGUAGE_CHOICES = [
 # ── Template generators ───────────────────────────────────────────────────────
 
 
-def _memory_template(project_name: str, preset: str, experience: str) -> str:
-    today = date.today().isoformat()
-    return f"""\
----
-updated: {today}
-project: {project_name}
-preset: {preset}
----
-
-# Project Memory
-
-## User Profile
-- Experience level: {experience}
-- Goals: (not yet defined — ask the user)
-- Completed topics: (none yet)
-
-## Project State
-- Preset: {preset}
-- Albert collections: (check ragfacile.toml)
-
-## Learned Facts
-(empty — will be populated across sessions)
-"""
-
-
 def _profile_template(experience: str, language: str) -> str:
     today = date.today().isoformat()
     experience_labels = {
@@ -100,23 +74,6 @@ def _profile_template(experience: str, language: str) -> str:
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
-
-
-def _read_preset(workspace: Path) -> str:
-    """Extract the preset name from ragfacile.toml, defaulting to 'balanced'."""
-    config_file = workspace / "ragfacile.toml"
-    if not config_file.exists():
-        return "balanced"
-    try:
-        import tomllib
-
-        with open(config_file, "rb") as f:
-            data = tomllib.load(f)
-        return data.get("meta", {}).get("preset", "balanced")
-    except tomllib.TOMLDecodeError:
-        return "balanced"
-    except OSError:
-        return "balanced"
 
 
 def _git_add(workspace: Path) -> None:
@@ -205,14 +162,6 @@ def run_init_wizard(workspace: Path) -> str:
     agent_dir.mkdir(parents=True, exist_ok=True)
     (workspace / _SKILLS_DIR).mkdir(parents=True, exist_ok=True)
 
-    project_name = workspace.name
-    preset = _read_preset(workspace)
-
-    # Write MEMORY.md
-    (workspace / _MEMORY_FILE).write_text(
-        _memory_template(project_name, preset, experience), encoding="utf-8"
-    )
-
     # Write profile.md
     (workspace / _PROFILE_FILE).write_text(
         _profile_template(experience, language), encoding="utf-8"
@@ -224,7 +173,6 @@ def run_init_wizard(workspace: Path) -> str:
     # ── Confirmation ──────────────────────────────────────────────────────────
     console.print()
     console.print("[green]✓[/green] Assistant ready")
-    console.print(f"[dim]  Memory: {workspace / _MEMORY_FILE}[/dim]")
     console.print(f"[dim]  Profile: {workspace / _PROFILE_FILE}[/dim]")
     console.print()
 

--- a/apps/cli/src/cli/commands/learn/init.py
+++ b/apps/cli/src/cli/commands/learn/init.py
@@ -65,9 +65,6 @@ def _profile_template(experience: str, language: str) -> str:
 - Experience level: {experience_labels.get(experience, experience)}
 - Initialized: {today}
 
-## Learning Progress
-(none yet — topics will be marked complete as you learn them)
-
 ## Session Count
 0
 """

--- a/apps/cli/src/cli/commands/learn/memory.py
+++ b/apps/cli/src/cli/commands/learn/memory.py
@@ -1,79 +1,32 @@
-"""Git-backed session memory for the rag-facile chat assistant.
+"""User profile context for the rag-facile chat assistant.
 
-Handles four concerns:
-  - load_context()          : read MEMORY.md + profile.md → system instructions
-  - append_turn()           : write each exchange to today's conversation log
-  - update_memory()         : post-session Albert call → append new facts to MEMORY.md
-  - git_commit_session()    : git add .rag-facile/ && commit
-  - increment_session_count(): bump Session Count in profile.md
+Handles two concerns:
+  - load_context()            : read profile.md → context string for the agent
+  - increment_session_count() : bump Session Count in profile.md
 """
 
-import os
 import re
-import subprocess
-from datetime import date, datetime
 from pathlib import Path
 
-import openai
-from rich.console import Console
-
-
-console = Console()
 
 # ── File paths (mirrors init.py layout) ──────────────────────────────────────
 
 _AGENT_DIR = Path(".rag-facile") / "agent"
-_MEMORY_FILE = _AGENT_DIR / "MEMORY.md"
 _PROFILE_FILE = _AGENT_DIR / "profile.md"
-_CONVERSATIONS_DIR = _AGENT_DIR / "conversations"
+
 
 # ── Context loading ───────────────────────────────────────────────────────────
 
 
 def load_context(workspace: Path) -> str:
-    """Return MEMORY.md + profile.md as a formatted string for system instructions.
+    """Return profile.md as a formatted string for the agent's first turn.
 
-    Returns empty string if neither file exists (e.g. outside a workspace).
+    Returns empty string if the file does not exist (e.g. outside a workspace).
     """
-    parts: list[str] = []
-
-    memory_file = workspace / _MEMORY_FILE
-    if memory_file.exists():
-        parts.append(memory_file.read_text(encoding="utf-8").strip())
-
     profile_file = workspace / _PROFILE_FILE
     if profile_file.exists():
-        parts.append(profile_file.read_text(encoding="utf-8").strip())
-
-    return "\n\n---\n\n".join(parts) if parts else ""
-
-
-# ── Turn logging ──────────────────────────────────────────────────────────────
-
-
-def _conversation_file(workspace: Path) -> Path:
-    """Return path to today's conversation log, creating the dir if needed."""
-    conv_dir = workspace / _CONVERSATIONS_DIR
-    conv_dir.mkdir(parents=True, exist_ok=True)
-    return conv_dir / f"{date.today().isoformat()}.md"
-
-
-def append_turn(workspace: Path, role: str, content: str) -> None:
-    """Append a single exchange turn to today's conversation log.
-
-    Creates the file with a header on first write of the day.
-    """
-    log_file = _conversation_file(workspace)
-    timestamp = datetime.now().strftime("%H:%M")
-
-    if not log_file.exists():
-        log_file.write_text(
-            f"# Session {date.today().isoformat()}\n\n", encoding="utf-8"
-        )
-
-    with log_file.open("a", encoding="utf-8") as f:
-        label = "Vous" if role == "user" else "Assistant"
-        f.write(f"## {timestamp} {label}\n\n{content}\n\n")
+        return profile_file.read_text(encoding="utf-8").strip()
+    return ""
 
 
 # ── Session count ─────────────────────────────────────────────────────────────
@@ -95,130 +48,3 @@ def increment_session_count(workspace: Path) -> int:
         profile_file.write_text(content, encoding="utf-8")
         return new_count
     return 1
-
-
-# ── Post-session memory update ────────────────────────────────────────────────
-
-_UPDATE_SYSTEM = """\
-You are updating an AI assistant's persistent memory file.
-Given the current memory and a session transcript, extract 0-3 new facts
-worth remembering for future sessions.
-
-Rules:
-- Return ONLY bullet points starting with "- ", one per line
-- Do NOT repeat facts already present in the memory
-- If nothing new is worth noting, return an empty string
-- Keep each fact concise (one sentence max)
-"""
-
-
-def update_memory(workspace: Path, session_log: str) -> None:
-    """Ask Albert to extract new facts from the session and append to MEMORY.md.
-
-    Best-effort: logs a warning on API failure, never raises.
-    """
-    if not session_log.strip():
-        return
-
-    memory_file = workspace / _MEMORY_FILE
-    if not memory_file.exists():
-        return
-
-    current_memory = memory_file.read_text(encoding="utf-8")
-
-    try:
-        client = openai.OpenAI(
-            api_key=os.getenv("OPENAI_API_KEY") or os.getenv("ALBERT_API_KEY", ""),
-            base_url=os.getenv(
-                "OPENAI_BASE_URL", "https://albert.api.etalab.gouv.fr/v1"
-            ),
-        )
-        response = client.chat.completions.create(
-            model=os.getenv("OPENAI_MODEL", "meta-llama/Llama-3.1-70B-Instruct"),
-            messages=[
-                {"role": "system", "content": _UPDATE_SYSTEM},
-                {
-                    "role": "user",
-                    "content": (
-                        f"Current memory:\n{current_memory}\n\n"
-                        f"Session transcript:\n{session_log}"
-                    ),
-                },
-            ],
-            max_tokens=200,
-            temperature=0.1,
-        )
-        new_facts = (response.choices[0].message.content or "").strip()
-    except openai.APIError as exc:
-        console.print(f"[dim yellow]⚠ Memory update skipped: {exc}[/dim yellow]")
-        return
-
-    if not new_facts:
-        return
-
-    # Remove placeholder line if still present
-    updated = current_memory.replace("(empty — will be populated across sessions)", "")
-
-    # Update frontmatter 'updated' date
-    updated = re.sub(
-        r"^updated: .*$",
-        f"updated: {date.today().isoformat()}",
-        updated,
-        flags=re.MULTILINE,
-    )
-
-    # Ensure "## Learned Facts" section exists, then append
-    if "## Learned Facts" not in updated:
-        updated = updated.rstrip() + "\n\n## Learned Facts\n"
-    updated = updated.rstrip() + f"\n{new_facts}\n"
-
-    memory_file.write_text(updated, encoding="utf-8")
-
-
-# ── Git commit ────────────────────────────────────────────────────────────────
-
-
-def git_commit_session(workspace: Path) -> None:
-    """Stage and commit .rag-facile/ changes with a session commit message.
-
-    Best-effort: silent when git is absent or .rag-facile/ is gitignored
-    (expected when running from the source repo during development).
-    """
-    today = date.today().isoformat()
-    try:
-        # Skip silently if .rag-facile/ is ignored by the workspace .gitignore
-        # (exit code 0 = ignored, 1 = not ignored, 128 = not a git repo)
-        check = subprocess.run(
-            ["git", "check-ignore", "-q", ".rag-facile/"],
-            cwd=workspace,
-            capture_output=True,
-        )
-        if check.returncode == 0:
-            return  # gitignored — skip (dev / source-repo scenario)
-
-        subprocess.run(
-            ["git", "add", ".rag-facile/"],
-            cwd=workspace,
-            check=True,
-            capture_output=True,
-        )
-        diff = subprocess.run(
-            ["git", "diff", "--cached", "--quiet"],
-            cwd=workspace,
-            capture_output=True,
-        )
-        if diff.returncode == 0:
-            return  # nothing staged — skip commit
-
-        subprocess.run(
-            ["git", "commit", "-m", f"agent: session {today}"],
-            cwd=workspace,
-            check=True,
-            capture_output=True,
-        )
-    except FileNotFoundError:
-        pass  # git not installed
-    except subprocess.CalledProcessError as exc:
-        console.print(
-            f"[dim yellow]⚠ Session commit failed: {exc.stderr.decode().strip()}[/dim yellow]"
-        )

--- a/apps/cli/tests/test_learn_init.py
+++ b/apps/cli/tests/test_learn_init.py
@@ -6,7 +6,6 @@ from typer.testing import CliRunner
 
 from cli.commands.learn.init import (
     _profile_template,
-    _read_preset,
     needs_init,
     read_language,
     run_init_wizard,
@@ -24,21 +23,6 @@ class TestNeedsInit:
     def test_returns_false_when_agent_dir_exists(self, tmp_path):
         (tmp_path / ".rag-facile" / "agent").mkdir(parents=True)
         assert needs_init(tmp_path) is False
-
-
-class TestReadPreset:
-    def test_returns_balanced_when_no_config(self, tmp_path):
-        assert _read_preset(tmp_path) == "balanced"
-
-    def test_reads_preset_from_toml(self, tmp_path):
-        (tmp_path / "ragfacile.toml").write_text(
-            '[meta]\npreset = "accurate"\n', encoding="utf-8"
-        )
-        assert _read_preset(tmp_path) == "accurate"
-
-    def test_returns_balanced_on_missing_key(self, tmp_path):
-        (tmp_path / "ragfacile.toml").write_text("[meta]\n", encoding="utf-8")
-        assert _read_preset(tmp_path) == "balanced"
 
 
 class TestProfileTemplate:
@@ -87,8 +71,8 @@ def _lang_en_exp_intermediate():
 
 
 class TestRunInitWizard:
-    def test_creates_memory_and_profile_files(self, tmp_path):
-        """Wizard creates MEMORY.md and profile.md in the workspace."""
+    def test_creates_profile_file(self, tmp_path):
+        """Wizard creates profile.md in the workspace."""
         with (
             patch(
                 "cli.commands.learn.init.questionary.select",
@@ -98,7 +82,6 @@ class TestRunInitWizard:
         ):
             run_init_wizard(tmp_path)
 
-        assert (tmp_path / ".rag-facile" / "agent" / "MEMORY.md").exists()
         assert (tmp_path / ".rag-facile" / "agent" / "profile.md").exists()
 
     def test_returns_selected_language(self, tmp_path):
@@ -124,7 +107,7 @@ class TestRunInitWizard:
 
         assert (tmp_path / ".rag-facile" / "skills").is_dir()
 
-    def test_experience_reflected_in_memory(self, tmp_path):
+    def test_experience_reflected_in_profile(self, tmp_path):
         with (
             patch(
                 "cli.commands.learn.init.questionary.select",
@@ -137,8 +120,8 @@ class TestRunInitWizard:
         ):
             run_init_wizard(tmp_path)
 
-        memory = (tmp_path / ".rag-facile" / "agent" / "MEMORY.md").read_text()
-        assert "expert" in memory
+        profile = (tmp_path / ".rag-facile" / "agent" / "profile.md").read_text()
+        assert "Expert" in profile
 
     def test_falls_back_to_defaults_on_non_interactive(self, tmp_path):
         """If questionary raises EOFError (non-interactive env), defaults are used."""
@@ -151,7 +134,7 @@ class TestRunInitWizard:
         ):
             run_init_wizard(tmp_path)  # should not raise
 
-        assert (tmp_path / ".rag-facile" / "agent" / "MEMORY.md").exists()
+        assert (tmp_path / ".rag-facile" / "agent" / "profile.md").exists()
 
     def test_git_add_called_for_workspace_git(self, tmp_path):
         with (
@@ -177,7 +160,7 @@ class TestRunInitWizard:
             ):
                 run_init_wizard(tmp_path)
 
-        assert (tmp_path / ".rag-facile" / "agent" / "MEMORY.md").exists()
+        assert (tmp_path / ".rag-facile" / "agent" / "profile.md").exists()
 
 
 class TestChatInitIntegration:

--- a/apps/cli/tests/test_learn_memory.py
+++ b/apps/cli/tests/test_learn_memory.py
@@ -1,17 +1,10 @@
-"""Tests for the git-backed session memory module."""
+"""Tests for the user profile context module."""
 
-import subprocess
-from unittest.mock import MagicMock, patch
-
-import openai
 import pytest
 
 from cli.commands.learn.memory import (
-    append_turn,
-    git_commit_session,
     increment_session_count,
     load_context,
-    update_memory,
 )
 
 
@@ -20,18 +13,12 @@ from cli.commands.learn.memory import (
 
 @pytest.fixture()
 def workspace(tmp_path):
-    """Minimal workspace with MEMORY.md and profile.md."""
+    """Minimal workspace with profile.md."""
     agent_dir = tmp_path / ".rag-facile" / "agent"
     agent_dir.mkdir(parents=True)
 
-    (agent_dir / "MEMORY.md").write_text(
-        "---\nupdated: 2026-02-20\nproject: test\npreset: balanced\n---\n\n"
-        "## User Profile\n- Experience level: new\n\n"
-        "## Learned Facts\n(empty — will be populated across sessions)\n",
-        encoding="utf-8",
-    )
     (agent_dir / "profile.md").write_text(
-        "# User Profile\n\n## Preferences\n- Language: fr\n\n## Session Count\n0\n",
+        "# User Profile\n\n## Preferences\n- Language: fr\n- Experience level: New to RAG\n\n## Session Count\n0\n",
         encoding="utf-8",
     )
     return tmp_path
@@ -44,59 +31,17 @@ class TestLoadContext:
     def test_returns_empty_when_no_files(self, tmp_path):
         assert load_context(tmp_path) == ""
 
-    def test_returns_memory_content(self, workspace):
+    def test_returns_profile_content(self, workspace):
         result = load_context(workspace)
         assert "User Profile" in result
-        assert "Experience level: new" in result
 
-    def test_includes_profile(self, workspace):
+    def test_includes_language_preference(self, workspace):
+        result = load_context(workspace)
+        assert "Language: fr" in result
+
+    def test_includes_session_count(self, workspace):
         result = load_context(workspace)
         assert "Session Count" in result
-
-    def test_separates_sections_with_divider(self, workspace):
-        result = load_context(workspace)
-        assert "---" in result
-
-
-# ── append_turn ───────────────────────────────────────────────────────────────
-
-
-class TestAppendTurn:
-    def test_creates_conversation_file(self, workspace):
-        append_turn(workspace, "user", "Bonjour")
-        conv_dir = workspace / ".rag-facile" / "agent" / "conversations"
-        assert any(conv_dir.glob("*.md"))
-
-    def test_user_label_is_vous(self, workspace):
-        append_turn(workspace, "user", "Bonjour")
-        log = next((workspace / ".rag-facile/agent/conversations").glob("*.md"))
-        assert "Vous" in log.read_text()
-
-    def test_assistant_label_is_assistant(self, workspace):
-        append_turn(workspace, "assistant", "Bonjour !")
-        log = next((workspace / ".rag-facile/agent/conversations").glob("*.md"))
-        assert "Assistant" in log.read_text()
-
-    def test_content_written(self, workspace):
-        append_turn(workspace, "user", "Qu'est-ce que le chunking ?")
-        log = next((workspace / ".rag-facile/agent/conversations").glob("*.md"))
-        assert "chunking" in log.read_text()
-
-    def test_multiple_turns_appended(self, workspace):
-        append_turn(workspace, "user", "Question 1")
-        append_turn(workspace, "assistant", "Réponse 1")
-        append_turn(workspace, "user", "Question 2")
-        log = next((workspace / ".rag-facile/agent/conversations").glob("*.md"))
-        content = log.read_text()
-        assert "Question 1" in content
-        assert "Question 2" in content
-        assert "Réponse 1" in content
-
-    def test_header_written_once(self, workspace):
-        append_turn(workspace, "user", "Hello")
-        append_turn(workspace, "user", "Hello again")
-        log = next((workspace / ".rag-facile/agent/conversations").glob("*.md"))
-        assert log.read_text().count("# Session") == 1
 
 
 # ── increment_session_count ───────────────────────────────────────────────────
@@ -119,115 +64,3 @@ class TestIncrementSessionCount:
 
     def test_returns_one_when_no_profile(self, tmp_path):
         assert increment_session_count(tmp_path) == 1
-
-
-# ── update_memory ─────────────────────────────────────────────────────────────
-
-
-class TestUpdateMemory:
-    def test_skips_on_empty_log(self, workspace):
-        memory_before = (workspace / ".rag-facile/agent/MEMORY.md").read_text()
-        update_memory(workspace, "")
-        assert (workspace / ".rag-facile/agent/MEMORY.md").read_text() == memory_before
-
-    def test_skips_when_no_memory_file(self, tmp_path):
-        # Should not raise
-        update_memory(tmp_path, "some log")
-
-    def test_appends_new_facts(self, workspace):
-        mock_response = MagicMock()
-        mock_response.choices[
-            0
-        ].message.content = "- L'utilisateur travaille sur un projet de RAG juridique"
-
-        with patch("cli.commands.learn.memory.openai.OpenAI") as mock_client:
-            mock_client.return_value.chat.completions.create.return_value = (
-                mock_response
-            )
-            update_memory(
-                workspace, "Vous: Je fais du RAG juridique\nAssistant: Intéressant!"
-            )
-
-        memory = (workspace / ".rag-facile/agent/MEMORY.md").read_text()
-        assert "RAG juridique" in memory
-
-    def test_removes_empty_placeholder(self, workspace):
-        mock_response = MagicMock()
-        mock_response.choices[0].message.content = "- Fait intéressant"
-
-        with patch("cli.commands.learn.memory.openai.OpenAI") as mock_client:
-            mock_client.return_value.chat.completions.create.return_value = (
-                mock_response
-            )
-            update_memory(workspace, "some log")
-
-        memory = (workspace / ".rag-facile/agent/MEMORY.md").read_text()
-        assert "(empty — will be populated across sessions)" not in memory
-
-    def test_skips_gracefully_on_api_error(self, workspace):
-        with patch("cli.commands.learn.memory.openai.OpenAI") as mock_client:
-            mock_client.return_value.chat.completions.create.side_effect = (
-                openai.APIConnectionError(request=MagicMock())
-            )
-            # Should not raise
-            update_memory(workspace, "some log")
-
-    def test_skips_when_no_new_facts(self, workspace):
-        mock_response = MagicMock()
-        mock_response.choices[0].message.content = ""
-
-        with patch("cli.commands.learn.memory.openai.OpenAI") as mock_client:
-            mock_client.return_value.chat.completions.create.return_value = (
-                mock_response
-            )
-            update_memory(workspace, "some log")
-
-        # File unchanged (modulo whitespace)
-        memory_after = (workspace / ".rag-facile/agent/MEMORY.md").read_text()
-        assert "Experience level" in memory_after
-
-
-# ── git_commit_session ────────────────────────────────────────────────────────
-
-
-class TestGitCommitSession:
-    def test_silent_when_git_not_found(self, workspace):
-        with patch(
-            "cli.commands.learn.memory.subprocess.run",
-            side_effect=FileNotFoundError,
-        ):
-            git_commit_session(workspace)  # should not raise
-
-    def test_warns_on_git_failure(self, workspace, capsys):
-        err = subprocess.CalledProcessError(1, "git", stderr=b"not a git repo")
-        with patch(
-            "cli.commands.learn.memory.subprocess.run",
-            side_effect=err,
-        ):
-            git_commit_session(workspace)  # should not raise
-
-    def test_skips_commit_when_nothing_staged(self, workspace):
-        """If git diff --cached is clean, no commit is made."""
-        check_ignore = MagicMock(returncode=1)  # 1 = not ignored
-        add_result = MagicMock(returncode=0)
-        diff_result = MagicMock(returncode=0)  # 0 = nothing staged
-
-        with patch(
-            "cli.commands.learn.memory.subprocess.run",
-            side_effect=[check_ignore, add_result, diff_result],
-        ) as mock_run:
-            git_commit_session(workspace)
-
-        assert mock_run.call_count == 3  # check-ignore + add + diff, no commit
-
-    def test_skips_silently_when_gitignored(self, workspace):
-        """If .rag-facile/ is gitignored (e.g. source repo), skip without warning."""
-        check_ignore = MagicMock(returncode=0)  # 0 = ignored
-
-        with patch(
-            "cli.commands.learn.memory.subprocess.run",
-            return_value=check_ignore,
-        ) as mock_run:
-            git_commit_session(workspace)
-
-        assert mock_run.call_count == 1  # only check-ignore, nothing else

--- a/uv.lock
+++ b/uv.lock
@@ -422,7 +422,7 @@ wheels = [
 
 [[package]]
 name = "chainlit-chat"
-version = "0.17.0"
+version = "0.18.1"
 source = { editable = "apps/chainlit-chat" }
 dependencies = [
     { name = "albert-client" },
@@ -498,7 +498,7 @@ wheels = [
 
 [[package]]
 name = "context"
-version = "0.17.0"
+version = "0.18.1"
 source = { editable = "packages/context" }
 dependencies = [
     { name = "rag-core" },
@@ -662,7 +662,7 @@ wheels = [
 
 [[package]]
 name = "evaluation"
-version = "0.17.0"
+version = "0.18.1"
 source = { editable = "packages/evaluation" }
 dependencies = [
     { name = "httpx" },
@@ -832,7 +832,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
-    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -1021,7 +1020,7 @@ wheels = [
 
 [[package]]
 name = "ingestion"
-version = "0.17.0"
+version = "0.18.1"
 source = { editable = "packages/ingestion" }
 dependencies = [
     { name = "albert-client" },
@@ -2388,7 +2387,7 @@ wheels = [
 
 [[package]]
 name = "pipelines"
-version = "0.17.0"
+version = "0.18.1"
 source = { editable = "packages/pipelines" }
 dependencies = [
     { name = "context" },
@@ -2810,7 +2809,7 @@ wheels = [
 
 [[package]]
 name = "query"
-version = "0.17.0"
+version = "0.18.1"
 source = { editable = "packages/query" }
 dependencies = [
     { name = "albert-client" },
@@ -2837,7 +2836,7 @@ wheels = [
 
 [[package]]
 name = "rag-core"
-version = "0.17.0"
+version = "0.18.1"
 source = { editable = "packages/rag-core" }
 dependencies = [
     { name = "pydantic" },
@@ -2854,7 +2853,7 @@ requires-dist = [
 
 [[package]]
 name = "rag-facile"
-version = "0.17.0"
+version = "0.18.1"
 source = { virtual = "." }
 dependencies = [
     { name = "albert-client" },
@@ -2919,7 +2918,7 @@ dev = [
 
 [[package]]
 name = "rag-facile-cli"
-version = "0.17.0"
+version = "0.18.1"
 source = { editable = "apps/cli" }
 dependencies = [
     { name = "albert-client" },
@@ -2982,7 +2981,7 @@ dev = [
 
 [[package]]
 name = "rag-facile-lib"
-version = "0.17.0"
+version = "0.18.1"
 source = { editable = "packages/rag-facile-lib" }
 dependencies = [
     { name = "albert-client" },
@@ -3049,7 +3048,7 @@ wheels = [
 
 [[package]]
 name = "reflex-chat"
-version = "0.17.0"
+version = "0.18.1"
 source = { editable = "apps/reflex-chat" }
 dependencies = [
     { name = "albert-client" },
@@ -3141,7 +3140,7 @@ wheels = [
 
 [[package]]
 name = "reranking"
-version = "0.17.0"
+version = "0.18.1"
 source = { editable = "packages/reranking" }
 dependencies = [
     { name = "albert-client" },
@@ -3168,7 +3167,7 @@ wheels = [
 
 [[package]]
 name = "retrieval"
-version = "0.17.0"
+version = "0.18.1"
 source = { editable = "packages/retrieval" }
 dependencies = [
     { name = "albert-client" },
@@ -3429,7 +3428,7 @@ wheels = [
 
 [[package]]
 name = "storage"
-version = "0.17.0"
+version = "0.18.1"
 source = { editable = "packages/storage" }
 dependencies = [
     { name = "albert-client" },
@@ -3627,7 +3626,7 @@ wheels = [
 
 [[package]]
 name = "tracing"
-version = "0.17.0"
+version = "0.18.1"
 source = { editable = "packages/tracing" }
 dependencies = [
     { name = "rag-core" },


### PR DESCRIPTION
## Summary

- Removes per-turn conversation logging (`append_turn`) — no more `.rag-facile/agent/conversations/YYYY-MM-DD.md` files written
- Removes post-session memory updates (`update_memory`) — no more Albert API call at session end to extract facts into `MEMORY.md`
- Removes git commit after each session (`git_commit_session`)
- Removes `MEMORY.md` creation from the first-run init wizard (file was only used by the now-removed memory update step)
- Profile (`profile.md`) is still read at session start and injected into the first turn as `[Profil utilisateur]` context

## Motivation

No good tooling exists to inspect or delete accumulated session memories, making the feature hard to manage and debug. The profile (language + experience level) remains useful context for the agent.

## Test plan

- [x] Run `rag-facile learn` in a workspace — confirm no `conversations/` directory is created after chatting
- [x] Confirm the session still reads `profile.md` and the agent adapts to language/experience level
- [x] Confirm no "Mise à jour de la mémoire..." spinner appears on quit
- [x] `uv run python -m pytest apps/cli/tests/` — 124 tests pass

👾 Generated with [Letta Code](https://letta.com)