### PR TITLE
feat: memory search — keyword + optional Albert semantic search

### DIFF
--- a/apps/cli/src/cli/commands/learn/agent.py
+++ b/apps/cli/src/cli/commands/learn/agent.py
@@ -35,6 +35,7 @@ from cli.commands.learn.tools import (
     get_recent_git_activity,
     memory_edit,
     memory_read,
+    memory_search,
     memory_write,
     run_rag_facile,
     set_available_skills,
@@ -101,6 +102,10 @@ MEMORY PROTOCOL:
 2. memory_read("MEMORY.md")  → read your curated facts
 3. Work on the user's task
 4. memory_write() or memory_edit() → save important facts proactively
+
+SEARCH BEFORE READ: When you need a specific fact but don't know which file it's in, \
+use memory_search("query") FIRST. It returns ranked snippets with file:line references \
+that you can drill into with memory_read("file:start-end").
 
 ASSUME INTERRUPTION: Your context window might be reset at any moment. \
 Record progress to memory so future sessions can pick up where you left off.
@@ -278,6 +283,7 @@ _TOOL_ICONS: dict[str, str] = {
     "get_agents_md": "📋",
     "get_recent_git_activity": "📜",
     "get_docs": "📖",
+    "memory_search": "🔍",
     "run_rag_facile": "🖥️",
 }
 
@@ -459,6 +465,7 @@ def start_chat(debug: bool = False) -> None:
             memory_read,
             memory_write,
             memory_edit,
+            memory_search,
         ]
     ] + [_wrap_activate_skill(activate_skill)]
 

--- a/apps/cli/src/cli/commands/learn/tools.py
+++ b/apps/cli/src/cli/commands/learn/tools.py
@@ -227,6 +227,7 @@ def activate_skill(name: str) -> str:
 
 from rag_facile.memory.tool import memory_edit  # noqa: E402, F401
 from rag_facile.memory.tool import memory_read  # noqa: E402, F401
+from rag_facile.memory.tool import memory_search  # noqa: E402, F401
 from rag_facile.memory.tool import memory_write  # noqa: E402, F401
 from rag_facile.memory.tool import set_workspace_root as _set_memory_workspace  # noqa: E402, F401
 

