### PR TITLE
fix: restore feat→minor version bumps (remove bump-patch-for-minor-pre-major)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,6 @@
 			"changelog-path": "CHANGELOG.md",
 			"version-file": "pyproject.toml",
 			"bump-minor-pre-major": true,
-			"bump-patch-for-minor-pre-major": true,
 			"extra-files": [
 				"apps/cli/pyproject.toml",
 				"apps/chainlit-chat/pyproject.toml",


### PR DESCRIPTION
## Problem

Release please PR #170 proposes `0.18.4` instead of `0.19.0` despite containing multiple `feat:` commits.

**Root cause**: `bump-patch-for-minor-pre-major: true` in `release-please-config.json` demotes all `feat:` commits to patch bumps while the version is pre-1.0 (`< 1.0.0`).

## Fix

Remove `bump-patch-for-minor-pre-major: true`. With only `bump-minor-pre-major: true` remaining:

| Commit type | Before (broken) | After (correct) |
|---|---|---|
| `fix:` | patch → `0.18.4` | patch → `0.18.4` ✅ |
| `feat:` | patch → `0.18.4` ❌ | minor → `0.19.0` ✅ |
| `feat!`/`fix!` | minor → `0.19.0` | minor → `0.19.0` ✅ |

## After merging

Release please will re-run on the push to main and update PR #170 from `0.18.4` → `0.19.0` automatically.

👾 Generated with [Letta Code](https://letta.com)