### PR TITLE
docs: clarify curl not required on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Build a RAG application for the French government in under 5 minutes, powered by
 ## Prerequisites
 
 - An **Albert API key** — [request one here](https://albert.sites.beta.gouv.fr/)
-- **curl** (pre-installed on macOS / Linux / WSL)
+- **curl** — pre-installed on macOS / Linux / WSL; not required on Windows (uses PowerShell)
 
 ## Install
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -7,7 +7,7 @@ This guide walks you through installing RAG Facile and running your first RAG ap
 ## Prerequisites
 
 - An **Albert API key** — [request one here](https://albert.sites.beta.gouv.fr/)
-- **curl** (pre-installed on macOS/Linux/WSL)
+- **curl** — pre-installed on macOS/Linux/WSL; not required on Windows (uses PowerShell)
 
 The installer handles everything else: it installs [uv](https://docs.astral.sh/uv/) (Python package manager) and [just](https://just.systems/) (command runner), then downloads and sets up a ready-to-run workspace.
 
@@ -37,7 +37,7 @@ Open a new PowerShell window after installation completes.
 4. Extracts it to `./my-rag-app/`
 5. Runs `uv sync` to install Python dependencies
 
-Total toolchain: just **curl + uv + just**. No proto, no moon, no global CLI tools.
+Total toolchain: just **uv + just**. No proto, no moon, no global CLI tools. (Linux/macOS/WSL also need **curl**, pre-installed on all three.)
 
 ## Your first app
 


### PR DESCRIPTION
## Summary

- Remove the implication that `curl` is a universal prerequisite
- Clarify that `curl` is only needed for the Linux/macOS/WSL bash installer
- Windows users install via PowerShell (`irm ... | iex`) — no `curl` needed

Fixes #180.

## Changes

- **README.md** — updated prerequisites bullet: `curl` now notes it is not required on Windows
- **docs/guides/getting-started.md** — same prerequisite update, plus corrected the "Total toolchain" summary to reflect the Windows path accurately

## Test plan

- [ ] Verify the prerequisites section in README.md clearly distinguishes Linux/macOS/WSL from Windows
- [ ] Verify `docs/guides/getting-started.md` prerequisites section matches README.md
- [ ] Verify the "What the installer does" section no longer implies curl is needed on Windows

👾 Generated with [Letta Code](https://letta.com)