--- a/packages/memory/src/rag_facile/memory/albert_search.py
+++ b/packages/memory/src/rag_facile/memory/albert_search.py
@@ -1,0 +1,245 @@
+"""Optional Albert-backed semantic search for agent memory.
+
+Uploads ``.agent/*.md`` files to a private Albert collection and uses the
+``/search`` endpoint for semantic retrieval.  Falls back gracefully when
+the ``albert`` package isn't installed or credentials are missing.
+
+**Incremental indexing**: tracks file modification times in
+``.agent/.search-state.json`` so only changed files are re-uploaded.
+
+This module is never imported directly by the memory package's core code.
+The ``memory_search`` tool in ``tool.py`` conditionally imports it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from rag_facile.memory._paths import AGENT_DIR
+from rag_facile.memory.search import SearchResult
+
+logger = logging.getLogger(__name__)
+
+_STATE_FILE = ".search-state.json"
+_COLLECTION_PREFIX = "rag-facile-memory"
+
+
+class AlbertMemoryIndex:
+    """Sync ``.agent/`` files to an Albert collection for semantic search.
+
+    Parameters
+    ----------
+    api_key:
+        Albert API key (``OPENAI_API_KEY`` or ``ALBERT_API_KEY``).
+    api_base:
+        Albert API base URL.
+    """
+
+    def __init__(self, api_key: str, api_base: str) -> None:
+        self._api_key = api_key
+        self._api_base = api_base
+        self._collection_id: int | None = None
+        self._synced = False
+
+    # ── Public API ────────────────────────────────────────────────────────────
+
+    def sync(self, workspace: Path) -> None:
+        """Upload new or changed ``.md`` files to the Albert collection.
+
+        Reads the state file to determine which files have changed since the
+        last sync.  Creates the collection on first call.
+        """
+        try:
+            from albert import AlbertClient
+        except ImportError:
+            logger.debug("albert package not installed — skipping semantic sync")
+            return
+
+        agent_dir = workspace / AGENT_DIR
+        if not agent_dir.exists():
+            return
+
+        state = self._load_state(agent_dir)
+        self._collection_id = state.get("collection_id")
+
+        client = AlbertClient(api_key=self._api_key, base_url=self._api_base)
+
+        # Create collection on first sync
+        if self._collection_id is None:
+            import time
+
+            name = f"{_COLLECTION_PREFIX}-{time.time_ns()}"
+            collection = client.create_collection(name, visibility="private")
+            self._collection_id = collection.id
+            logger.info("Created memory collection: %s (id=%d)", name, collection.id)
+
+        # Find changed files
+        stored_mtimes: dict[str, float] = state.get("files", {})
+        current_files = self._discover_md_files(agent_dir)
+        changed: list[tuple[str, Path]] = []
+
+        for rel_path, abs_path in current_files:
+            mtime = abs_path.stat().st_mtime_ns
+            if stored_mtimes.get(rel_path) != mtime:
+                changed.append((rel_path, abs_path))
+                stored_mtimes[rel_path] = mtime
+
+        if not changed:
+            logger.debug("No memory files changed since last sync")
+            self._synced = True
+            return
+
+        # Upload changed files
+        for rel_path, abs_path in changed:
+            try:
+                # Albert requires supported file types. Markdown is supported.
+                # Upload directly if .md; otherwise convert to temp .md file.
+                client.upload_document(
+                    abs_path,
+                    self._collection_id,
+                    chunk_size=512,
+                    chunk_overlap=50,
+                    preset_separators="markdown",
+                )
+                logger.info("Uploaded memory file: %s", rel_path)
+            except Exception:  # noqa: BLE001 — sync must not crash the chat
+                logger.warning("Failed to upload %s — skipping", rel_path)
+                # Don't update mtime so we retry next time
+                stored_mtimes.pop(rel_path, None)
+
+        # Save state
+        self._save_state(agent_dir, stored_mtimes)
+        self._synced = True
+
+    def search(
+        self,
+        query: str,
+        workspace: Path,
+        *,
+        limit: int = 8,
+    ) -> list[SearchResult]:
+        """Semantic search across memory files via Albert API.
+
+        Syncs lazily on first search if not already synced.
+
+        Returns
+        -------
+        list[SearchResult]
+            Results with file path inferred from chunk metadata.
+        """
+        if not self._synced:
+            self.sync(workspace)
+
+        if self._collection_id is None:
+            return []
+
+        try:
+            from albert import AlbertClient
+        except ImportError:
+            return []
+
+        client = AlbertClient(api_key=self._api_key, base_url=self._api_base)
+
+        try:
+            response = client.search(
+                prompt=query,
+                collections=[self._collection_id],
+                limit=limit,
+                method="semantic",
+            )
+        except Exception:  # noqa: BLE001 — search must not crash the chat
+            logger.warning("Albert memory search failed — falling back to keyword only")
+            return []
+
+        results: list[SearchResult] = []
+        for hit in response.data:
+            chunk = hit.chunk
+            # Try to infer file path from metadata
+            file_path = "unknown"
+            if chunk.metadata and isinstance(chunk.metadata, dict):
+                file_path = chunk.metadata.get("source", "unknown")
+
+            # Extract snippet from chunk content
+            snippet_lines = chunk.content.strip().splitlines()
+            snippet = "\n".join(snippet_lines[:5])
+
+            results.append(
+                SearchResult(
+                    file=file_path,
+                    line_start=1,  # Albert doesn't provide line numbers
+                    line_end=len(snippet_lines),
+                    snippet=snippet,
+                    score=round(hit.score, 4),
+                )
+            )
+
+        return results
+
+    # ── State persistence ─────────────────────────────────────────────────────
+
+    def _load_state(self, agent_dir: Path) -> dict:
+        """Load the sync state from ``.agent/.search-state.json``."""
+        state_file = agent_dir / _STATE_FILE
+        if not state_file.exists():
+            return {}
+        try:
+            return json.loads(state_file.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return {}
+
+    def _save_state(self, agent_dir: Path, file_mtimes: dict[str, float]) -> None:
+        """Save the sync state to ``.agent/.search-state.json``."""
+        state = {
+            "collection_id": self._collection_id,
+            "files": file_mtimes,
+        }
+        state_file = agent_dir / _STATE_FILE
+        state_file.write_text(json.dumps(state, indent=2), encoding="utf-8")
+
+    # ── File discovery ────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _discover_md_files(agent_dir: Path) -> list[tuple[str, Path]]:
+        """Return ``(relative_path, absolute_path)`` for all ``.md`` files."""
+        results: list[tuple[str, Path]] = []
+        for md_file in sorted(agent_dir.rglob("*.md")):
+            rel = str(md_file.relative_to(agent_dir))
+            results.append((rel, md_file))
+        return results
+
+
+# ── RRF fusion ────────────────────────────────────────────────────────────────
+
+
+def fuse_search_results(
+    keyword_results: list[SearchResult],
+    semantic_results: list[SearchResult],
+    *,
+    k: int = 60,
+    limit: int = 8,
+) -> list[SearchResult]:
+    """Merge keyword and semantic results via Reciprocal Rank Fusion.
+
+    Dedup key: ``(file, line_start)``.  The snippet from the first-seen
+    result is kept.
+    """
+    rrf_scores: dict[tuple[str, int], float] = {}
+    best: dict[tuple[str, int], SearchResult] = {}
+
+    for result_list in (keyword_results, semantic_results):
+        for rank, result in enumerate(result_list):
+            key = (result["file"], result["line_start"])
+            score = 1.0 / (k + rank + 1)
+            rrf_scores[key] = rrf_scores.get(key, 0.0) + score
+            if key not in best:
+                best[key] = result
+
+    fused: list[SearchResult] = []
+    for key, rrf_score in sorted(rrf_scores.items(), key=lambda x: x[1], reverse=True):
+        entry = best[key].copy()
+        entry["score"] = round(rrf_score, 4)
+        fused.append(entry)
+
+    return fused[:limit]

--- a/packages/memory/src/rag_facile/memory/search.py
+++ b/packages/memory/src/rag_facile/memory/search.py
@@ -19,7 +19,7 @@ Scoring
 from __future__ import annotations
 
 import re
-from datetime import date
+from datetime import date, datetime
 from pathlib import Path
 from typing import TypedDict
 
@@ -169,8 +169,6 @@ def _recency_multiplier(file_path: Path) -> float:
         # Fall back to mtime
         try:
             mtime = file_path.stat().st_mtime
-            from datetime import datetime
-
             file_date = datetime.fromtimestamp(mtime).date()  # noqa: DTZ006
         except OSError:
             return 1.0

--- a/packages/memory/src/rag_facile/memory/search.py
+++ b/packages/memory/src/rag_facile/memory/search.py
@@ -1,0 +1,264 @@
+"""Local keyword search across the ``.agent/`` memory directory.
+
+Zero external dependencies — uses only stdlib (``re``, ``pathlib``,
+``datetime``).  The search is designed for the "Search then Get" pattern:
+results include file paths with line ranges so the agent can drill in
+with ``memory_read(path:start-end)``.
+
+Scoring
+-------
+1. Tokenize the query into significant words (≥3 chars, no stopwords).
+2. Walk all ``.md`` files under ``.agent/``.
+3. For each line, count how many query words appear (word-boundary match).
+4. Bonuses: ``## `` header lines ×2, ``MEMORY.md`` ×1.5.
+5. Group consecutive matching lines into snippets (max 5 lines).
+6. Recency boost: newer files score higher.
+7. Sort by score, return top *max_results*.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date
+from pathlib import Path
+from typing import TypedDict
+
+from rag_facile.memory._paths import AGENT_DIR
+
+# ── Result type ───────────────────────────────────────────────────────────────
+
+
+class SearchResult(TypedDict):
+    """A single search hit with file location and snippet."""
+
+    file: str  # relative to .agent/, e.g. "sessions/2026-03-01-setup.md"
+    line_start: int  # 1-indexed
+    line_end: int  # 1-indexed, inclusive
+    snippet: str  # the matching lines with a small context window
+    score: float
+
+
+# ── Stopwords ─────────────────────────────────────────────────────────────────
+
+_STOPWORDS = frozenset(
+    "le la les un une des de du au aux et ou en à par pour dans sur "
+    "avec est ce cette que qui ne pas se son sa ses leur mon ma mes "
+    "the a an and or in on at to for with is are was were of from by not".split()
+)
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+
+def keyword_search(
+    workspace: Path,
+    query: str,
+    *,
+    max_results: int = 10,
+    context_lines: int = 2,
+) -> list[SearchResult]:
+    """Search all ``.md`` files under ``.agent/`` for *query* terms.
+
+    Parameters
+    ----------
+    workspace:
+        Root directory containing ``.agent/``.
+    query:
+        Free-text search query.
+    max_results:
+        Maximum number of snippets to return.
+    context_lines:
+        Number of lines of context above/below each matching line.
+
+    Returns
+    -------
+    list[SearchResult]
+        Snippets sorted by descending score.
+    """
+    agent_dir = workspace / AGENT_DIR
+    if not agent_dir.exists():
+        return []
+
+    words = _tokenize(query)
+    if not words:
+        return []
+
+    # Build regex patterns for each query word (word-boundary match)
+    patterns = [re.compile(rf"\b{re.escape(w)}\b", re.IGNORECASE) for w in words]
+
+    results: list[SearchResult] = []
+
+    for md_file in _iter_md_files(agent_dir):
+        rel_path = str(md_file.relative_to(agent_dir))
+        lines = md_file.read_text(encoding="utf-8").splitlines()
+
+        # Score each line
+        line_scores: list[tuple[int, float]] = []  # (0-indexed line num, score)
+        for i, line in enumerate(lines):
+            score = _score_line(line, patterns)
+            if score > 0:
+                # Header bonus
+                if line.strip().startswith("## "):
+                    score *= 2.0
+                # MEMORY.md priority
+                if rel_path == "MEMORY.md":
+                    score *= 1.5
+                line_scores.append((i, score))
+
+        if not line_scores:
+            continue
+
+        # Recency boost
+        recency = _recency_multiplier(md_file)
+
+        # Group into snippets
+        snippets = _group_into_snippets(line_scores, lines, context_lines=context_lines)
+
+        for snippet_start, snippet_end, snippet_score, snippet_text in snippets:
+            results.append(
+                SearchResult(
+                    file=rel_path,
+                    line_start=snippet_start + 1,  # 1-indexed
+                    line_end=snippet_end + 1,
+                    snippet=snippet_text,
+                    score=round(snippet_score * recency, 4),
+                )
+            )
+
+    # Sort by score descending, then by file name for stability
+    results.sort(key=lambda r: (-r["score"], r["file"]))
+    return results[:max_results]
+
+
+# ── Internals ─────────────────────────────────────────────────────────────────
+
+
+def _tokenize(query: str) -> list[str]:
+    """Extract significant words from *query* (≥3 chars, no stopwords)."""
+    return [w for w in re.findall(r"\b\w{3,}\b", query.lower()) if w not in _STOPWORDS]
+
+
+def _iter_md_files(agent_dir: Path) -> list[Path]:
+    """Return all ``.md`` files under *agent_dir*, recursively."""
+    return sorted(agent_dir.rglob("*.md"))
+
+
+def _score_line(line: str, patterns: list[re.Pattern[str]]) -> float:
+    """Return the number of distinct query words found in *line*."""
+    return sum(1.0 for p in patterns if p.search(line))
+
+
+def _recency_multiplier(file_path: Path) -> float:
+    """Return a multiplier ≥1.0 that boosts recent files.
+
+    Extracts date from filename (``YYYY-MM-DD*.md``) or falls back to
+    file modification time.  Files from today get 1.3×, yesterday 1.2×,
+    older files 1.0×.
+    """
+    # Try to extract date from filename (e.g. "2026-03-01.md" or "2026-03-01-1430-topic.md")
+    match = re.match(r"(\d{4}-\d{2}-\d{2})", file_path.name)
+    if match:
+        try:
+            file_date = date.fromisoformat(match.group(1))
+        except ValueError:
+            file_date = None
+    else:
+        file_date = None
+
+    if file_date is None:
+        # Fall back to mtime
+        try:
+            mtime = file_path.stat().st_mtime
+            from datetime import datetime
+
+            file_date = datetime.fromtimestamp(mtime).date()  # noqa: DTZ006
+        except OSError:
+            return 1.0
+
+    today = date.today()
+    days_ago = (today - file_date).days
+
+    if days_ago <= 0:
+        return 1.3
+    if days_ago <= 1:
+        return 1.2
+    if days_ago <= 7:
+        return 1.1
+    return 1.0
+
+
+def _group_into_snippets(
+    line_scores: list[tuple[int, float]],
+    all_lines: list[str],
+    *,
+    context_lines: int = 2,
+    max_snippet_lines: int = 7,
+) -> list[tuple[int, int, float, str]]:
+    """Group scored lines into contiguous snippets.
+
+    Returns
+    -------
+    list of (start_idx, end_idx, total_score, text)
+        Indices are 0-based.
+    """
+    if not line_scores:
+        return []
+
+    # Sort by line number
+    line_scores.sort(key=lambda x: x[0])
+    total_lines = len(all_lines)
+
+    snippets: list[tuple[int, int, float, str]] = []
+    current_start = max(0, line_scores[0][0] - context_lines)
+    current_end = min(total_lines - 1, line_scores[0][0] + context_lines)
+    current_score = line_scores[0][1]
+
+    for line_idx, score in line_scores[1:]:
+        expanded_start = max(0, line_idx - context_lines)
+        expanded_end = min(total_lines - 1, line_idx + context_lines)
+
+        # If this line's context overlaps with current snippet, merge
+        if expanded_start <= current_end + 1:
+            current_end = max(current_end, expanded_end)
+            current_score += score
+        else:
+            # Emit current snippet
+            _emit_snippet(
+                snippets,
+                current_start,
+                current_end,
+                current_score,
+                all_lines,
+                max_snippet_lines,
+            )
+            current_start = expanded_start
+            current_end = expanded_end
+            current_score = score
+
+    # Emit last snippet
+    _emit_snippet(
+        snippets,
+        current_start,
+        current_end,
+        current_score,
+        all_lines,
+        max_snippet_lines,
+    )
+
+    return snippets
+
+
+def _emit_snippet(
+    snippets: list[tuple[int, int, float, str]],
+    start: int,
+    end: int,
+    score: float,
+    all_lines: list[str],
+    max_lines: int,
+) -> None:
+    """Build and append a snippet to *snippets*."""
+    # Cap snippet length
+    if end - start + 1 > max_lines:
+        end = start + max_lines - 1
+    text = "\n".join(all_lines[start : end + 1])
+    snippets.append((start, end, score, text))

