### PR TITLE
feat: memory compaction — 3-layer pruning for unbounded token growth

### DIFF
--- a/apps/cli/src/cli/commands/learn/agent.py
+++ b/apps/cli/src/cli/commands/learn/agent.py
@@ -260,10 +260,10 @@ def _trim_agent_memory(step: ActionStep, *, agent: ToolCallingAgent) -> None:
         return
 
     # Steps to prune: oldest action steps beyond the limit
-    to_prune = set(id(s) for s in action_steps[:-_MAX_AGENT_STEPS])
-    for s in agent.memory.steps:
-        if id(s) in to_prune:
-            s.model_input_messages = None  # free largest object first
+    steps_to_prune = action_steps[:-_MAX_AGENT_STEPS]
+    to_prune = {id(s) for s in steps_to_prune}
+    for s in steps_to_prune:
+        s.model_input_messages = None  # free largest object first
 
     agent.memory.steps = [
         s

--- a/apps/cli/src/cli/commands/learn/agent.py
+++ b/apps/cli/src/cli/commands/learn/agent.py
@@ -14,6 +14,7 @@ from dotenv import load_dotenv
 from rich.markdown import Markdown
 from rich.panel import Panel
 from smolagents import OpenAIServerModel, ToolCallingAgent
+from smolagents.memory import ActionStep, TaskStep
 from smolagents.monitoring import LogLevel
 from smolagents.utils import AgentError, AgentMaxStepsError
 
@@ -239,6 +240,38 @@ class _SessionState:
         self.skill_injected: bool = False
 
 
+# Maximum number of ActionSteps to keep in the agent's memory.
+# Older steps have their model_input_messages cleared to free memory,
+# and then are removed, keeping only the most recent ones.
+_MAX_AGENT_STEPS = 20
+
+
+def _trim_agent_memory(step: ActionStep, *, agent: ToolCallingAgent) -> None:
+    """Step callback: prune old steps from the agent's in-memory history.
+
+    Keeps:
+    - All ``TaskStep`` instances (required for context)
+    - The most recent *_MAX_AGENT_STEPS* ``ActionStep`` instances
+    Removes older ``ActionStep`` instances and clears their
+    ``model_input_messages`` to free the largest objects first.
+    """
+    action_steps = [s for s in agent.memory.steps if isinstance(s, ActionStep)]
+    if len(action_steps) <= _MAX_AGENT_STEPS:
+        return
+
+    # Steps to prune: oldest action steps beyond the limit
+    to_prune = set(id(s) for s in action_steps[:-_MAX_AGENT_STEPS])
+    for s in agent.memory.steps:
+        if id(s) in to_prune:
+            s.model_input_messages = None  # free largest object first
+
+    agent.memory.steps = [
+        s
+        for s in agent.memory.steps
+        if isinstance(s, TaskStep) or id(s) not in to_prune
+    ]
+
+
 _TOOL_ICONS: dict[str, str] = {
     "activate_skill": "📚",
     "get_agents_md": "📋",
@@ -346,6 +379,12 @@ def start_chat(debug: bool = False) -> None:
     from rag_facile.memory.context import bootstrap_context
     from rag_facile.memory.stores import EpisodicLog, SemanticStore
 
+    # Compact old episodic logs before loading context (prunes stale data)
+    if workspace:
+        from rag_facile.memory.lifecycle import compact_episodic_logs
+
+        compact_episodic_logs(workspace)
+
     profile_context = bootstrap_context(workspace) if workspace else ""
 
     # Ensure MEMORY.md exists (creates from template on first session)
@@ -404,6 +443,7 @@ def start_chat(debug: bool = False) -> None:
         instructions=_SYSTEM_PROMPT,
         verbosity_level=LogLevel.INFO if debug else LogLevel.OFF,
         max_steps=5,
+        step_callbacks=[_trim_agent_memory],
     )
 
     # Welcome

--- a/apps/cli/tests/test_learn.py
+++ b/apps/cli/tests/test_learn.py
@@ -135,3 +135,63 @@ class TestNewCommand:
         assert result.exit_code == 0
         # _finalize called twice: once for /new, once for quit
         assert mock_finalize.call_count == 2
+
+
+# ── _trim_agent_memory ────────────────────────────────────────────────────────
+
+
+class TestTrimAgentMemory:
+    """Unit tests for the step callback that prunes old agent steps."""
+
+    def test_noop_when_under_limit(self):
+        from unittest.mock import MagicMock
+
+        from smolagents.memory import ActionStep, AgentMemory, TaskStep
+        from smolagents.monitoring import Timing
+
+        from cli.commands.learn.agent import _MAX_AGENT_STEPS, _trim_agent_memory
+
+        agent = MagicMock()
+        memory = AgentMemory(system_prompt="test")
+        memory.steps.append(TaskStep(task="test"))
+        for i in range(_MAX_AGENT_STEPS - 1):
+            memory.steps.append(
+                ActionStep(step_number=i, timing=Timing(start_time=0, end_time=0))
+            )
+        agent.memory = memory
+
+        step = memory.steps[-1]
+        _trim_agent_memory(step, agent=agent)
+        # All steps should remain (under limit)
+        action_count = sum(1 for s in memory.steps if isinstance(s, ActionStep))
+        assert action_count == _MAX_AGENT_STEPS - 1
+
+    def test_prunes_oldest_steps(self):
+        from unittest.mock import MagicMock
+
+        from smolagents.memory import ActionStep, AgentMemory, TaskStep
+        from smolagents.monitoring import Timing
+
+        from cli.commands.learn.agent import _MAX_AGENT_STEPS, _trim_agent_memory
+
+        agent = MagicMock()
+        memory = AgentMemory(system_prompt="test")
+        memory.steps.append(TaskStep(task="test"))
+        for i in range(_MAX_AGENT_STEPS + 10):
+            memory.steps.append(
+                ActionStep(step_number=i, timing=Timing(start_time=0, end_time=0))
+            )
+        agent.memory = memory
+
+        step = memory.steps[-1]
+        _trim_agent_memory(step, agent=agent)
+
+        action_count = sum(1 for s in memory.steps if isinstance(s, ActionStep))
+        assert action_count == _MAX_AGENT_STEPS
+        # TaskStep preserved
+        assert any(isinstance(s, TaskStep) for s in memory.steps)
+        # Oldest steps removed — highest step_number should survive
+        remaining_numbers = [
+            s.step_number for s in memory.steps if isinstance(s, ActionStep)
+        ]
+        assert remaining_numbers[-1] == _MAX_AGENT_STEPS + 9

--- a/packages/memory/src/rag_facile/memory/context.py
+++ b/packages/memory/src/rag_facile/memory/context.py
@@ -76,8 +76,9 @@ def bootstrap_context(
             if len(section) > remaining:
                 # Truncate logs to fit, keeping the beginning (newest entries)
                 header = "[Memory — Recent Conversations]\n"
-                available = remaining - len(header) - 20  # leave room for "…"
-                section = header + logs[:available] + "\n…(truncated)"
+                truncation_marker = "\n…(truncated)"
+                available = remaining - len(header) - len(truncation_marker)
+                section = header + logs[:available] + truncation_marker
             sections.append(section)
 
     if not sections:

--- a/packages/memory/src/rag_facile/memory/context.py
+++ b/packages/memory/src/rag_facile/memory/context.py
@@ -18,8 +18,21 @@ from rag_facile.memory._paths import PROFILE_FILE
 from rag_facile.memory.stores import EpisodicLog, SemanticStore
 
 
-def bootstrap_context(workspace: Path, *, log_days: int = 2) -> str:
+# Default character budget for the injected context (~2000 tokens).
+MAX_CONTEXT_CHARS = 8000
+
+# Separator used between sections.
+_SEP = "\n\n---\n\n"
+
+
+def bootstrap_context(
+    workspace: Path, *, log_days: int = 2, max_chars: int = MAX_CONTEXT_CHARS
+) -> str:
     """Return the combined memory context for the start of a session.
+
+    Sections are added in priority order (semantic store > profile >
+    episodic logs).  If the total exceeds *max_chars*, lower-priority
+    sections are truncated or dropped to fit.
 
     Parameters
     ----------
@@ -27,6 +40,8 @@ def bootstrap_context(workspace: Path, *, log_days: int = 2) -> str:
         Root directory containing ``.agent/``.
     log_days:
         Number of past days of episodic logs to include (default 2).
+    max_chars:
+        Maximum total characters for the combined context.
 
     Returns
     -------
@@ -34,25 +49,38 @@ def bootstrap_context(workspace: Path, *, log_days: int = 2) -> str:
         Formatted context string (may be empty if no memory files exist).
     """
     sections: list[str] = []
+    remaining = max_chars
 
-    # 1. Semantic store (curated facts, capped at 200 lines)
+    # 1. Semantic store (highest priority — curated facts, capped at 200 lines)
     semantic = SemanticStore.load(workspace)
     if semantic:
-        sections.append(f"[Memory — Semantic Store]\n{semantic}")
+        section = f"[Memory — Semantic Store]\n{semantic}"
+        sections.append(section)
+        remaining -= len(section) + len(_SEP)
 
-    # 2. Profile
+    # 2. Profile (small, almost always fits)
     profile_path = workspace / PROFILE_FILE
     if profile_path.exists():
         profile = profile_path.read_text(encoding="utf-8").strip()
         if profile:
-            sections.append(f"[Memory — Profile]\n{profile}")
+            section = f"[Memory — Profile]\n{profile}"
+            if len(section) <= remaining:
+                sections.append(section)
+                remaining -= len(section) + len(_SEP)
 
-    # 3. Recent episodic logs
-    logs = EpisodicLog.read_recent(workspace, days=log_days)
-    if logs:
-        sections.append(f"[Memory — Recent Conversations]\n{logs}")
+    # 3. Recent episodic logs (lowest priority — truncated to fit budget)
+    if remaining > 100:  # don't bother if barely any room
+        logs = EpisodicLog.read_recent(workspace, days=log_days)
+        if logs:
+            section = f"[Memory — Recent Conversations]\n{logs}"
+            if len(section) > remaining:
+                # Truncate logs to fit, keeping the beginning (newest entries)
+                header = "[Memory — Recent Conversations]\n"
+                available = remaining - len(header) - 20  # leave room for "…"
+                section = header + logs[:available] + "\n…(truncated)"
+            sections.append(section)
 
     if not sections:
         return ""
 
-    return "\n\n---\n\n".join(sections)
+    return _SEP.join(sections)

--- a/packages/memory/src/rag_facile/memory/lifecycle.py
+++ b/packages/memory/src/rag_facile/memory/lifecycle.py
@@ -1,4 +1,4 @@
-"""Session lifecycle hooks — checkpointing, finalisation, git commit.
+"""Session lifecycle hooks — checkpointing, finalisation, compaction, git commit.
 
 Coordinates the memory stores during and after a chat session:
 
@@ -6,6 +6,7 @@ Coordinates the memory stores during and after a chat session:
   out of the agent's context window.
 * **Finalisation** — end-of-session: save snapshot, update semantic store,
   increment session count, git commit.
+* **Compaction** — prune old episodic logs, keeping only checkpoint entries.
 * **Git commit** — best-effort commit of ``.agent/`` changes.
 """
 
@@ -14,10 +15,10 @@ from __future__ import annotations
 import logging
 import re
 import subprocess
-from datetime import datetime
+from datetime import date, datetime, timedelta
 from pathlib import Path
 
-from rag_facile.memory._paths import PROFILE_FILE
+from rag_facile.memory._paths import LOGS_DIR, PROFILE_FILE
 from rag_facile.memory.stores import EpisodicLog, SemanticStore, SessionSnapshot
 
 logger = logging.getLogger(__name__)
@@ -134,7 +135,10 @@ def finalize_session(
     # 3. Session count
     increment_session_count(workspace)
 
-    # 4. Git commit
+    # 4. Compact semantic store (prune oldest entries if sections overflow)
+    SemanticStore.compact(workspace)
+
+    # 5. Git commit
     git_commit_session(workspace)
 
 
@@ -218,6 +222,77 @@ def git_commit_session(workspace: Path) -> None:
         logger.debug(
             "git commit failed: %s", exc.stderr.decode() if exc.stderr else exc
         )
+
+
+# ── Episodic log compaction ────────────────────────────────────────────────────
+
+# Regex matching checkpoint headers: "## HH:MM — Checkpoint"
+_CHECKPOINT_HEADER = re.compile(r"^## \d{2}:\d{2} — Checkpoint$", re.MULTILINE)
+
+
+def compact_episodic_logs(workspace: Path, *, keep_days: int = 2) -> int:
+    """Compact old episodic log files, keeping only checkpoint entries.
+
+    Log files older than *keep_days* are rewritten to contain only their
+    ``## HH:MM — Checkpoint`` sections (summary, decisions, facts).  If a
+    file has no checkpoints it is deleted entirely.
+
+    Returns the number of files compacted or removed.
+    """
+    logs_dir = workspace / LOGS_DIR
+    if not logs_dir.exists():
+        return 0
+
+    cutoff = date.today() - timedelta(days=keep_days)
+    compacted = 0
+
+    for log_file in sorted(logs_dir.glob("*.md")):
+        # Parse date from filename (YYYY-MM-DD.md)
+        try:
+            file_date = date.fromisoformat(log_file.stem)
+        except ValueError:
+            continue  # skip non-date files
+        if file_date >= cutoff:
+            continue  # recent — keep as-is
+
+        content = log_file.read_text(encoding="utf-8")
+        checkpoint_sections = _extract_checkpoint_sections(content)
+
+        if not checkpoint_sections:
+            log_file.unlink()
+            logger.debug("Deleted empty log: %s", log_file.name)
+        else:
+            header = f"# {file_date.isoformat()} (compacted)\n"
+            log_file.write_text(
+                header + "\n".join(checkpoint_sections) + "\n",
+                encoding="utf-8",
+            )
+            logger.debug("Compacted log: %s", log_file.name)
+        compacted += 1
+
+    return compacted
+
+
+def _extract_checkpoint_sections(content: str) -> list[str]:
+    """Extract checkpoint sections from a log file's content.
+
+    Each checkpoint section starts with ``## HH:MM — Checkpoint`` and
+    extends to the next ``## `` header or end of file.
+    """
+    sections: list[str] = []
+    lines = content.splitlines()
+    i = 0
+    while i < len(lines):
+        if _CHECKPOINT_HEADER.match(lines[i]):
+            block = [lines[i]]
+            i += 1
+            while i < len(lines) and not lines[i].startswith("## "):
+                block.append(lines[i])
+                i += 1
+            sections.append("\n".join(block).rstrip())
+        else:
+            i += 1
+    return sections
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────

--- a/packages/memory/src/rag_facile/memory/stores.py
+++ b/packages/memory/src/rag_facile/memory/stores.py
@@ -220,9 +220,13 @@ class SemanticStore:
                 if not re.match(r"^- \[\d{4}-\d{2}-\d{2}\]", e.strip())
             ]
 
-            # Keep newest dated entries (they sort lexically by date)
+            # Keep newest dated entries (they sort lexically by date).
+            # If undated entries alone exceed the limit, truncate them too.
             dated.sort(reverse=True)
-            kept = undated + dated[: max(0, max_entries_per_section - len(undated))]
+            kept = (
+                undated[:max_entries_per_section]
+                + dated[: max(0, max_entries_per_section - len(undated))]
+            )
             removed = len(entries) - len(kept)
             total_removed += removed
 

--- a/packages/memory/src/rag_facile/memory/stores.py
+++ b/packages/memory/src/rag_facile/memory/stores.py
@@ -168,6 +168,82 @@ class SemanticStore:
                 content = content.replace("---\n", f"---\n{key}: {value}\n", 1)
         path.write_text(content, encoding="utf-8")
 
+    @staticmethod
+    def compact(workspace: Path, *, max_entries_per_section: int = 20) -> int:
+        """Prune each section in ``MEMORY.md`` to at most *max_entries_per_section*.
+
+        Entries are lines starting with ``- ``.  Date-stamped entries
+        (``- [YYYY-MM-DD] ...``) are kept newest-first; undated entries are
+        kept in their original order and count toward the limit.
+
+        Returns the total number of entries removed across all sections.
+        """
+        path = workspace / MEMORY_FILE
+        if not path.exists():
+            return 0
+
+        content = path.read_text(encoding="utf-8")
+        total_removed = 0
+
+        for section in SEMANTIC_SECTIONS:
+            header_pattern = rf"^(## {re.escape(section)}\s*\n)"
+            match = re.search(header_pattern, content, re.MULTILINE)
+            if not match:
+                continue
+
+            # Find section boundaries
+            start = match.end()
+            rest = content[start:]
+            next_section = re.search(r"^## ", rest, re.MULTILINE)
+            end = start + next_section.start() if next_section else len(content)
+            section_text = content[start:end]
+
+            # Split into entry lines and non-entry lines
+            entries: list[str] = []
+            non_entries: list[str] = []
+            for line in section_text.splitlines():
+                if line.strip().startswith("- "):
+                    entries.append(line)
+                else:
+                    non_entries.append(line)
+
+            if len(entries) <= max_entries_per_section:
+                continue
+
+            # Sort dated entries newest-first, keep undated in original order
+            dated = [
+                e for e in entries if re.match(r"^- \[\d{4}-\d{2}-\d{2}\]", e.strip())
+            ]
+            undated = [
+                e
+                for e in entries
+                if not re.match(r"^- \[\d{4}-\d{2}-\d{2}\]", e.strip())
+            ]
+
+            # Keep newest dated entries (they sort lexically by date)
+            dated.sort(reverse=True)
+            kept = undated + dated[: max(0, max_entries_per_section - len(undated))]
+            removed = len(entries) - len(kept)
+            total_removed += removed
+
+            # Rebuild section: non-entries (blank lines, table headers) + kept entries
+            new_section = "\n".join(non_entries + kept) + "\n"
+            content = content[:start] + new_section + content[end:]
+
+        if total_removed > 0:
+            # Update frontmatter date
+            today = date.today().isoformat()
+            content = re.sub(
+                r"^(updated:\s*).+$",
+                rf"\g<1>{today}",
+                content,
+                count=1,
+                flags=re.MULTILINE,
+            )
+            path.write_text(content, encoding="utf-8")
+
+        return total_removed
+
 
 # ── Episodic Log ──────────────────────────────────────────────────────────────
 

--- a/packages/memory/tests/test_context.py
+++ b/packages/memory/tests/test_context.py
@@ -54,3 +54,57 @@ class TestBootstrapContext:
         result = bootstrap_context(tmp_path, log_days=1)
         assert "Future entry" in result
         assert "Old entry" not in result
+
+
+class TestBootstrapContextBudget:
+    def test_truncates_logs_when_over_budget(self, tmp_path):
+        SemanticStore.create(tmp_path)
+        # Create a large episodic log
+        large_log = "Important content. " * 500  # ~9500 chars
+        EpisodicLog.append_turn(tmp_path, "user", large_log)
+
+        result = bootstrap_context(tmp_path, max_chars=2000)
+        assert len(result) <= 2200  # allow some slack for headers
+        assert "Semantic Store" in result  # highest priority kept
+        assert "truncated" in result  # logs were truncated
+
+    def test_drops_profile_when_no_room(self, tmp_path):
+        # Create a large semantic store that fills the budget
+        SemanticStore.create(tmp_path)
+        for i in range(50):
+            SemanticStore.add_entry(
+                tmp_path, "Key Facts", f"Important fact number {i} with extra detail"
+            )
+
+        agent_dir = tmp_path / ".agent"
+        (agent_dir / "profile.md").write_text(
+            "# Profile\n" + "- Detail\n" * 100, encoding="utf-8"
+        )
+
+        result = bootstrap_context(tmp_path, max_chars=1500)
+        assert "Semantic Store" in result
+
+    def test_respects_large_budget(self, tmp_path):
+        SemanticStore.create(tmp_path)
+        EpisodicLog.append_turn(tmp_path, "user", "Short message")
+        agent_dir = tmp_path / ".agent"
+        (agent_dir / "profile.md").write_text(
+            "# Profile\n- Language: en\n", encoding="utf-8"
+        )
+
+        result = bootstrap_context(tmp_path, max_chars=50000)
+        assert "Semantic Store" in result
+        assert "Profile" in result
+        assert "Recent Conversations" in result
+        assert "truncated" not in result  # nothing needs truncating
+
+    def test_skips_logs_when_remaining_too_small(self, tmp_path):
+        # Fill most of the budget with semantic store
+        SemanticStore.create(tmp_path)
+        for i in range(30):
+            SemanticStore.add_entry(tmp_path, "Key Facts", f"Fact {i} data")
+        EpisodicLog.append_turn(tmp_path, "user", "Test turn")
+
+        # Very tight budget — logs section requires >100 chars remaining
+        result = bootstrap_context(tmp_path, max_chars=800)
+        assert "Semantic Store" in result

--- a/packages/memory/tests/test_lifecycle.py
+++ b/packages/memory/tests/test_lifecycle.py
@@ -7,9 +7,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from rag_facile.memory.lifecycle import (
+    _extract_checkpoint_sections,
     _extract_checkpoint_summary,
     _extract_topics,
     _format_transcript,
+    compact_episodic_logs,
     finalize_session,
     git_commit_session,
     increment_session_count,
@@ -369,3 +371,106 @@ class TestExtractCheckpointSummary:
         content = EpisodicLog.today_path(workspace).read_text()
         assert "Checkpoint" in content
         assert "**Decisions**" in content and "**New facts**" in content
+
+
+# ── _extract_checkpoint_sections ──────────────────────────────────────────────
+
+
+class TestExtractCheckpointSections:
+    def test_extracts_checkpoint_block(self):
+        content = (
+            "# 2026-03-01\n\n"
+            "## 10:00 — Vous\nBonjour\n\n"
+            "## 10:01 — Assistant\nBienvenue !\n\n"
+            "## 10:05 — Checkpoint\n**Summary**: Discussed setup\n"
+            "**Decisions**: Changed top_k\n\n"
+            "## 10:10 — Vous\nMerci\n"
+        )
+        sections = _extract_checkpoint_sections(content)
+        assert len(sections) == 1
+        assert "Discussed setup" in sections[0]
+        assert "Changed top_k" in sections[0]
+
+    def test_returns_empty_for_no_checkpoints(self):
+        content = "# 2026-03-01\n\n## 10:00 — Vous\nHello\n"
+        assert _extract_checkpoint_sections(content) == []
+
+    def test_extracts_multiple_checkpoints(self):
+        content = (
+            "## 10:05 — Checkpoint\n**Summary**: First\n\n"
+            "## 10:10 — Vous\nMiddle turn\n\n"
+            "## 10:15 — Checkpoint\n**Summary**: Second\n"
+        )
+        sections = _extract_checkpoint_sections(content)
+        assert len(sections) == 2
+        assert "First" in sections[0]
+        assert "Second" in sections[1]
+
+
+# ── compact_episodic_logs ─────────────────────────────────────────────────────
+
+
+class TestCompactEpisodicLogs:
+    def test_noop_when_no_logs(self, workspace):
+        assert compact_episodic_logs(workspace) == 0
+
+    def test_leaves_recent_logs_untouched(self, workspace):
+        from rag_facile.memory.stores import EpisodicLog
+
+        EpisodicLog.append_turn(workspace, "user", "Recent message")
+        original = EpisodicLog.today_path(workspace).read_text()
+        assert compact_episodic_logs(workspace) == 0
+        assert EpisodicLog.today_path(workspace).read_text() == original
+
+    def test_deletes_old_log_without_checkpoints(self, workspace):
+        logs_dir = workspace / ".agent" / "logs"
+        logs_dir.mkdir(parents=True)
+        old_file = logs_dir / "2020-01-01.md"
+        old_file.write_text(
+            "# 2020-01-01\n\n## 10:00 — Vous\nOld message\n\n"
+            "## 10:01 — Assistant\nOld reply\n",
+            encoding="utf-8",
+        )
+        assert compact_episodic_logs(workspace) == 1
+        assert not old_file.exists()
+
+    def test_compacts_old_log_with_checkpoints(self, workspace):
+        logs_dir = workspace / ".agent" / "logs"
+        logs_dir.mkdir(parents=True)
+        old_file = logs_dir / "2020-01-01.md"
+        old_file.write_text(
+            "# 2020-01-01\n\n"
+            "## 10:00 — Vous\nBonjour\n\n"
+            "## 10:01 — Assistant\nBienvenue\n\n"
+            "## 10:05 — Checkpoint\n**Summary**: Discussed setup\n"
+            "**Decisions**: Changed top_k\n\n"
+            "## 10:10 — Vous\nMerci\n",
+            encoding="utf-8",
+        )
+        assert compact_episodic_logs(workspace) == 1
+        assert old_file.exists()
+        content = old_file.read_text()
+        assert "compacted" in content
+        assert "Checkpoint" in content
+        assert "Discussed setup" in content
+        # Raw turns should be gone
+        assert "Bonjour" not in content
+        assert "Merci" not in content
+
+    def test_respects_keep_days(self, workspace):
+        from datetime import date, timedelta
+
+        logs_dir = workspace / ".agent" / "logs"
+        logs_dir.mkdir(parents=True)
+        # File from 3 days ago
+        old_date = date.today() - timedelta(days=3)
+        old_file = logs_dir / f"{old_date.isoformat()}.md"
+        old_file.write_text("# Old\n## 10:00 — Vous\nTest\n", encoding="utf-8")
+        # File from 1 day ago (within keep_days=2)
+        recent_date = date.today() - timedelta(days=1)
+        recent_file = logs_dir / f"{recent_date.isoformat()}.md"
+        recent_file.write_text("# Recent\n## 10:00 — Vous\nKeep\n", encoding="utf-8")
+
+        assert compact_episodic_logs(workspace, keep_days=2) == 1
+        assert not old_file.exists()  # deleted (no checkpoints)
+        assert recent_file.exists()  # within keep_days

--- a/packages/memory/tests/test_stores.py
+++ b/packages/memory/tests/test_stores.py
@@ -306,3 +306,77 @@ class TestSessionSnapshotListRecent:
                 start_time=datetime(2026, 3, 1, 21, i),
             )
         assert len(SessionSnapshot.list_recent(workspace, n=3)) == 3
+
+
+# ── SemanticStore.compact ─────────────────────────────────────────────────────
+
+
+class TestSemanticStoreCompact:
+    def test_noop_when_no_file(self, workspace):
+        assert SemanticStore.compact(workspace) == 0
+
+    def test_noop_when_under_limit(self, workspace):
+        SemanticStore.create(workspace)
+        for i in range(5):
+            SemanticStore.add_entry(workspace, "Key Facts", f"Fact {i}")
+        assert SemanticStore.compact(workspace) == 0
+
+    def test_prunes_oldest_dated_entries(self, workspace):
+        SemanticStore.create(workspace)
+        # Add 25 entries — each gets today's date
+        for i in range(25):
+            SemanticStore.add_entry(workspace, "Key Facts", f"Fact number {i}")
+
+        removed = SemanticStore.compact(workspace, max_entries_per_section=20)
+        assert removed == 5
+
+        # Verify remaining entries
+        entries = SemanticStore.read_section(workspace, "Key Facts")
+        assert len(entries) == 20
+
+    def test_preserves_undated_entries(self, workspace):
+        SemanticStore.create(workspace)
+        # Write undated entries directly
+        path = workspace / ".agent" / "MEMORY.md"
+        content = path.read_text(encoding="utf-8")
+        # Insert 3 undated lines after ## Key Facts
+        insert = "- Undated fact A\n- Undated fact B\n- Undated fact C\n"
+        content = content.replace("## Key Facts\n", f"## Key Facts\n{insert}")
+        path.write_text(content, encoding="utf-8")
+
+        # Add 20 dated entries on top
+        for i in range(20):
+            SemanticStore.add_entry(workspace, "Key Facts", f"Dated {i}")
+
+        removed = SemanticStore.compact(workspace, max_entries_per_section=20)
+        assert removed == 3  # 23 total, 3 removed
+
+        entries = SemanticStore.read_section(workspace, "Key Facts")
+        assert len(entries) == 20
+        # Undated entries should be preserved (they're kept first)
+        assert any("Undated fact A" in e for e in entries)
+
+    def test_updates_frontmatter_date(self, workspace):
+        SemanticStore.create(workspace)
+        for i in range(25):
+            SemanticStore.add_entry(workspace, "Key Facts", f"Fact {i}")
+
+        SemanticStore.compact(workspace, max_entries_per_section=20)
+
+        path = workspace / ".agent" / "MEMORY.md"
+        content = path.read_text(encoding="utf-8")
+        assert f"updated: {date.today().isoformat()}" in content
+
+    def test_only_touches_overflowing_sections(self, workspace):
+        SemanticStore.create(workspace)
+        # Add 5 entries to Preferences (under limit) and 25 to Key Facts
+        for i in range(5):
+            SemanticStore.add_entry(workspace, "Preferences", f"Pref {i}")
+        for i in range(25):
+            SemanticStore.add_entry(workspace, "Key Facts", f"Fact {i}")
+
+        removed = SemanticStore.compact(workspace, max_entries_per_section=20)
+        assert removed == 5  # only Key Facts pruned
+
+        prefs = SemanticStore.read_section(workspace, "Preferences")
+        assert len(prefs) == 5  # Preferences untouched

--- a/packages/memory/tests/test_stores.py
+++ b/packages/memory/tests/test_stores.py
@@ -380,3 +380,19 @@ class TestSemanticStoreCompact:
 
         prefs = SemanticStore.read_section(workspace, "Preferences")
         assert len(prefs) == 5  # Preferences untouched
+
+    def test_caps_undated_entries_when_exceeding_limit(self, workspace):
+        """Regression: undated entries alone > limit must be truncated."""
+        SemanticStore.create(workspace)
+        path = workspace / ".agent" / "MEMORY.md"
+        content = path.read_text(encoding="utf-8")
+        # Insert 25 undated entries directly (no date prefix)
+        insert = "".join(f"- Undated fact {i}\n" for i in range(25))
+        content = content.replace("## Key Facts\n", f"## Key Facts\n{insert}")
+        path.write_text(content, encoding="utf-8")
+
+        removed = SemanticStore.compact(workspace, max_entries_per_section=20)
+        assert removed == 5
+
+        entries = SemanticStore.read_section(workspace, "Key Facts")
+        assert len(entries) == 20


### PR DESCRIPTION
## Summary

- **Episodic log compaction**: Old log files (>2 days) are rewritten to keep only checkpoint sections; raw turn-by-turn entries are pruned. Files with no checkpoints are deleted entirely. Called at session start (before `bootstrap_context`) and implicitly during finalization.
- **Semantic store compaction**: Sections in `MEMORY.md` are capped at 20 entries per section — newest dated entries are preserved, oldest pruned. Called during `finalize_session`.
- **Agent memory trimming**: `_trim_agent_memory` step callback registered on `ToolCallingAgent` prunes oldest `ActionStep`s beyond a 20-step limit, clearing `model_input_messages` (the largest objects) first.
- **Bootstrap context budget**: `bootstrap_context()` now accepts `max_chars=8000` (~2000 tokens). Sections are added in priority order (semantic store > profile > episodic logs). Lower-priority sections are truncated to fit.

## Test plan

- [x] 129 memory package tests passing (18 new)
- [x] 120 CLI tests passing (2 new for `_trim_agent_memory`)
- [x] Ruff check + format clean
- [x] `ty` type check passing (pre-commit hook)
- [x] Manual test: run `rag-facile learn`, have a >8 turn conversation, verify checkpoint fires and logs are written
- [ ] Manual test: run multiple sessions across days, verify old logs are compacted on next session start

👾 Generated with [Letta Code](https://letta.com)