### PR TITLE
fix: remove language selection from learn init wizard — always French

### DIFF
--- a/apps/cli/src/cli/commands/learn/init.py
+++ b/apps/cli/src/cli/commands/learn/init.py
@@ -41,11 +41,6 @@ _EXPERIENCE_CHOICES = [
     questionary.Choice("Expert — minimal guidance", value="expert"),
 ]
 
-_LANGUAGE_CHOICES = [
-    questionary.Choice("Français 🇫🇷", value="fr"),
-    questionary.Choice("English 🇬🇧", value="en"),
-]
-
 
 # ── Template generators ───────────────────────────────────────────────────────
 
@@ -131,26 +126,17 @@ def run_init_wizard(workspace: Path) -> str:
     )
     console.print()
 
-    # ── Ask 2 questions (language first so the rest adapts) ──────────────────
-    # questionary returns None on Ctrl+C — check after each question so we
-    # don't fall through to the next one when the user cancels.
+    # ── Ask 1 question (language is always French) ────────────────────────────
     language = "fr"
     experience = "new"
     try:
         result = questionary.select(
-            "Preferred language for our conversations?",
-            choices=_LANGUAGE_CHOICES,
+            "Votre niveau d'expérience avec RAG ?",
+            choices=_EXPERIENCE_CHOICES,
             style=_STYLE,
         ).ask()
         if result is not None:
-            language = result
-            result = questionary.select(
-                "Your experience with RAG?",
-                choices=_EXPERIENCE_CHOICES,
-                style=_STYLE,
-            ).ask()
-            if result is not None:
-                experience = result
+            experience = result
     except (EOFError, OSError):
         pass  # non-interactive terminal (pipe, CI) — keep defaults
 

--- a/apps/cli/tests/test_learn_init.py
+++ b/apps/cli/tests/test_learn_init.py
@@ -64,6 +64,10 @@ def _exp_intermediate():
     return [type("Q", (), {"ask": lambda self: "intermediate"})()]
 
 
+def _exp_expert():
+    return [type("Q", (), {"ask": lambda self: "expert"})()]
+
+
 class TestRunInitWizard:
     def test_creates_profile_file(self, tmp_path):
         """Wizard creates profile.md in the workspace."""
@@ -106,7 +110,7 @@ class TestRunInitWizard:
         with (
             patch(
                 "cli.commands.learn.init.questionary.select",
-                side_effect=[type("Q", (), {"ask": lambda self: "expert"})()],
+                side_effect=_exp_expert(),
             ),
             patch("cli.commands.learn.init._git_add"),
         ):

--- a/apps/cli/tests/test_learn_init.py
+++ b/apps/cli/tests/test_learn_init.py
@@ -55,19 +55,13 @@ class TestReadLanguage:
         assert read_language(tmp_path) == "fr"
 
 
-# questionary.select mock helpers (language first, then experience)
-def _lang_fr_exp_new():
-    return [
-        type("Q", (), {"ask": lambda self: "fr"})(),
-        type("Q", (), {"ask": lambda self: "new"})(),
-    ]
+# questionary.select mock helpers (experience only — language is always French)
+def _exp_new():
+    return [type("Q", (), {"ask": lambda self: "new"})()]
 
 
-def _lang_en_exp_intermediate():
-    return [
-        type("Q", (), {"ask": lambda self: "en"})(),
-        type("Q", (), {"ask": lambda self: "intermediate"})(),
-    ]
+def _exp_intermediate():
+    return [type("Q", (), {"ask": lambda self: "intermediate"})()]
 
 
 class TestRunInitWizard:
@@ -76,7 +70,7 @@ class TestRunInitWizard:
         with (
             patch(
                 "cli.commands.learn.init.questionary.select",
-                side_effect=_lang_fr_exp_new(),
+                side_effect=_exp_new(),
             ),
             patch("cli.commands.learn.init._git_add"),
         ):
@@ -84,22 +78,23 @@ class TestRunInitWizard:
 
         assert (tmp_path / ".agent" / "profile.md").exists()
 
-    def test_returns_selected_language(self, tmp_path):
+    def test_always_returns_french(self, tmp_path):
+        """Wizard always returns 'fr' — language is not selectable."""
         with (
             patch(
                 "cli.commands.learn.init.questionary.select",
-                side_effect=_lang_en_exp_intermediate(),
+                side_effect=_exp_intermediate(),
             ),
             patch("cli.commands.learn.init._git_add"),
         ):
             lang = run_init_wizard(tmp_path)
-        assert lang == "en"
+        assert lang == "fr"
 
     def test_creates_skills_directory(self, tmp_path):
         with (
             patch(
                 "cli.commands.learn.init.questionary.select",
-                side_effect=_lang_en_exp_intermediate(),
+                side_effect=_exp_intermediate(),
             ),
             patch("cli.commands.learn.init._git_add"),
         ):
@@ -111,10 +106,7 @@ class TestRunInitWizard:
         with (
             patch(
                 "cli.commands.learn.init.questionary.select",
-                side_effect=[
-                    type("Q", (), {"ask": lambda self: "en"})(),
-                    type("Q", (), {"ask": lambda self: "expert"})(),
-                ],
+                side_effect=[type("Q", (), {"ask": lambda self: "expert"})()],
             ),
             patch("cli.commands.learn.init._git_add"),
         ):
@@ -140,7 +132,7 @@ class TestRunInitWizard:
         with (
             patch(
                 "cli.commands.learn.init.questionary.select",
-                side_effect=_lang_fr_exp_new(),
+                side_effect=_exp_new(),
             ),
             patch("cli.commands.learn.init._git_add") as mock_git,
         ):
@@ -154,7 +146,7 @@ class TestRunInitWizard:
             with (
                 patch(
                     "cli.commands.learn.init.questionary.select",
-                    side_effect=_lang_fr_exp_new(),
+                    side_effect=_exp_new(),
                 ),
                 patch("cli.commands.learn.init._git_add"),
             ):


### PR DESCRIPTION
## Summary

- Remove the language-selection question from the `rag-facile learn` first-run wizard — the command targets French government developers exclusively
- Wizard now asks only the experience-level question (translated to French)
- Hard-codes `language = "fr"` throughout; `_LANGUAGE_CHOICES` list deleted

## Test plan

### Automated
- [x] `uv run python -m pytest apps/cli/tests/` — 123 tests passing

### Manual — first run (no `.agent/` directory)

```bash
cd <your-rag-facile-workspace>
rm -rf .agent   # ensure a clean first-run state
rag-facile learn
```

Expected:
- Welcome panel appears in French
- **Only one question** is asked: `"Votre niveau d'expérience avec RAG ?"` (new / some experience / expert)
- No language prompt at all
- After answering, `.agent/profile.md` is created with `Language: fr`
- Chat starts immediately in French

### Manual — subsequent runs

```bash
rag-facile learn   # .agent/ already exists
```

Expected:
- Wizard is skipped entirely
- Chat starts directly in French

### Manual — non-interactive / CI environment

```bash
echo "q" | rag-facile learn
```

Expected:
- Wizard falls back silently to `experience = new`, `language = fr`
- No crash or traceback

👾 Generated with [Letta Code](https://letta.com)