--- a/packages/memory/src/rag_facile/memory/tool.py
+++ b/packages/memory/src/rag_facile/memory/tool.py
@@ -5,29 +5,58 @@ Four ``@tool``-decorated functions scoped to the ``.agent/`` directory:
 - ``memory_read``   — list a directory or read a file (with optional line range)
 - ``memory_write``  — create or overwrite a file
 - ``memory_edit``   — find-and-replace in a file
-- ``memory_search`` — keyword search across all memory files
+- ``memory_search`` — keyword + optional Albert semantic search across all memory files
 
 All paths are validated to stay within ``.agent/`` (path traversal protection).
 """
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from smolagents import tool
 
 from rag_facile.memory._paths import AGENT_DIR
+
+if TYPE_CHECKING:
+    from rag_facile.memory.albert_search import AlbertMemoryIndex
 
 # ── Module-level workspace reference ──────────────────────────────────────────
 # Set once at session start by the agent harness.
 
 _workspace_root: Path | None = None
 
+# ── Albert index singleton ────────────────────────────────────────────────────
+# Created lazily on first search call when API credentials are available.
+# Reset whenever set_workspace_root() is called with a new path so the index
+# doesn't retain stale collection IDs across tests or workspace changes.
+
+_albert_index: AlbertMemoryIndex | None = None
+
 
 def set_workspace_root(root: Path | None) -> None:
     """Register the workspace root so memory tools can locate ``.agent/``."""
-    global _workspace_root  # noqa: PLW0603
+    global _workspace_root, _albert_index  # noqa: PLW0603
     _workspace_root = root
+    _albert_index = None  # reset when workspace changes so index is re-created
+
+
+def _get_albert_index() -> AlbertMemoryIndex | None:
+    """Return the Albert index singleton, or ``None`` if credentials are absent."""
+    global _albert_index  # noqa: PLW0603
+    api_key = os.environ.get("OPENAI_API_KEY") or os.environ.get("ALBERT_API_KEY", "")
+    if not api_key:
+        return None
+    if _albert_index is None:
+        from rag_facile.memory.albert_search import AlbertMemoryIndex as _Index
+
+        api_base = os.environ.get(
+            "OPENAI_BASE_URL", "https://albert.api.etalab.gouv.fr/v1"
+        )
+        _albert_index = _Index(api_key=api_key, api_base=api_base)
+    return _albert_index
 
 
 # ── Path safety ───────────────────────────────────────────────────────────────
@@ -268,8 +297,13 @@ def memory_edit(path: str, old_str: str, new_str: str) -> str:
 def memory_search(query: str) -> str:
     """Search across all memory files for relevant information.
 
-    Uses keyword matching to find snippets in MEMORY.md, daily logs, and
-    session archives.  Results include file paths with line ranges — use
+    Runs a local keyword search over all ``.agent/*.md`` files and, when
+    Albert API credentials are available, also performs a semantic vector
+    search against a private Albert collection.  Results from both layers
+    are merged with Reciprocal Rank Fusion so the most relevant snippets
+    surface at the top regardless of which layer found them.
+
+    Results include file paths with line ranges — use
     memory_read(path:start-end) to read more context.
 
     Use this BEFORE memory_read when you need to find information but don't
@@ -282,9 +316,17 @@ def memory_search(query: str) -> str:
     if _workspace_root is None:
         return "No workspace detected — memory unavailable."
 
+    from rag_facile.memory.albert_search import fuse_search_results
     from rag_facile.memory.search import keyword_search
 
-    results = keyword_search(_workspace_root, query, max_results=8)
+    kw_results = keyword_search(_workspace_root, query, max_results=8)
+
+    albert_index = _get_albert_index()
+    if albert_index is not None:
+        sem_results = albert_index.search(query, _workspace_root, limit=8)
+        results = fuse_search_results(kw_results, sem_results, limit=8)
+    else:
+        results = kw_results
 
     if not results:
         return f'No results found for "{query}".'

--- a/packages/memory/src/rag_facile/memory/tool.py
+++ b/packages/memory/src/rag_facile/memory/tool.py
@@ -1,10 +1,11 @@
-"""Standard file-operation tools for agent memory (Read / Write / Edit).
+"""Standard file-operation tools for agent memory (Read / Write / Edit / Search).
 
-Three ``@tool``-decorated functions scoped to the ``.agent/`` directory:
+Four ``@tool``-decorated functions scoped to the ``.agent/`` directory:
 
-- ``memory_read``  — list a directory or read a file (with optional line range)
-- ``memory_write`` — create or overwrite a file
-- ``memory_edit``  — find-and-replace in a file
+- ``memory_read``   — list a directory or read a file (with optional line range)
+- ``memory_write``  — create or overwrite a file
+- ``memory_edit``   — find-and-replace in a file
+- ``memory_search`` — keyword search across all memory files
 
 All paths are validated to stay within ``.agent/`` (path traversal protection).
 """
@@ -261,3 +262,43 @@ def memory_edit(path: str, old_str: str, new_str: str) -> str:
     new_content = content.replace(old_str, new_str, 1)
     resolved.write_text(new_content, encoding="utf-8")
     return f"Edited .agent/{path}: replaced 1 occurrence."
+
+
+@tool
+def memory_search(query: str) -> str:
+    """Search across all memory files for relevant information.
+
+    Uses keyword matching to find snippets in MEMORY.md, daily logs, and
+    session archives.  Results include file paths with line ranges — use
+    memory_read(path:start-end) to read more context.
+
+    Use this BEFORE memory_read when you need to find information but don't
+    know which file contains it.
+
+    Args:
+        query: Natural language search query, e.g. "deployment config",
+               "Albert API rate limit", "user preferences".
+    """
+    if _workspace_root is None:
+        return "No workspace detected — memory unavailable."
+
+    from rag_facile.memory.search import keyword_search
+
+    results = keyword_search(_workspace_root, query, max_results=8)
+
+    if not results:
+        return f'No results found for "{query}".'
+
+    lines: list[str] = [f'Found {len(results)} result(s) for "{query}":\n']
+    for i, r in enumerate(results, 1):
+        path_ref = f"{r['file']}:{r['line_start']}-{r['line_end']}"
+        lines.append(f"{i}. [{r['score']:.2f}] {path_ref}")
+        # Indent snippet lines with >
+        for snippet_line in r["snippet"].splitlines()[:4]:
+            lines.append(f"   > {snippet_line}")
+        lines.append("")
+
+    lines.append(
+        'Use memory_read("file:start-end") to read more context from any result.'
+    )
+    return "\n".join(lines)

--- a/packages/memory/tests/test_albert_search.py
+++ b/packages/memory/tests/test_albert_search.py
@@ -1,0 +1,280 @@
+"""Tests for the optional Albert-backed semantic search.
+
+All Albert API calls are mocked — no network access required.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rag_facile.memory.albert_search import (
+    AlbertMemoryIndex,
+    fuse_search_results,
+)
+from rag_facile.memory.search import SearchResult
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def workspace(tmp_path: Path) -> Path:
+    """Create a workspace with sample .agent/ files."""
+    agent = tmp_path / ".agent"
+    agent.mkdir()
+    (agent / "MEMORY.md").write_text(
+        "## Key Facts\n- Albert API rate limit is 10 req/min\n",
+        encoding="utf-8",
+    )
+    logs = agent / "logs"
+    logs.mkdir()
+    (logs / "2026-03-01.md").write_text(
+        "## 14:30\nDiscussed deployment config\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def _make_mock_client(collection_id: int = 42):
+    """Create a mock AlbertClient with create_collection, upload_document, search."""
+    mock_client = MagicMock()
+
+    # create_collection
+    mock_collection = MagicMock()
+    mock_collection.id = collection_id
+    mock_client.create_collection.return_value = mock_collection
+
+    # upload_document
+    mock_client.upload_document.return_value = MagicMock()
+
+    return mock_client
+
+
+def _make_mock_search_response(hits: list[dict]):
+    """Create a mock SearchResponse with given hits."""
+    response = MagicMock()
+    data = []
+    for h in hits:
+        hit = MagicMock()
+        hit.score = h["score"]
+        hit.chunk = MagicMock()
+        hit.chunk.content = h["content"]
+        hit.chunk.metadata = h.get("metadata", {})
+        data.append(hit)
+    response.data = data
+    return response
+
+
+# ── AlbertMemoryIndex tests ───────────────────────────────────────────────────
+
+
+class TestSync:
+    @patch("albert.AlbertClient")
+    def test_creates_collection_on_first_sync(self, mock_cls, workspace: Path) -> None:
+        mock_client = _make_mock_client(collection_id=99)
+        mock_cls.return_value = mock_client
+
+        index = AlbertMemoryIndex(api_key="test-key", api_base="https://api.test")
+        index.sync(workspace)
+
+        mock_client.create_collection.assert_called_once()
+        assert index._collection_id == 99
+
+    @patch("albert.AlbertClient")
+    def test_uploads_md_files(self, mock_cls, workspace: Path) -> None:
+        mock_client = _make_mock_client()
+        mock_cls.return_value = mock_client
+
+        index = AlbertMemoryIndex(api_key="test-key", api_base="https://api.test")
+        index.sync(workspace)
+
+        # Should upload MEMORY.md and logs/2026-03-01.md
+        assert mock_client.upload_document.call_count == 2
+
+    @patch("albert.AlbertClient")
+    def test_incremental_sync(self, mock_cls, workspace: Path) -> None:
+        """Second sync with no changes should skip uploads."""
+        mock_client = _make_mock_client()
+        mock_cls.return_value = mock_client
+
+        index = AlbertMemoryIndex(api_key="test-key", api_base="https://api.test")
+        index.sync(workspace)
+
+        # Reset mock and sync again — no changes
+        mock_client.upload_document.reset_mock()
+        index._synced = False  # force re-sync
+        index.sync(workspace)
+
+        assert mock_client.upload_document.call_count == 0
+
+    @patch("albert.AlbertClient")
+    def test_resyncs_changed_files(self, mock_cls, workspace: Path) -> None:
+        """Files modified after first sync should be re-uploaded."""
+        mock_client = _make_mock_client()
+        mock_cls.return_value = mock_client
+
+        index = AlbertMemoryIndex(api_key="test-key", api_base="https://api.test")
+        index.sync(workspace)
+
+        # Modify MEMORY.md
+        memory = workspace / ".agent" / "MEMORY.md"
+        memory.write_text("## Updated\n- New fact\n", encoding="utf-8")
+
+        # Force re-sync
+        mock_client.upload_document.reset_mock()
+        index._synced = False
+        index.sync(workspace)
+
+        # Only the changed file should be uploaded
+        assert mock_client.upload_document.call_count == 1
+
+    @patch("albert.AlbertClient")
+    def test_saves_state_file(self, mock_cls, workspace: Path) -> None:
+        mock_client = _make_mock_client(collection_id=42)
+        mock_cls.return_value = mock_client
+
+        index = AlbertMemoryIndex(api_key="test-key", api_base="https://api.test")
+        index.sync(workspace)
+
+        state_file = workspace / ".agent" / ".search-state.json"
+        assert state_file.exists()
+        state = json.loads(state_file.read_text())
+        assert state["collection_id"] == 42
+        assert "files" in state
+
+    def test_missing_albert_package(self, workspace: Path) -> None:
+        """Should gracefully skip when albert isn't installed."""
+        index = AlbertMemoryIndex(api_key="test-key", api_base="https://api.test")
+        with patch.dict("sys.modules", {"albert": None}):
+            # This should not raise
+            index.sync(workspace)
+        assert not index._synced
+
+    def test_no_agent_dir(self, tmp_path: Path) -> None:
+        """Should do nothing if .agent/ doesn't exist."""
+        index = AlbertMemoryIndex(api_key="test-key", api_base="https://api.test")
+        index.sync(tmp_path)
+        assert not index._synced
+
+
+class TestSearch:
+    @patch("albert.AlbertClient")
+    def test_returns_results(self, mock_cls, workspace: Path) -> None:
+        mock_client = _make_mock_client()
+        mock_cls.return_value = mock_client
+
+        # Set up search response
+        mock_client.search.return_value = _make_mock_search_response(
+            [
+                {
+                    "score": 0.95,
+                    "content": "Albert API rate limit is 10 req/min",
+                    "metadata": {"source": "MEMORY.md"},
+                },
+                {
+                    "score": 0.82,
+                    "content": "Discussed deployment config\nWith production settings",
+                    "metadata": {"source": "logs/2026-03-01.md"},
+                },
+            ]
+        )
+
+        index = AlbertMemoryIndex(api_key="test-key", api_base="https://api.test")
+        # Pre-set collection to avoid sync
+        index._collection_id = 42
+        index._synced = True
+
+        results = index.search("Albert API", workspace)
+        assert len(results) == 2
+        assert results[0]["score"] == 0.95
+        assert results[0]["file"] == "MEMORY.md"
+
+    @patch("albert.AlbertClient")
+    def test_no_collection_returns_empty(self, mock_cls, workspace: Path) -> None:
+        index = AlbertMemoryIndex(api_key="test-key", api_base="https://api.test")
+        index._synced = True  # skip sync
+        index._collection_id = None
+
+        results = index.search("anything", workspace)
+        assert results == []
+
+    @patch("albert.AlbertClient")
+    def test_api_error_returns_empty(self, mock_cls, workspace: Path) -> None:
+        mock_client = _make_mock_client()
+        mock_cls.return_value = mock_client
+        mock_client.search.side_effect = RuntimeError("API error")
+
+        index = AlbertMemoryIndex(api_key="test-key", api_base="https://api.test")
+        index._collection_id = 42
+        index._synced = True
+
+        results = index.search("anything", workspace)
+        assert results == []
+
+
+# ── RRF fusion tests ──────────────────────────────────────────────────────────
+
+
+class TestFuseSearchResults:
+    def test_fuses_two_lists(self) -> None:
+        kw = [
+            SearchResult(
+                file="MEMORY.md", line_start=1, line_end=2, snippet="fact A", score=1.0
+            ),
+            SearchResult(
+                file="logs/a.md", line_start=5, line_end=7, snippet="fact B", score=0.5
+            ),
+        ]
+        sem = [
+            SearchResult(
+                file="logs/a.md", line_start=5, line_end=7, snippet="fact B", score=0.9
+            ),
+            SearchResult(
+                file="sessions/s.md",
+                line_start=1,
+                line_end=3,
+                snippet="fact C",
+                score=0.8,
+            ),
+        ]
+        fused = fuse_search_results(kw, sem, limit=10)
+        # logs/a.md should get double RRF boost (appears in both lists)
+        files = [r["file"] for r in fused]
+        assert "logs/a.md" in files
+        assert len(fused) == 3
+
+    def test_dedup_by_file_and_line(self) -> None:
+        kw = [
+            SearchResult(
+                file="MEMORY.md", line_start=1, line_end=2, snippet="same", score=1.0
+            ),
+        ]
+        sem = [
+            SearchResult(
+                file="MEMORY.md", line_start=1, line_end=2, snippet="same", score=0.9
+            ),
+        ]
+        fused = fuse_search_results(kw, sem)
+        # Should be deduped to one result
+        assert len(fused) == 1
+
+    def test_limit_respected(self) -> None:
+        kw = [
+            SearchResult(
+                file=f"file{i}.md",
+                line_start=1,
+                line_end=1,
+                snippet=f"fact {i}",
+                score=1.0,
+            )
+            for i in range(10)
+        ]
+        fused = fuse_search_results(kw, [], limit=3)
+        assert len(fused) == 3
+
+    def test_empty_inputs(self) -> None:
+        assert fuse_search_results([], []) == []

--- a/packages/memory/tests/test_search.py
+++ b/packages/memory/tests/test_search.py
@@ -1,0 +1,300 @@
+"""Tests for the local keyword search engine."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+import re
+
+from rag_facile.memory.search import (
+    _group_into_snippets,
+    _recency_multiplier,
+    _score_line,
+    _tokenize,
+    keyword_search,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def workspace(tmp_path: Path) -> Path:
+    """Create a workspace with .agent/ directory and sample files."""
+    agent = tmp_path / ".agent"
+    agent.mkdir()
+
+    # MEMORY.md — semantic store
+    (agent / "MEMORY.md").write_text(
+        "---\nupdated: 2026-03-02\n---\n\n"
+        "# Agent Memory\n\n"
+        "## User Identity\n"
+        "- Name: Luis\n"
+        "- Role: Developer at DINUM\n\n"
+        "## Preferences\n"
+        "- Prefers French language for UI\n"
+        "- Uses Albert API for embeddings\n\n"
+        "## Project State\n"
+        "- [2026-03-01] Preset changed to accurate\n"
+        "- [2026-03-02] Pipeline uses query expansion\n\n"
+        "## Key Facts\n"
+        "- Albert API rate limit is 10 requests per minute\n"
+        "- Collection 785 contains service-public documents\n",
+        encoding="utf-8",
+    )
+
+    # Daily log
+    logs = agent / "logs"
+    logs.mkdir()
+    (logs / "2026-03-02.md").write_text(
+        "# 2026-03-02\n\n"
+        "## 14:30 — Vous\n"
+        "How do I configure query expansion?\n\n"
+        "## 14:31 — Assistant\n"
+        "Query expansion uses the multi_query strategy.\n"
+        "You can enable it in the accurate preset.\n",
+        encoding="utf-8",
+    )
+    (logs / "2026-02-28.md").write_text(
+        "# 2026-02-28\n\n"
+        "## 10:00 — Vous\n"
+        "What is the Albert API rate limit?\n\n"
+        "## 10:01 — Assistant\n"
+        "The Albert API allows 10 requests per minute.\n",
+        encoding="utf-8",
+    )
+
+    # Session snapshot
+    sessions = agent / "sessions"
+    sessions.mkdir()
+    (sessions / "2026-03-01-1430-deployment-config.md").write_text(
+        "---\ndate: 2026-03-01\nsummary: deployment config\n---\n\n"
+        "# Session: deployment config\n\n"
+        "## Vous\n"
+        "I need help with deployment configuration for production.\n\n"
+        "## Assistant\n"
+        "For production deployment, you should set temperature to 0.1\n"
+        "and increase top_k to 15 for better recall.\n",
+        encoding="utf-8",
+    )
+
+    return tmp_path
+
+
+# ── Tokenizer tests ───────────────────────────────────────────────────────────
+
+
+class TestTokenize:
+    def test_extracts_significant_words(self) -> None:
+        assert _tokenize("query expansion configuration") == [
+            "query",
+            "expansion",
+            "configuration",
+        ]
+
+    def test_filters_stopwords(self) -> None:
+        result = _tokenize("the query for expansion and configuration")
+        assert "the" not in result
+        assert "for" not in result
+        assert "and" not in result
+        assert "query" in result
+
+    def test_filters_short_words(self) -> None:
+        result = _tokenize("a is ok but longer words stay")
+        assert "ok" not in result
+        assert "is" not in result
+        assert "longer" in result
+        assert "words" in result
+
+    def test_empty_query(self) -> None:
+        assert _tokenize("") == []
+        assert _tokenize("the and or") == []
+
+    def test_lowercase(self) -> None:
+        assert _tokenize("Albert API") == ["albert", "api"]
+
+
+# ── Line scoring tests ────────────────────────────────────────────────────────
+
+
+class TestScoreLine:
+    def _patterns(self, *words: str) -> list[re.Pattern[str]]:
+        return [re.compile(rf"\b{re.escape(w)}\b", re.IGNORECASE) for w in words]
+
+    def test_single_word_match(self) -> None:
+        patterns = self._patterns("albert")
+        assert _score_line("The Albert API is great", patterns) == 1.0
+
+    def test_multiple_word_match(self) -> None:
+        patterns = self._patterns("albert", "api")
+        assert _score_line("The Albert API is great", patterns) == 2.0
+
+    def test_no_match(self) -> None:
+        patterns = self._patterns("deployment")
+        assert _score_line("The Albert API is great", patterns) == 0.0
+
+    def test_case_insensitive(self) -> None:
+        patterns = self._patterns("albert")
+        assert _score_line("ALBERT is a service", patterns) == 1.0
+
+
+# ── Recency multiplier tests ─────────────────────────────────────────────────
+
+
+class TestRecencyMultiplier:
+    def test_today_file(self, tmp_path: Path) -> None:
+        today = date.today().isoformat()
+        f = tmp_path / f"{today}.md"
+        f.write_text("test")
+        assert _recency_multiplier(f) == 1.3
+
+    def test_old_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "2024-01-01.md"
+        f.write_text("test")
+        assert _recency_multiplier(f) == 1.0
+
+    def test_no_date_in_filename(self, tmp_path: Path) -> None:
+        f = tmp_path / "MEMORY.md"
+        f.write_text("test")
+        # Falls back to mtime — file just created, so should be today
+        assert _recency_multiplier(f) >= 1.2
+
+
+# ── Snippet grouping tests ───────────────────────────────────────────────────
+
+
+class TestGroupIntoSnippets:
+    def test_single_match(self) -> None:
+        lines = ["line 0", "line 1", "match here", "line 3", "line 4"]
+        scored = [(2, 1.0)]
+        snippets = _group_into_snippets(scored, lines, context_lines=1)
+        assert len(snippets) == 1
+        start, end, score, text = snippets[0]
+        assert start == 1  # context_lines=1 → one line before
+        assert end == 3  # one line after
+        assert score == 1.0
+        assert "match here" in text
+
+    def test_adjacent_matches_merged(self) -> None:
+        lines = [f"line {i}" for i in range(10)]
+        scored = [(2, 1.0), (4, 1.5)]  # close enough to merge with context=2
+        snippets = _group_into_snippets(scored, lines, context_lines=2)
+        assert len(snippets) == 1
+        assert snippets[0][2] == 2.5  # scores combined
+
+    def test_distant_matches_separate(self) -> None:
+        lines = [f"line {i}" for i in range(20)]
+        scored = [(2, 1.0), (15, 1.5)]
+        snippets = _group_into_snippets(scored, lines, context_lines=1)
+        assert len(snippets) == 2
+
+    def test_empty_scores(self) -> None:
+        assert _group_into_snippets([], ["a", "b"]) == []
+
+
+# ── Integration tests ─────────────────────────────────────────────────────────
+
+
+class TestKeywordSearch:
+    def test_finds_in_memory_md(self, workspace: Path) -> None:
+        results = keyword_search(workspace, "Albert API rate limit")
+        assert len(results) > 0
+        # MEMORY.md should rank high (has the exact phrase + 1.5x boost)
+        memory_results = [r for r in results if r["file"] == "MEMORY.md"]
+        assert len(memory_results) > 0
+
+    def test_finds_in_logs(self, workspace: Path) -> None:
+        results = keyword_search(workspace, "query expansion")
+        assert len(results) > 0
+        log_results = [r for r in results if r["file"].startswith("logs/")]
+        assert len(log_results) > 0
+
+    def test_finds_in_sessions(self, workspace: Path) -> None:
+        results = keyword_search(workspace, "deployment production")
+        assert len(results) > 0
+        session_results = [r for r in results if r["file"].startswith("sessions/")]
+        assert len(session_results) > 0
+
+    def test_no_results_for_unmatched_query(self, workspace: Path) -> None:
+        results = keyword_search(workspace, "kubernetes orchestration")
+        assert results == []
+
+    def test_empty_query_returns_empty(self, workspace: Path) -> None:
+        results = keyword_search(workspace, "")
+        assert results == []
+
+    def test_stopwords_only_returns_empty(self, workspace: Path) -> None:
+        results = keyword_search(workspace, "the and or")
+        assert results == []
+
+    def test_max_results_respected(self, workspace: Path) -> None:
+        results = keyword_search(workspace, "Albert", max_results=2)
+        assert len(results) <= 2
+
+    def test_results_sorted_by_score(self, workspace: Path) -> None:
+        results = keyword_search(workspace, "Albert API")
+        scores = [r["score"] for r in results]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_missing_agent_dir(self, tmp_path: Path) -> None:
+        results = keyword_search(tmp_path, "anything")
+        assert results == []
+
+    def test_memory_md_gets_priority_boost(self, workspace: Path) -> None:
+        """MEMORY.md results should score higher than equivalent log matches."""
+        results = keyword_search(workspace, "Albert API rate limit")
+        # Both MEMORY.md and logs have "Albert API rate limit"
+        memory_scores = [r["score"] for r in results if r["file"] == "MEMORY.md"]
+        log_scores = [
+            r["score"]
+            for r in results
+            if r["file"].startswith("logs/") and r["score"] > 0
+        ]
+        if memory_scores and log_scores:
+            assert max(memory_scores) > max(log_scores)
+
+    def test_header_bonus(self, workspace: Path) -> None:
+        """Matches in ## headers should score higher."""
+        agent = workspace / ".agent"
+        (agent / "test_header.md").write_text(
+            "## Deployment Guide\n"
+            "This section covers deployment.\n"
+            "Some unrelated content here.\n",
+            encoding="utf-8",
+        )
+        results = keyword_search(workspace, "deployment")
+        # Header match should contribute a higher score
+        assert len(results) > 0
+
+    def test_line_numbers_are_1_indexed(self, workspace: Path) -> None:
+        results = keyword_search(workspace, "Albert")
+        for r in results:
+            assert r["line_start"] >= 1
+            assert r["line_end"] >= r["line_start"]
+
+    def test_snippets_contain_matching_text(self, workspace: Path) -> None:
+        results = keyword_search(workspace, "query expansion")
+        for r in results:
+            assert (
+                "query" in r["snippet"].lower() or "expansion" in r["snippet"].lower()
+            )
+
+    def test_recency_boost_newer_file_ranks_higher(self, workspace: Path) -> None:
+        """A match in today's log should rank higher than the same match in an old log."""
+        agent = workspace / ".agent" / "logs"
+        today = date.today().isoformat()
+        (agent / f"{today}.md").write_text(
+            "# Today\n\n## 15:00 — Vous\nSpecific unique term xyzzy\n",
+            encoding="utf-8",
+        )
+        (agent / "2024-01-01.md").write_text(
+            "# Old\n\n## 10:00 — Vous\nSpecific unique term xyzzy\n",
+            encoding="utf-8",
+        )
+        results = keyword_search(workspace, "xyzzy")
+        assert len(results) >= 2
+        # Today's file should rank first
+        assert today in results[0]["file"]

--- a/packages/memory/tests/test_tool.py
+++ b/packages/memory/tests/test_tool.py
@@ -240,3 +240,48 @@ class TestMemorySearch:
     def test_search_empty_agent_dir(self, agent_dir):
         result = memory_search.forward("anything")
         assert "no results" in result.lower()
+
+    def test_search_uses_albert_when_credentials_present(
+        self, memory_file, monkeypatch
+    ):
+        """When OPENAI_API_KEY is set, Albert semantic results are fused in."""
+        sem_result = {
+            "file": "MEMORY.md",
+            "line_start": 3,
+            "line_end": 5,
+            "score": 0.9,
+            "snippet": "Albert semantic hit",
+        }
+
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+        import rag_facile.memory.tool as tool_mod
+
+        # Reset singleton so _get_albert_index creates a fresh one
+        tool_mod._albert_index = None
+
+        mock_index = __import__("unittest.mock", fromlist=["MagicMock"]).MagicMock()
+        mock_index.search.return_value = [sem_result]
+
+        with __import__("unittest.mock", fromlist=["patch"]).patch(
+            "rag_facile.memory.tool._get_albert_index", return_value=mock_index
+        ):
+            result = memory_search.forward("Albert")
+
+        assert "result" in result.lower()
+        mock_index.search.assert_called_once()
+
+    def test_search_falls_back_to_keyword_when_no_credentials(
+        self, memory_file, monkeypatch
+    ):
+        """When no API key is present, memory_search uses keyword results only."""
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("ALBERT_API_KEY", raising=False)
+
+        import rag_facile.memory.tool as tool_mod
+
+        tool_mod._albert_index = None
+
+        result = memory_search.forward("Luis Developer")
+        # Keyword search still finds content
+        assert "result" in result.lower()

--- a/packages/memory/tests/test_tool.py
+++ b/packages/memory/tests/test_tool.py
@@ -1,4 +1,4 @@
-"""Tests for the standard file-operation memory tools (read / write / edit)."""
+"""Tests for the standard file-operation memory tools (read / write / edit / search)."""
 
 import pytest
 
@@ -6,6 +6,7 @@ from rag_facile.memory.tool import (
     _safe_resolve,
     memory_edit,
     memory_read,
+    memory_search,
     memory_write,
     set_workspace_root,
 )
@@ -188,3 +189,54 @@ class TestMemoryEdit:
         (agent_dir / "subdir").mkdir()
         result = memory_edit.forward("subdir", "old", "new")
         assert "directory" in result.lower()
+
+
+# ── memory_search ─────────────────────────────────────────────────────────────
+
+
+class TestMemorySearch:
+    def test_no_workspace(self):
+        set_workspace_root(None)
+        result = memory_search.forward("anything")
+        assert "unavailable" in result.lower()
+
+    def test_search_finds_content(self, memory_file):
+        result = memory_search.forward("Luis Developer")
+        assert "result" in result.lower()
+        assert "MEMORY.md" in result
+
+    def test_search_no_results(self, memory_file):
+        result = memory_search.forward("kubernetes orchestration")
+        assert "no results" in result.lower()
+
+    def test_search_returns_line_references(self, memory_file):
+        result = memory_search.forward("balanced preset")
+        # Should contain file:line-line references
+        assert "MEMORY.md:" in result
+
+    def test_search_across_multiple_files(self, agent_dir):
+        """Search should find content in different files."""
+        # MEMORY.md
+        (agent_dir / "MEMORY.md").write_text(
+            "## Key Facts\n- Albert is an API\n", encoding="utf-8"
+        )
+        # Log file
+        logs = agent_dir / "logs"
+        logs.mkdir()
+        (logs / "2026-03-01.md").write_text(
+            "## 14:30\nAlbert API returned an error\n", encoding="utf-8"
+        )
+        result = memory_search.forward("Albert API")
+        assert "MEMORY.md" in result
+        assert "logs/" in result
+
+    def test_search_output_format(self, memory_file):
+        result = memory_search.forward("Luis")
+        # Should have numbered results with scores
+        assert "1." in result
+        # Should have the drill-in hint
+        assert "memory_read" in result
+
+    def test_search_empty_agent_dir(self, agent_dir):
+        result = memory_search.forward("anything")
+        assert "no results" in result.lower()


### PR DESCRIPTION
## Summary

- **Local keyword search** (`packages/memory/src/rag_facile/memory/search.py`) — zero-dependency search across all `.agent/*.md` files. Tokenizes queries (French + English stopword filtering), scores lines with word-boundary matching, applies header bonuses (×2), MEMORY.md priority (×1.5), and recency boost (today ×1.3). Groups consecutive matches into contextual snippets with `file:start-end` references for drill-in.

- **Optional Albert semantic search** (`albert_search.py`) — uploads changed `.agent/` files to a private Albert collection for vector-based retrieval. Incremental sync via mtime tracking in `.search-state.json`. Falls back gracefully when Albert is unavailable. RRF (Reciprocal Rank Fusion) merges keyword + semantic results.

- **`memory_search` tool** — new `@tool` for the agent, wired into `agent.py` and `tools.py`. Returns ranked snippets with line references. System prompt updated with "SEARCH BEFORE READ" guidance: search first when you don't know which file contains the information.

## Test plan

- [x] 30 keyword search tests (tokenizer, line scoring, recency, snippet grouping, integration)
- [x] 14 Albert search tests (sync, incremental, API error fallback, RRF fusion — all mocked)
- [x] 7 tool integration tests (no workspace, search finds content, cross-file, output format)
- [x] 195 memory package tests passing
- [x] 123 CLI tests passing
- [x] ruff check + format clean
- [x] ty check passing (pre-commit hook)

👾 Generated with [Letta Code](https://letta.com)