### PR TITLE
feat(chainlit): Supabase auth and conversation persistence

### DIFF
--- a/.moon/templates/chainlit-chat/.env.example
+++ b/.moon/templates/chainlit-chat/.env.example
@@ -6,6 +6,8 @@ OPENAI_MODEL=gpt-4
 # DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
 
 # Optional: Supabase Auth (enables login form)
-# Get values from `supabase status`
+# Run `chainlit create-secret` to generate CHAINLIT_AUTH_SECRET
+# Get SUPABASE_URL and SUPABASE_ANON_KEY from `supabase status`
+# CHAINLIT_AUTH_SECRET=your_chainlit_auth_secret_here
 # SUPABASE_URL=http://127.0.0.1:54321
 # SUPABASE_ANON_KEY=your_anon_key_here

--- a/.moon/templates/chainlit-chat/.env.example
+++ b/.moon/templates/chainlit-chat/.env.example
@@ -1,3 +1,11 @@
 OPENAI_API_KEY=your_api_key_here
 OPENAI_BASE_URL=https://api.openai.com/v1
 OPENAI_MODEL=gpt-4
+
+# Optional: PostgreSQL persistence (enables conversation history)
+# DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
+
+# Optional: Supabase Auth (enables login form)
+# Get values from `supabase status`
+# SUPABASE_URL=http://127.0.0.1:54321
+# SUPABASE_ANON_KEY=your_anon_key_here

--- a/.moon/templates/chainlit-chat/app.py
+++ b/.moon/templates/chainlit-chat/app.py
@@ -9,14 +9,14 @@ import engineio
 import engineio.payload
 from chainlit.input_widget import Switch
 from dotenv import load_dotenv
-from rag_facile.pipelines import process_query
-from rag_facile.tracing import update_trace_with_response
 from supabase import create_client
 from supabase_auth.errors import AuthApiError
 
 from albert import AsyncAlbertClient
 from rag_facile.core import get_config
 from rag_facile.core.mediatech import get_collection_name
+from rag_facile.pipelines import process_query
+from rag_facile.tracing import update_trace_with_response
 
 
 # Increase the number of packets allowed in a single payload to prevent "Too
@@ -60,15 +60,31 @@ async def auth_callback(username: str, password: str) -> Optional[cl.User]:
     user = response.user
     if not user:
         return None
+    # Use the stable Supabase UUID as identifier for reliable user tracking.
+    # Email can change; the UUID is immutable and unique across all users.
     return cl.User(
-        identifier=user.email or username,
-        metadata={"role": "user", "provider": "supabase", "sub": str(user.id)},
+        identifier=str(user.id),
+        metadata={
+            "role": "user",
+            "provider": "supabase",
+            "email": user.email or username,
+        },
     )
 
 
 @cl.on_chat_resume
 async def on_chat_resume(thread: cl.ThreadDict) -> None:
     """Restore conversation history when resuming a thread."""
+    # Defense-in-depth: verify the thread belongs to the current user.
+    # Chainlit's data layer does not enforce per-user filtering on get_thread(),
+    # so we guard here until RLS policies are added.
+    current_user = cl.user_session.get("user")
+    if current_user and thread.get("userIdentifier") != current_user.identifier:
+        await cl.Message(
+            content="Unauthorized: this thread does not belong to you."
+        ).send()
+        return
+
     # Rebuild message history from the persisted thread
     message_history = [
         {"role": "system", "content": rag_config.generation.system_prompt}

--- a/.moon/templates/chainlit-chat/app.py
+++ b/.moon/templates/chainlit-chat/app.py
@@ -2,14 +2,17 @@ import ast
 import json
 import os
 import time
+from typing import Optional
 
 import chainlit as cl
 import engineio
 import engineio.payload
 from chainlit.input_widget import Switch
+from dotenv import load_dotenv
 from rag_facile.pipelines import process_query
 from rag_facile.tracing import update_trace_with_response
-from dotenv import load_dotenv
+from supabase import create_client
+from supabase_auth.errors import AuthApiError
 
 from albert import AsyncAlbertClient
 from rag_facile.core import get_config
@@ -33,6 +36,63 @@ base_url = os.getenv("OPENAI_BASE_URL")
 model = os.getenv("OPENAI_MODEL") or rag_config.generation.model
 
 client = AsyncAlbertClient(api_key=api_key, base_url=base_url)
+
+# Supabase Auth configuration (optional)
+SUPABASE_URL = os.getenv("SUPABASE_URL", "")
+SUPABASE_ANON_KEY = os.getenv("SUPABASE_ANON_KEY", "")
+
+# Note: Chainlit auto-detects DATABASE_URL and uses ChainlitDataLayer (asyncpg)
+# for persistence. No decorator needed - just set DATABASE_URL in .env.
+
+
+@cl.password_auth_callback
+async def auth_callback(username: str, password: str) -> Optional[cl.User]:
+    """Authenticate against Supabase Auth (GoTrue)."""
+    if not SUPABASE_URL or not SUPABASE_ANON_KEY:
+        return None  # Auth disabled when Supabase not configured
+    sb = create_client(SUPABASE_URL, SUPABASE_ANON_KEY)
+    try:
+        response = sb.auth.sign_in_with_password(
+            {"email": username, "password": password}
+        )
+    except AuthApiError:
+        return None  # Invalid credentials or Supabase unreachable
+    user = response.user
+    if not user:
+        return None
+    return cl.User(
+        identifier=user.email or username,
+        metadata={"role": "user", "provider": "supabase", "sub": str(user.id)},
+    )
+
+
+@cl.on_chat_resume
+async def on_chat_resume(thread: cl.ThreadDict) -> None:
+    """Restore conversation history when resuming a thread."""
+    # Rebuild message history from the persisted thread
+    message_history = [
+        {"role": "system", "content": rag_config.generation.system_prompt}
+    ]
+    for step in thread.get("steps", []):
+        if step.get("type") == "user_message":
+            message_history.append({"role": "user", "content": step.get("content", "")})
+        elif step.get("type") == "assistant_message":
+            message_history.append(
+                {"role": "assistant", "content": step.get("content", "")}
+            )
+    cl.user_session.set("message_history", message_history)
+
+    # Restore active collections from config (no persistence for toggles yet)
+    active_collections = list(rag_config.storage.collections)
+    cl.user_session.set("active_collections", active_collections)
+
+    # Show collection toggles
+    widgets = []
+    for col_id in rag_config.storage.collections:
+        name = get_collection_name(col_id) or f"Collection {col_id}"
+        widgets.append(Switch(id=f"col_{col_id}", label=f"📚 {name}", initial=True))
+    if widgets:
+        await cl.ChatSettings(widgets).send()
 
 
 # Example dummy function

--- a/.moon/templates/chainlit-chat/app.py
+++ b/.moon/templates/chainlit-chat/app.py
@@ -65,6 +65,7 @@ async def auth_callback(username: str, password: str) -> Optional[cl.User]:
     # Email can change; the UUID is immutable and unique across all users.
     return cl.User(
         identifier=str(user.id),
+        display_name=user.email or username,
         metadata={
             "role": "user",
             "provider": "supabase",

--- a/.moon/templates/chainlit-chat/app.py
+++ b/.moon/templates/chainlit-chat/app.py
@@ -8,6 +8,7 @@ import chainlit as cl
 import engineio
 import engineio.payload
 from chainlit.input_widget import Switch
+from chainlit.types import ThreadDict
 from dotenv import load_dotenv
 from supabase import create_client
 from supabase_auth.errors import AuthApiError
@@ -73,7 +74,7 @@ async def auth_callback(username: str, password: str) -> Optional[cl.User]:
 
 
 @cl.on_chat_resume
-async def on_chat_resume(thread: cl.ThreadDict) -> None:
+async def on_chat_resume(thread: ThreadDict) -> None:
     """Restore conversation history when resuming a thread."""
     # Defense-in-depth: verify the thread belongs to the current user.
     # Chainlit's data layer does not enforce per-user filtering on get_thread(),

--- a/.moon/templates/chainlit-chat/app.py
+++ b/.moon/templates/chainlit-chat/app.py
@@ -63,9 +63,15 @@ async def auth_callback(username: str, password: str) -> Optional[cl.User]:
         return None
     # Use the stable Supabase UUID as identifier for reliable user tracking.
     # Email can change; the UUID is immutable and unique across all users.
+    #
+    # display_name priority: user_metadata["display_name"] > email > login username.
+    # Set display_name in Supabase Studio → Auth → Users → Edit user metadata
+    # to show a friendly name (e.g. full name) instead of the email address.
+    user_meta = user.user_metadata or {}
+    display_name = user_meta.get("display_name") or user.email or username
     return cl.User(
         identifier=str(user.id),
-        display_name=user.email or username,
+        display_name=display_name,
         metadata={
             "role": "user",
             "provider": "supabase",

--- a/.moon/templates/chainlit-chat/pyproject.toml
+++ b/.moon/templates/chainlit-chat/pyproject.toml
@@ -10,6 +10,8 @@ dependencies = [
     "chainlit>=1.3.0",
     "python-dotenv>=1.0.0",
     "supabase>=2.0.0",
+    # workspace packages
+    "rag-core",
 ]
 
 [project.scripts]

--- a/.moon/templates/chainlit-chat/pyproject.toml
+++ b/.moon/templates/chainlit-chat/pyproject.toml
@@ -5,9 +5,11 @@ description = "{{ description }}"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
+    "asyncpg>=0.29.0",
     "rag-facile-lib",
     "chainlit>=1.3.0",
     "python-dotenv>=1.0.0",
+    "supabase>=2.0.0",
 ]
 
 [project.scripts]

--- a/apps/chainlit-chat/.env.example
+++ b/apps/chainlit-chat/.env.example
@@ -6,6 +6,8 @@ OPENAI_MODEL=gpt-4
 # DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
 
 # Optional: Supabase Auth (enables login form)
-# Get values from `supabase status`
+# Run `chainlit create-secret` to generate CHAINLIT_AUTH_SECRET
+# Get SUPABASE_URL and SUPABASE_ANON_KEY from `supabase status`
+# CHAINLIT_AUTH_SECRET=your_chainlit_auth_secret_here
 # SUPABASE_URL=http://127.0.0.1:54321
 # SUPABASE_ANON_KEY=your_anon_key_here

--- a/apps/chainlit-chat/.env.example
+++ b/apps/chainlit-chat/.env.example
@@ -1,3 +1,11 @@
 OPENAI_API_KEY=your_api_key_here
 OPENAI_BASE_URL=https://api.openai.com/v1
 OPENAI_MODEL=gpt-4
+
+# Optional: PostgreSQL persistence (enables conversation history)
+# DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
+
+# Optional: Supabase Auth (enables login form)
+# Get values from `supabase status`
+# SUPABASE_URL=http://127.0.0.1:54321
+# SUPABASE_ANON_KEY=your_anon_key_here

--- a/apps/chainlit-chat/app.py
+++ b/apps/chainlit-chat/app.py
@@ -9,14 +9,14 @@ import engineio
 import engineio.payload
 from chainlit.input_widget import Switch
 from dotenv import load_dotenv
-from rag_facile.pipelines import process_query
-from rag_facile.tracing import update_trace_with_response
 from supabase import create_client
 from supabase_auth.errors import AuthApiError
 
 from albert import AsyncAlbertClient
 from rag_facile.core import get_config
 from rag_facile.core.mediatech import get_collection_name
+from rag_facile.pipelines import process_query
+from rag_facile.tracing import update_trace_with_response
 
 
 # Increase the number of packets allowed in a single payload to prevent "Too
@@ -60,15 +60,31 @@ async def auth_callback(username: str, password: str) -> Optional[cl.User]:
     user = response.user
     if not user:
         return None
+    # Use the stable Supabase UUID as identifier for reliable user tracking.
+    # Email can change; the UUID is immutable and unique across all users.
     return cl.User(
-        identifier=user.email or username,
-        metadata={"role": "user", "provider": "supabase", "sub": str(user.id)},
+        identifier=str(user.id),
+        metadata={
+            "role": "user",
+            "provider": "supabase",
+            "email": user.email or username,
+        },
     )
 
 
 @cl.on_chat_resume
 async def on_chat_resume(thread: cl.ThreadDict) -> None:
     """Restore conversation history when resuming a thread."""
+    # Defense-in-depth: verify the thread belongs to the current user.
+    # Chainlit's data layer does not enforce per-user filtering on get_thread(),
+    # so we guard here until RLS policies are added.
+    current_user = cl.user_session.get("user")
+    if current_user and thread.get("userIdentifier") != current_user.identifier:
+        await cl.Message(
+            content="Unauthorized: this thread does not belong to you."
+        ).send()
+        return
+
     # Rebuild message history from the persisted thread
     message_history = [
         {"role": "system", "content": rag_config.generation.system_prompt}

--- a/apps/chainlit-chat/app.py
+++ b/apps/chainlit-chat/app.py
@@ -2,14 +2,17 @@ import ast
 import json
 import os
 import time
+from typing import Optional
 
 import chainlit as cl
 import engineio
 import engineio.payload
 from chainlit.input_widget import Switch
+from dotenv import load_dotenv
 from rag_facile.pipelines import process_query
 from rag_facile.tracing import update_trace_with_response
-from dotenv import load_dotenv
+from supabase import create_client
+from supabase_auth.errors import AuthApiError
 
 from albert import AsyncAlbertClient
 from rag_facile.core import get_config
@@ -33,6 +36,63 @@ base_url = os.getenv("OPENAI_BASE_URL")
 model = os.getenv("OPENAI_MODEL") or rag_config.generation.model
 
 client = AsyncAlbertClient(api_key=api_key, base_url=base_url)
+
+# Supabase Auth configuration (optional)
+SUPABASE_URL = os.getenv("SUPABASE_URL", "")
+SUPABASE_ANON_KEY = os.getenv("SUPABASE_ANON_KEY", "")
+
+# Note: Chainlit auto-detects DATABASE_URL and uses ChainlitDataLayer (asyncpg)
+# for persistence. No decorator needed - just set DATABASE_URL in .env.
+
+
+@cl.password_auth_callback
+async def auth_callback(username: str, password: str) -> Optional[cl.User]:
+    """Authenticate against Supabase Auth (GoTrue)."""
+    if not SUPABASE_URL or not SUPABASE_ANON_KEY:
+        return None  # Auth disabled when Supabase not configured
+    sb = create_client(SUPABASE_URL, SUPABASE_ANON_KEY)
+    try:
+        response = sb.auth.sign_in_with_password(
+            {"email": username, "password": password}
+        )
+    except AuthApiError:
+        return None  # Invalid credentials or Supabase unreachable
+    user = response.user
+    if not user:
+        return None
+    return cl.User(
+        identifier=user.email or username,
+        metadata={"role": "user", "provider": "supabase", "sub": str(user.id)},
+    )
+
+
+@cl.on_chat_resume
+async def on_chat_resume(thread: cl.ThreadDict) -> None:
+    """Restore conversation history when resuming a thread."""
+    # Rebuild message history from the persisted thread
+    message_history = [
+        {"role": "system", "content": rag_config.generation.system_prompt}
+    ]
+    for step in thread.get("steps", []):
+        if step.get("type") == "user_message":
+            message_history.append({"role": "user", "content": step.get("content", "")})
+        elif step.get("type") == "assistant_message":
+            message_history.append(
+                {"role": "assistant", "content": step.get("content", "")}
+            )
+    cl.user_session.set("message_history", message_history)
+
+    # Restore active collections from config (no persistence for toggles yet)
+    active_collections = list(rag_config.storage.collections)
+    cl.user_session.set("active_collections", active_collections)
+
+    # Show collection toggles
+    widgets = []
+    for col_id in rag_config.storage.collections:
+        name = get_collection_name(col_id) or f"Collection {col_id}"
+        widgets.append(Switch(id=f"col_{col_id}", label=f"📚 {name}", initial=True))
+    if widgets:
+        await cl.ChatSettings(widgets).send()
 
 
 # Example dummy function

--- a/apps/chainlit-chat/app.py
+++ b/apps/chainlit-chat/app.py
@@ -65,6 +65,7 @@ async def auth_callback(username: str, password: str) -> Optional[cl.User]:
     # Email can change; the UUID is immutable and unique across all users.
     return cl.User(
         identifier=str(user.id),
+        display_name=user.email or username,
         metadata={
             "role": "user",
             "provider": "supabase",

--- a/apps/chainlit-chat/app.py
+++ b/apps/chainlit-chat/app.py
@@ -8,6 +8,7 @@ import chainlit as cl
 import engineio
 import engineio.payload
 from chainlit.input_widget import Switch
+from chainlit.types import ThreadDict
 from dotenv import load_dotenv
 from supabase import create_client
 from supabase_auth.errors import AuthApiError
@@ -73,7 +74,7 @@ async def auth_callback(username: str, password: str) -> Optional[cl.User]:
 
 
 @cl.on_chat_resume
-async def on_chat_resume(thread: cl.ThreadDict) -> None:
+async def on_chat_resume(thread: ThreadDict) -> None:
     """Restore conversation history when resuming a thread."""
     # Defense-in-depth: verify the thread belongs to the current user.
     # Chainlit's data layer does not enforce per-user filtering on get_thread(),

--- a/apps/chainlit-chat/app.py
+++ b/apps/chainlit-chat/app.py
@@ -63,9 +63,15 @@ async def auth_callback(username: str, password: str) -> Optional[cl.User]:
         return None
     # Use the stable Supabase UUID as identifier for reliable user tracking.
     # Email can change; the UUID is immutable and unique across all users.
+    #
+    # display_name priority: user_metadata["display_name"] > email > login username.
+    # Set display_name in Supabase Studio → Auth → Users → Edit user metadata
+    # to show a friendly name (e.g. full name) instead of the email address.
+    user_meta = user.user_metadata or {}
+    display_name = user_meta.get("display_name") or user.email or username
     return cl.User(
         identifier=str(user.id),
-        display_name=user.email or username,
+        display_name=display_name,
         metadata={
             "role": "user",
             "provider": "supabase",

--- a/apps/chainlit-chat/pyproject.toml
+++ b/apps/chainlit-chat/pyproject.toml
@@ -5,13 +5,14 @@ description = "Chainlit Chat with OpenAI Functions Streaming"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "albert-client",
     "asyncpg>=0.29.0",
     "chainlit>=1.3.0",
-    "pipelines",
-    "rag-core",
     "python-dotenv>=1.0.0",
     "supabase>=2.0.0",
+    # workspace packages
+    "albert-client",
+    "pipelines",
+    "rag-core",
 ]
 
 [project.scripts]

--- a/apps/chainlit-chat/pyproject.toml
+++ b/apps/chainlit-chat/pyproject.toml
@@ -6,10 +6,12 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "albert-client",
+    "asyncpg>=0.29.0",
     "chainlit>=1.3.0",
     "pipelines",
     "rag-core",
     "python-dotenv>=1.0.0",
+    "supabase>=2.0.0",
 ]
 
 [project.scripts]

--- a/docs/guides/supabase-setup.md
+++ b/docs/guides/supabase-setup.md
@@ -95,7 +95,9 @@ Copy the output value.
 supabase status
 ```
 
-Copy the `API URL` and `anon key` values.
+Copy the **`API URL`** (e.g. `http://127.0.0.1:54321`) and **`anon key`** values.
+
+> **Common mistake**: do not use the `REST URL` (`http://127.0.0.1:54321/rest/v1`) — the supabase client appends `/auth/v1/token` to whatever you set, so a trailing `/rest/v1` produces a 404.
 
 ### 3. Add to `.env`
 

--- a/docs/guides/supabase-setup.md
+++ b/docs/guides/supabase-setup.md
@@ -92,7 +92,7 @@ Copy the `API URL` and `anon key` values.
 ```bash
 # Supabase Auth (enables Chainlit login)
 SUPABASE_URL=http://127.0.0.1:54321
-SUPABASE_ANON_KEY=<anon key from supabase status>
+SUPABASE_ANON_KEY=your_anon_key_here
 ```
 
 ### 3. Create users

--- a/docs/guides/supabase-setup.md
+++ b/docs/guides/supabase-setup.md
@@ -75,6 +75,45 @@ connection_string = "postgresql://postgres:postgres@127.0.0.1:54322/postgres"
 
 Open Supabase Studio at http://localhost:54323 to browse tables.
 
+## Enable Chainlit Authentication
+
+When `SUPABASE_URL` and `SUPABASE_ANON_KEY` are set, Chainlit shows a login form and validates credentials against Supabase Auth (GoTrue).
+
+### 1. Get Supabase credentials
+
+```bash
+supabase status
+```
+
+Copy the `API URL` and `anon key` values.
+
+### 2. Add to `.env`
+
+```bash
+# Supabase Auth (enables Chainlit login)
+SUPABASE_URL=http://127.0.0.1:54321
+SUPABASE_ANON_KEY=<anon key from supabase status>
+```
+
+### 3. Create users
+
+In Supabase Studio (http://localhost:54323):
+
+1. Go to **Authentication** → **Users**
+2. Click **Create new user**
+3. Enter email and password
+4. Toggle **Auto Confirm User** (for local development)
+
+### 4. Restart Chainlit
+
+```bash
+just run chainlit
+```
+
+The login form appears. Sign in with the user you created.
+
+> **Note**: Auth is optional. Without `SUPABASE_URL` and `SUPABASE_ANON_KEY`, Chainlit runs without login (current behavior).
+
 ## Colima Users (macOS)
 
 If you use [Colima](https://github.com/abiosoft/colima) instead of Docker Desktop, you may hit permission errors on `supabase start`:

--- a/docs/guides/supabase-setup.md
+++ b/docs/guides/supabase-setup.md
@@ -79,7 +79,17 @@ Open Supabase Studio at http://localhost:54323 to browse tables.
 
 When `SUPABASE_URL` and `SUPABASE_ANON_KEY` are set, Chainlit shows a login form and validates credentials against Supabase Auth (GoTrue).
 
-### 1. Get Supabase credentials
+### 1. Generate a JWT secret
+
+Chainlit requires a secret to sign session tokens:
+
+```bash
+chainlit create-secret
+```
+
+Copy the output value.
+
+### 2. Get Supabase credentials
 
 ```bash
 supabase status
@@ -87,15 +97,18 @@ supabase status
 
 Copy the `API URL` and `anon key` values.
 
-### 2. Add to `.env`
+### 3. Add to `.env`
 
 ```bash
+# Required: JWT secret for Chainlit session tokens
+CHAINLIT_AUTH_SECRET=your_chainlit_auth_secret_here
+
 # Supabase Auth (enables Chainlit login)
 SUPABASE_URL=http://127.0.0.1:54321
 SUPABASE_ANON_KEY=your_anon_key_here
 ```
 
-### 3. Create users
+### 4. Create users
 
 In Supabase Studio (http://localhost:54323):
 
@@ -104,7 +117,7 @@ In Supabase Studio (http://localhost:54323):
 3. Enter email and password
 4. Toggle **Auto Confirm User** (for local development)
 
-### 4. Restart Chainlit
+### 5. Restart Chainlit
 
 ```bash
 just run chainlit
@@ -112,7 +125,7 @@ just run chainlit
 
 The login form appears. Sign in with the user you created.
 
-> **Note**: Auth is optional. Without `SUPABASE_URL` and `SUPABASE_ANON_KEY`, Chainlit runs without login (current behavior).
+> **Note**: Auth is optional. Without `SUPABASE_URL` and `SUPABASE_ANON_KEY`, Chainlit runs without login (current behavior). `CHAINLIT_AUTH_SECRET` is only required when auth is enabled.
 
 ## Colima Users (macOS)
 

--- a/supabase/migrations/00000000000001_chainlit.sql
+++ b/supabase/migrations/00000000000001_chainlit.sql
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS "Thread" (
     "userId"         UUID REFERENCES "User"("id") ON DELETE SET NULL,
     "userIdentifier" TEXT,
     "tags"           TEXT[],
-    "metadata"       JSONB,
+    "metadata"       JSONB NOT NULL DEFAULT '{}'::jsonb,
     "createdAt"      TIMESTAMPTZ DEFAULT now(),
     "updatedAt"      TIMESTAMPTZ DEFAULT now(),
     "deletedAt"      TIMESTAMPTZ
@@ -40,7 +40,7 @@ CREATE INDEX IF NOT EXISTS idx_thread_updated ON "Thread" ("updatedAt" DESC);
 
 CREATE TABLE IF NOT EXISTS "Step" (
     "id"            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    "threadId"      UUID NOT NULL REFERENCES "Thread"("id") ON DELETE CASCADE,
+    "threadId"      UUID REFERENCES "Thread"("id") ON DELETE CASCADE,
     "parentId"      UUID,
     "name"          TEXT NOT NULL,
     "type"          TEXT NOT NULL,

--- a/supabase/migrations/00000000000001_chainlit.sql
+++ b/supabase/migrations/00000000000001_chainlit.sql
@@ -1,80 +1,68 @@
 -- Migration: Chainlit data layer schema
 --
--- Tables required by Chainlit's SQLAlchemyDataLayer for persistent
+-- Tables required by Chainlit's ChainlitDataLayer (asyncpg) for persistent
 -- conversation history, step tracking, file elements, and feedback.
 --
--- Schema translated from Chainlit's official documentation:
--- https://docs.chainlit.io/data-layers/sqlalchemy
+-- Table and column names must match exactly what ChainlitDataLayer queries.
+-- Chainlit uses PascalCase table names and camelCase column names (with double
+-- quotes) — we preserve them exactly to avoid mapping issues.
 --
--- Includes columns added in later Chainlit versions:
---   - "modes"        (v2.9.4)
---   - "autoCollapse" (v2.10)
---
--- Chainlit uses camelCase column names — we preserve them exactly
--- to avoid any mapping issues with SQLAlchemyDataLayer.
+-- Derived from chainlit/data/chainlit_data_layer.py INSERT/SELECT statements.
 
--- ── Users ─────────────────────────────────────────────────────────
+-- ── Users ──────────────────────────────────────────────────────────────────
 
-CREATE TABLE IF NOT EXISTS users (
-    "id"         UUID PRIMARY KEY,
+CREATE TABLE IF NOT EXISTS "User" (
+    "id"         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     "identifier" TEXT NOT NULL UNIQUE,
     "metadata"   JSONB NOT NULL DEFAULT '{}'::jsonb,
-    "createdAt"  TEXT
+    "createdAt"  TIMESTAMPTZ DEFAULT now(),
+    "updatedAt"  TIMESTAMPTZ DEFAULT now()
 );
 
--- ── Threads (conversations) ───────────────────────────────────────
+-- ── Threads (conversations) ────────────────────────────────────────────────
 
-CREATE TABLE IF NOT EXISTS threads (
-    "id"             UUID PRIMARY KEY,
-    "createdAt"      TEXT,
+CREATE TABLE IF NOT EXISTS "Thread" (
+    "id"             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     "name"           TEXT,
-    "userId"         UUID REFERENCES users("id") ON DELETE CASCADE,
+    "userId"         UUID REFERENCES "User"("id") ON DELETE SET NULL,
     "userIdentifier" TEXT,
     "tags"           TEXT[],
-    "metadata"       JSONB
+    "metadata"       JSONB,
+    "createdAt"      TIMESTAMPTZ DEFAULT now(),
+    "updatedAt"      TIMESTAMPTZ DEFAULT now()
 );
 
-CREATE INDEX IF NOT EXISTS idx_threads_user
-    ON threads ("userId");
+CREATE INDEX IF NOT EXISTS idx_thread_user ON "Thread" ("userId");
+CREATE INDEX IF NOT EXISTS idx_thread_updated ON "Thread" ("updatedAt" DESC);
 
--- ── Steps (individual messages / tool calls) ──────────────────────
+-- ── Steps (messages and tool calls) ───────────────────────────────────────
 
-CREATE TABLE IF NOT EXISTS steps (
-    "id"            UUID PRIMARY KEY,
+CREATE TABLE IF NOT EXISTS "Step" (
+    "id"            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    "threadId"      UUID NOT NULL REFERENCES "Thread"("id") ON DELETE CASCADE,
+    "parentId"      UUID,
     "name"          TEXT NOT NULL,
     "type"          TEXT NOT NULL,
-    "threadId"      UUID NOT NULL REFERENCES threads("id") ON DELETE CASCADE,
-    "parentId"      UUID,
-    "streaming"     BOOLEAN NOT NULL DEFAULT false,
-    "waitForAnswer" BOOLEAN,
-    "isError"       BOOLEAN,
-    "metadata"      JSONB,
-    "tags"          TEXT[],
     "input"         TEXT,
     "output"        TEXT,
-    "createdAt"     TEXT,
-    "command"       TEXT,
-    "start"         TEXT,
-    "end"           TEXT,
-    "generation"    JSONB,
+    "metadata"      JSONB,
+    "tags"          TEXT[],
     "showInput"     TEXT,
-    "language"      TEXT,
-    "indent"        INT,
-    "defaultOpen"   BOOLEAN,
-    "modes"         TEXT,
-    "autoCollapse"  BOOLEAN
+    "isError"       BOOLEAN DEFAULT false,
+    "startTime"     TIMESTAMPTZ,
+    "endTime"       TIMESTAMPTZ,
+    "createdAt"     TIMESTAMPTZ DEFAULT now()
 );
 
-CREATE INDEX IF NOT EXISTS idx_steps_thread
-    ON steps ("threadId");
-CREATE INDEX IF NOT EXISTS idx_steps_created
-    ON steps ("createdAt" DESC);
+CREATE INDEX IF NOT EXISTS idx_step_thread ON "Step" ("threadId");
+CREATE INDEX IF NOT EXISTS idx_step_start ON "Step" ("startTime");
 
--- ── Elements (file attachments, images, etc.) ─────────────────────
+-- ── Elements (file attachments, images, etc.) ─────────────────────────────
 
-CREATE TABLE IF NOT EXISTS elements (
-    "id"          UUID PRIMARY KEY,
-    "threadId"    UUID REFERENCES threads("id") ON DELETE CASCADE,
+CREATE TABLE IF NOT EXISTS "Element" (
+    "id"          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    "threadId"    UUID REFERENCES "Thread"("id") ON DELETE CASCADE,
+    "stepId"      UUID REFERENCES "Step"("id") ON DELETE CASCADE,
     "type"        TEXT,
     "url"         TEXT,
     "chainlitKey" TEXT,
@@ -84,61 +72,57 @@ CREATE TABLE IF NOT EXISTS elements (
     "size"        TEXT,
     "page"        INT,
     "language"    TEXT,
-    "forId"       UUID,
     "mime"        TEXT,
-    "props"       JSONB
+    "props"       JSONB,
+    "metadata"    JSONB
 );
 
-CREATE INDEX IF NOT EXISTS idx_elements_thread
-    ON elements ("threadId");
+CREATE INDEX IF NOT EXISTS idx_element_thread ON "Element" ("threadId");
+CREATE INDEX IF NOT EXISTS idx_element_step ON "Element" ("stepId");
 
--- ── Feedbacks ─────────────────────────────────────────────────────
+-- ── Feedbacks ──────────────────────────────────────────────────────────────
 
-CREATE TABLE IF NOT EXISTS feedbacks (
-    "id"       UUID PRIMARY KEY,
-    "forId"    UUID NOT NULL,
-    "threadId" UUID NOT NULL REFERENCES threads("id") ON DELETE CASCADE,
-    "value"    INT NOT NULL,
-    "comment"  TEXT
+CREATE TABLE IF NOT EXISTS "Feedback" (
+    "id"      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    "stepId"  UUID NOT NULL REFERENCES "Step"("id") ON DELETE CASCADE,
+    "name"    TEXT,
+    "value"   INT NOT NULL,
+    "comment" TEXT
 );
 
-CREATE INDEX IF NOT EXISTS idx_feedbacks_for
-    ON feedbacks ("forId");
+CREATE INDEX IF NOT EXISTS idx_feedback_step ON "Feedback" ("stepId");
 
--- ── Row Level Security ────────────────────────────────────────────
--- Same pattern as tracing: RLS enabled to lock down PostgREST access.
--- Application connects as postgres role with full access.
--- anon/authenticated roles have no policies = no access.
+-- ── Row Level Security ─────────────────────────────────────────────────────
+-- RLS is enabled to prevent direct PostgREST access from anon/authenticated
+-- roles. The application connects as the postgres role which has full access.
 
-ALTER TABLE users ENABLE ROW LEVEL SECURITY;
-ALTER TABLE threads ENABLE ROW LEVEL SECURITY;
-ALTER TABLE steps ENABLE ROW LEVEL SECURITY;
-ALTER TABLE elements ENABLE ROW LEVEL SECURITY;
-ALTER TABLE feedbacks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "User" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Thread" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Step" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Element" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Feedback" ENABLE ROW LEVEL SECURITY;
 
--- Full access for the application's postgres role
-CREATE POLICY users_app_full_access ON users
+CREATE POLICY user_app_full_access ON "User"
     FOR ALL TO postgres USING (true) WITH CHECK (true);
 
-CREATE POLICY threads_app_full_access ON threads
+CREATE POLICY thread_app_full_access ON "Thread"
     FOR ALL TO postgres USING (true) WITH CHECK (true);
 
-CREATE POLICY steps_app_full_access ON steps
+CREATE POLICY step_app_full_access ON "Step"
     FOR ALL TO postgres USING (true) WITH CHECK (true);
 
-CREATE POLICY elements_app_full_access ON elements
+CREATE POLICY element_app_full_access ON "Element"
     FOR ALL TO postgres USING (true) WITH CHECK (true);
 
-CREATE POLICY feedbacks_app_full_access ON feedbacks
+CREATE POLICY feedback_app_full_access ON "Feedback"
     FOR ALL TO postgres USING (true) WITH CHECK (true);
 
--- ── Future: per-user isolation ────────────────────────────────────
--- When multi-user auth is enabled, add policies like:
+-- ── Future: per-user row isolation ────────────────────────────────────────
+-- When multi-user auth is production-hardened, add policies like:
 --
---   CREATE POLICY threads_user_isolation ON threads
+--   CREATE POLICY thread_user_isolation ON "Thread"
 --       FOR ALL TO authenticated
---       USING ((select auth.uid()) = "userId")
---       WITH CHECK ((select auth.uid()) = "userId");
+--       USING ((select auth.uid()::text) = "userIdentifier")
+--       WITH CHECK ((select auth.uid()::text) = "userIdentifier");
 --
--- Note: wrap auth.uid() in (select ...) for performance —
--- prevents per-row function evaluation (see security-rls-performance).
+-- Note: wrap auth.uid() in (select ...) to prevent per-row evaluation.

--- a/supabase/migrations/00000000000001_chainlit.sql
+++ b/supabase/migrations/00000000000001_chainlit.sql
@@ -29,7 +29,8 @@ CREATE TABLE IF NOT EXISTS "Thread" (
     "tags"           TEXT[],
     "metadata"       JSONB,
     "createdAt"      TIMESTAMPTZ DEFAULT now(),
-    "updatedAt"      TIMESTAMPTZ DEFAULT now()
+    "updatedAt"      TIMESTAMPTZ DEFAULT now(),
+    "deletedAt"      TIMESTAMPTZ
 );
 
 CREATE INDEX IF NOT EXISTS idx_thread_user ON "Thread" ("userId");

--- a/uv.lock
+++ b/uv.lock
@@ -247,6 +247,22 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/11/97b5c2af72a5d0b9bc3fa30cd4b9ce22284a9a943a150fdc768763caf035/asyncpg-0.31.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c204fab1b91e08b0f47e90a75d1b3c62174dab21f670ad6c5d0f243a228f015b", size = 661111, upload-time = "2025-11-24T23:26:04.467Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/71/157d611c791a5e2d0423f09f027bd499935f0906e0c2a416ce712ba51ef3/asyncpg-0.31.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54a64f91839ba59008eccf7aad2e93d6e3de688d796f35803235ea1c4898ae1e", size = 636928, upload-time = "2025-11-24T23:26:05.944Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fc/9e3486fb2bbe69d4a867c0b76d68542650a7ff1574ca40e84c3111bb0c6e/asyncpg-0.31.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0e0822b1038dc7253b337b0f3f676cadc4ac31b126c5d42691c39691962e403", size = 3424067, upload-time = "2025-11-24T23:26:07.957Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c6/8c9d076f73f07f995013c791e018a1cd5f31823c2a3187fc8581706aa00f/asyncpg-0.31.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bef056aa502ee34204c161c72ca1f3c274917596877f825968368b2c33f585f4", size = 3518156, upload-time = "2025-11-24T23:26:09.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/60683a0baf50fbc546499cfb53132cb6835b92b529a05f6a81471ab60d0c/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0bfbcc5b7ffcd9b75ab1558f00db2ae07db9c80637ad1b2469c43df79d7a5ae2", size = 3319636, upload-time = "2025-11-24T23:26:11.168Z" },
+    { url = "https://files.pythonhosted.org/packages/50/dc/8487df0f69bd398a61e1792b3cba0e47477f214eff085ba0efa7eac9ce87/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22bc525ebbdc24d1261ecbf6f504998244d4e3be1721784b5f64664d61fbe602", size = 3472079, upload-time = "2025-11-24T23:26:13.164Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a1/c5bbeeb8531c05c89135cb8b28575ac2fac618bcb60119ee9696c3faf71c/asyncpg-0.31.0-cp313-cp313-win32.whl", hash = "sha256:f890de5e1e4f7e14023619399a471ce4b71f5418cd67a51853b9910fdfa73696", size = 527606, upload-time = "2025-11-24T23:26:14.78Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/b25ccb84a246b470eb943b0107c07edcae51804912b824054b3413995a10/asyncpg-0.31.0-cp313-cp313-win_amd64.whl", hash = "sha256:dc5f2fa9916f292e5c5c8b2ac2813763bcd7f58e130055b4ad8a0531314201ab", size = 596569, upload-time = "2025-11-24T23:26:16.189Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -346,6 +362,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cachetools"
+version = "6.2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/91/d9ae9a66b01102a18cd16db0cf4cd54187ffe10f0865cc80071a4104fbb3/cachetools-6.2.6.tar.gz", hash = "sha256:16c33e1f276b9a9c0b49ab5782d901e3ad3de0dd6da9bf9bcd29ac5672f2f9e6", size = 32363, upload-time = "2026-01-27T20:32:59.956Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/45/f458fa2c388e79dd9d8b9b0c99f1d31b568f27388f2fdba7bb66bbc0c6ed/cachetools-6.2.6-py3-none-any.whl", hash = "sha256:8c9717235b3c651603fff0076db52d6acbfd1b338b8ed50256092f7ce9c85bda", size = 11668, upload-time = "2026-01-27T20:32:58.527Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -427,19 +452,23 @@ version = "0.20.0"
 source = { editable = "apps/chainlit-chat" }
 dependencies = [
     { name = "albert-client" },
+    { name = "asyncpg" },
     { name = "chainlit" },
     { name = "pipelines" },
     { name = "python-dotenv" },
     { name = "rag-core" },
+    { name = "supabase" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "albert-client", editable = "packages/albert-client" },
+    { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "chainlit", specifier = ">=1.3.0" },
     { name = "pipelines", editable = "packages/pipelines" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "rag-core", editable = "packages/rag-core" },
+    { name = "supabase", specifier = ">=2.0.0" },
 ]
 
 [[package]]
@@ -614,6 +643,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
+name = "deprecation"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
 ]
 
 [[package]]
@@ -862,6 +903,19 @@ wheels = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -883,6 +937,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/00/b3/7bc1ff91d1ac18420b7ad1e169b618b27c00001b96310a89f8a9294fe509/hf_xet-1.3.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:06cdbde243c85f39a63b28e9034321399c507bcd5e7befdd17ed2ccc06dfe14e", size = 4398020, upload-time = "2026-02-27T17:26:03.977Z" },
     { url = "https://files.pythonhosted.org/packages/2b/0b/99bfd948a3ed3620ab709276df3ad3710dcea61976918cce8706502927af/hf_xet-1.3.2-cp37-abi3-win_amd64.whl", hash = "sha256:9298b47cce6037b7045ae41482e703c471ce36b52e73e49f71226d2e8e5685a1", size = 3641624, upload-time = "2026-02-27T17:26:13.542Z" },
     { url = "https://files.pythonhosted.org/packages/cc/02/9a6e4ca1f3f73a164c0cd48e41b3cc56585dcc37e809250de443d673266f/hf_xet-1.3.2-cp37-abi3-win_arm64.whl", hash = "sha256:83d8ec273136171431833a6957e8f3af496bee227a0fe47c7b8b39c106d1749a", size = 3503976, upload-time = "2026-02-27T17:26:12.123Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
 ]
 
 [[package]]
@@ -913,6 +976,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
+[package.optional-dependencies]
+http2 = [
+    { name = "h2" },
+]
+
 [[package]]
 name = "httpx-sse"
 version = "0.4.3"
@@ -940,6 +1008,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d5/7a/304cec37112382c4fe29a43bcb0d5891f922785d18745883d2aa4eb74e4b/huggingface_hub-1.6.0.tar.gz", hash = "sha256:d931ddad8ba8dfc1e816bf254810eb6f38e5c32f60d4184b5885662a3b167325", size = 717071, upload-time = "2026-03-06T14:19:18.524Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/92/e3/e3a44f54c8e2f28983fcf07f13d4260b37bd6a0d3a081041bc60b91d230e/huggingface_hub-1.6.0-py3-none-any.whl", hash = "sha256:ef40e2d5cb85e48b2c067020fa5142168342d5108a1b267478ed384ecbf18961", size = 612874, upload-time = "2026-03-06T14:19:16.844Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -2425,6 +2502,21 @@ wheels = [
 ]
 
 [[package]]
+name = "postgrest"
+version = "2.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecation" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "pydantic" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/96/52f4ce2123fed5cda50ede3b04135fc163944c6776a8315da8e2e38e0931/postgrest-2.28.0.tar.gz", hash = "sha256:c36b38646d25ea4255321d3d924ce70f8d20ec7799cb42c1221d6a818d4f6515", size = 13841, upload-time = "2026-02-10T13:17:00.648Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/47/43deadb113d8730e59d5045eb0968eb2ca8ccbad7506bd4fc4a18294e114/postgrest-2.28.0-py3-none-any.whl", hash = "sha256:7bca2f24dd1a1bf8a3d586c7482aba6cd41662da6733045fad585b63b7f7df75", size = 22008, upload-time = "2026-02-10T13:16:59.307Z" },
+]
+
+[[package]]
 name = "pre-commit"
 version = "4.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2658,6 +2750,35 @@ wheels = [
 ]
 
 [[package]]
+name = "pyiceberg"
+version = "0.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "click" },
+    { name = "fsspec" },
+    { name = "mmh3" },
+    { name = "pydantic" },
+    { name = "pyparsing" },
+    { name = "pyroaring" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "strictyaml" },
+    { name = "tenacity" },
+    { name = "zstandard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/f0/7616676603fdbd05ab97816337a9b31be08a5f9e1ffd636260812b217e0f/pyiceberg-0.11.1.tar.gz", hash = "sha256:366fe0d5a74e3cf1d4e7cbf3c49e308da60e7835ea268667be9185388f05d7a5", size = 1076075, upload-time = "2026-03-03T00:10:27.61Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/4c/a122d80d98cb6125d87024681263406433f0c25c699d503f5633521e6809/pyiceberg-0.11.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b7ec5db19feab98a31fcd5caccf4a9a4e83f96933d1ca393ba7aea665710c2bb", size = 532644, upload-time = "2026-03-03T00:10:18.574Z" },
+    { url = "https://files.pythonhosted.org/packages/10/94/9a8fa5fc580e6dccd34bbbf51e7658cd7b49540e2458783addeff5e22a91/pyiceberg-0.11.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cec0616d2ba6e7dda6327089a2f34ec723aa9ac2c389857ef0b83f65fb135dd6", size = 532787, upload-time = "2026-03-03T00:10:19.656Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/ab/ab7c88828bc17d77dbbc5a765419dfec2135629e1d74cdd0762cd38ad867/pyiceberg-0.11.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ddb360da76c62c7c23ec3da40e1af48e6712a563905fea2d1a8911ff7a3b6c4d", size = 722202, upload-time = "2026-03-03T00:10:21.012Z" },
+    { url = "https://files.pythonhosted.org/packages/df/38/079cf1c0bf86da315472a926eec0dba10135f43374a2e267336eb98d8c76/pyiceberg-0.11.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d8790f420ebc484236017edba59182cf2a21bd3e4224a0bd0760a9c7268e96a", size = 724037, upload-time = "2026-03-03T00:10:22.176Z" },
+    { url = "https://files.pythonhosted.org/packages/08/6b/08eaef477debb110438d943ef3f5985096f660ccb735d6344701cbd075a9/pyiceberg-0.11.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ae27ba4d37925d5b2cff192acaa70c8bb114d632bbc527cc91fea0370702b866", size = 716035, upload-time = "2026-03-03T00:10:23.789Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/59/7671d6a630ab1d85c6e7ca8ddf438dc63a0b0dd183bc4be69bf25c0fa5f6/pyiceberg-0.11.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:db66a4e0fdfbf4090631d59c3f65e960d9a5561e9259f6f3993cbe91e396837e", size = 720887, upload-time = "2026-03-03T00:10:24.824Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/2b/5c8ad37807efaedb14b20f01f36462684468c80da5b74f4018fb4c1804b5/pyiceberg-0.11.1-cp313-cp313-win_amd64.whl", hash = "sha256:eb3a0a3e630ee89758eb96b39b456f4697732351fb0c080e9498ea578f9b71f9", size = 530923, upload-time = "2026-03-03T00:10:26.196Z" },
+]
+
+[[package]]
 name = "pyjwt"
 version = "2.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2672,12 +2793,43 @@ crypto = [
 ]
 
 [[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
 name = "pypdf"
 version = "6.8.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b4/a3/e705b0805212b663a4c27b861c8a603dba0f8b4bb281f96f8e746576a50d/pypdf-6.8.0.tar.gz", hash = "sha256:cb7eaeaa4133ce76f762184069a854e03f4d9a08568f0e0623f7ea810407833b", size = 5307831, upload-time = "2026-03-09T13:37:40.591Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/ec/4ccf3bb86b1afe5d7176e1c8abcdbf22b53dd682ec2eda50e1caadcf6846/pypdf-6.8.0-py3-none-any.whl", hash = "sha256:2a025080a8dd73f48123c89c57174a5ff3806c71763ee4e49572dc90454943c7", size = 332177, upload-time = "2026-03-09T13:37:38.774Z" },
+]
+
+[[package]]
+name = "pyroaring"
+version = "1.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/e4/975f0fa77fc3590820b4a3ac49704644b389795409bc12eb91729f845812/pyroaring-1.0.3.tar.gz", hash = "sha256:cd7392d1c010c9e41c11c62cd0610c8852e7e9698b1f7f6c2fcdefe50e7ef6da", size = 188688, upload-time = "2025-10-09T09:08:22.448Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/95/97142ee32587ddda9e2cd614b865eeb5c0ee91006a51928f4074cd6e8e5f/pyroaring-1.0.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:20bc947054b197d1baa76cd05d70b8e04f95b82e698266e2f8f2f4b36d764477", size = 678813, upload-time = "2025-10-09T09:07:29.936Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5e/cff22be3a76a80024bdf00a9decdffedc6e80f037328a58b58c1b521442d/pyroaring-1.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ba5909b4c66bb85cab345e2f3a87e5ce671509c94b8c9823d8db64e107cbe854", size = 373661, upload-time = "2025-10-09T09:07:30.983Z" },
+    { url = "https://files.pythonhosted.org/packages/86/73/fc406a67cd49e1707d1c3d08214458959dd579eff88c28587b356dfa068b/pyroaring-1.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b744746ba5da27fad760067f12633f5d384db6a1e65648d00244ceacbbd87731", size = 313559, upload-time = "2025-10-09T09:07:32.099Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/64/c7fe510523445f27e2cb04de6ffd3137f9d72db438b62db2bfa3dafcf4fc/pyroaring-1.0.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b16c2a2791a5a09c4b59c0e1069ac1c877d0df25cae3155579c7eac8844676e", size = 1875926, upload-time = "2025-10-09T09:07:33.701Z" },
+    { url = "https://files.pythonhosted.org/packages/47/74/da9b8ad2ca9ce6af1377f2cffdad6582a51a5f5df4f26df5c41810c9de5b/pyroaring-1.0.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e7f68dfcf8d01177267f4bc06c4960fe8e39577470d1b52c9af8b61a72ca8767", size = 2064377, upload-time = "2025-10-09T09:07:35.273Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e3/8a70c5a5f7821c63709e2769aeccda8ae87a192198374bc475cbee543a22/pyroaring-1.0.3-cp313-cp313-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:dba4e4700030182a981a3c887aa73887697145fc9ffb192f908aa59b718fbbdd", size = 1778320, upload-time = "2025-10-09T09:07:36.782Z" },
+    { url = "https://files.pythonhosted.org/packages/04/4c/08159a07c3723a2775064887543766b6115b4975e7baaa4d51e5580701a4/pyroaring-1.0.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e26dd1dc1edba02288902914bdb559e53e346e9155defa43c31fcab831b55342", size = 1786569, upload-time = "2025-10-09T09:07:38.473Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/ff/55a18d0e7e0dc4cd9f43988b746e788234a8d660fa17367c5ed9fa799348/pyroaring-1.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6eb98d2cacfc6d51c6a69893f04075e07b3df761eac71ba162c43b9b4c4452ad", size = 2852766, upload-time = "2025-10-09T09:07:39.633Z" },
+    { url = "https://files.pythonhosted.org/packages/24/3c/419e25c51843dd40975ae37d67dea4f2f256554b5bec32237f607ec8ef21/pyroaring-1.0.3-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:a967e9eddb9485cbdd95d6371e3dada67880844d836c0283d3b11efe9225d1b7", size = 2683904, upload-time = "2025-10-09T09:07:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/75/64/8d91f1b85b42925af632fc2c1047bb314be622dce890a4181a0a8d6e498d/pyroaring-1.0.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b12ef7f992ba7be865f91c7c098fd8ac6c413563aaa14d5b1e2bcb8cb43a4614", size = 2973884, upload-time = "2025-10-09T09:07:42.34Z" },
+    { url = "https://files.pythonhosted.org/packages/61/6d/c867625549df0dc9ad675424ecf989fa2f08f0571bd46dfc4f7218737dd2/pyroaring-1.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:82ca5be174b85c40be7b00bc6bf39b2931a1b4a465f3af17ec6b9c48e9aa6fe0", size = 3103671, upload-time = "2025-10-09T09:07:44.055Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b1/d47c5ec2b2580d0b94f42575be8f49907a0f4aa396fdc18660f3b5060d54/pyroaring-1.0.3-cp313-cp313-win32.whl", hash = "sha256:f758c681e63ffe74b20423695e71f0410920f41b075cee679ffb5bc2bf38440b", size = 205153, upload-time = "2025-10-09T09:07:45.496Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/92/3600486936eebab747ae1462d231d7f87d234da24a04e82e1915c00f4427/pyroaring-1.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:428c3bb384fe4c483feb5cf7aa3aef1621fb0a5c4f3d391da67b2c4a43f08a10", size = 260349, upload-time = "2025-10-09T09:07:46.524Z" },
+    { url = "https://files.pythonhosted.org/packages/77/96/8dde074f1ad2a1c3d2091b22de80d1b3007824e649e06eeeebded83f4d48/pyroaring-1.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:9c0c856e8aa5606e8aed5f30201286e404fdc9093f81fefe82d2e79e67472bb2", size = 218775, upload-time = "2025-10-09T09:07:47.558Z" },
 ]
 
 [[package]]
@@ -3031,6 +3183,20 @@ requires-dist = [
     { name = "albert-client", editable = "packages/albert-client" },
     { name = "pypdf", specifier = ">=5.0.0" },
     { name = "tomli-w", specifier = ">=1.0.0" },
+]
+
+[[package]]
+name = "realtime"
+version = "2.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d7/0c/a3f34afadd988a99b86b842b334ad1036ae32672e2e5ad89a0b450dc6926/realtime-2.28.0.tar.gz", hash = "sha256:d18cedcebd6a8f22fcd509bc767f639761eb218b7b2b6f14fc4205b6259b50fc", size = 18726, upload-time = "2026-02-10T13:17:02.755Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/04/dd8409d015a872bc1763a87d5d4e82d82c3eac99e9045f2fceab7f38b4b2/realtime-2.28.0-py3-none-any.whl", hash = "sha256:db1bd59bab9b1fcc9f9d3b1a073bed35bf4994d720e6751f10031a58d57a3836", size = 22375, upload-time = "2026-02-10T13:17:01.412Z" },
 ]
 
 [[package]]
@@ -3481,6 +3647,89 @@ requires-dist = [
 ]
 
 [[package]]
+name = "storage3"
+version = "2.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecation" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "pydantic" },
+    { name = "pyiceberg" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/3b/63bddc4d09aa7bdb46366fcc1bc96c6aef5d4de40ec8e0000d7b30f41534/storage3-2.28.0.tar.gz", hash = "sha256:bc1d008aff67de7a0f2bd867baee7aadbcdb6f78f5a310b4f7a38e8c13c19865", size = 20104, upload-time = "2026-02-10T13:17:04.758Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/10/adf75d912429398f626df1dad61e8c4225a5b8fdf0db8588277a77b26e5c/storage3-2.28.0-py3-none-any.whl", hash = "sha256:ecb50efd2ac71dabbdf97e99ad346eafa630c4c627a8e5a138ceb5fbbadae716", size = 28239, upload-time = "2026-02-10T13:17:03.572Z" },
+]
+
+[[package]]
+name = "strenum"
+version = "0.4.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/ad/430fb60d90e1d112a62ff57bdd1f286ec73a2a0331272febfddd21f330e1/StrEnum-0.4.15.tar.gz", hash = "sha256:878fb5ab705442070e4dd1929bb5e2249511c0bcf2b0eeacf3bcd80875c82eff", size = 23384, upload-time = "2023-06-29T22:02:58.399Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl", hash = "sha256:a30cda4af7cc6b5bf52c8055bc4bf4b2b6b14a93b574626da33df53cf7740659", size = 8851, upload-time = "2023-06-29T22:02:56.947Z" },
+]
+
+[[package]]
+name = "strictyaml"
+version = "1.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/08/efd28d49162ce89c2ad61a88bd80e11fb77bc9f6c145402589112d38f8af/strictyaml-1.7.3.tar.gz", hash = "sha256:22f854a5fcab42b5ddba8030a0e4be51ca89af0267961c8d6cfa86395586c407", size = 115206, upload-time = "2023-03-10T12:50:27.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/7c/a81ef5ef10978dd073a854e0fa93b5d8021d0594b639cc8f6453c3c78a1d/strictyaml-1.7.3-py3-none-any.whl", hash = "sha256:fb5c8a4edb43bebb765959e420f9b3978d7f1af88c80606c03fb420888f5d1c7", size = 123917, upload-time = "2023-03-10T12:50:17.242Z" },
+]
+
+[[package]]
+name = "supabase"
+version = "2.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "postgrest" },
+    { name = "realtime" },
+    { name = "storage3" },
+    { name = "supabase-auth" },
+    { name = "supabase-functions" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/87/05ee1feadf8ca34479707123b3e8b60d84776fd5c53676f03fe459fe9b44/supabase-2.28.0.tar.gz", hash = "sha256:aea299aaab2a2eed3c57e0be7fc035c6807214194cce795a3575add20268ece1", size = 9693, upload-time = "2026-02-10T13:17:06.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8e/a94600a09b5243b86f6f79f86b0fdfe1e5ea7815f00dfa2035bf2ba2b4f7/supabase-2.28.0-py3-none-any.whl", hash = "sha256:42776971c7d0ccca16034df1ab96a31c50228eb1eb19da4249ad2f756fc20272", size = 16635, upload-time = "2026-02-10T13:17:05.714Z" },
+]
+
+[[package]]
+name = "supabase-auth"
+version = "2.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx", extra = ["http2"] },
+    { name = "pydantic" },
+    { name = "pyjwt", extra = ["crypto"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/03/2c53c436799911a664e4aecea5bdcf34c92382c180a829557babcc2ab9c4/supabase_auth-2.28.0.tar.gz", hash = "sha256:2bb8f18ff39934e44b28f10918db965659f3735cd6fbfcc022fe0b82dbf8233e", size = 39279, upload-time = "2026-02-10T13:17:09.143Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/94/6a947240e5ed98f9c1199283838793ab1c1c8a8141d669c38b1f35332291/supabase_auth-2.28.0-py3-none-any.whl", hash = "sha256:2ac85026cc285054c7fa6d41924f3a333e9ec298c013e5b5e1754039ba7caec9", size = 48516, upload-time = "2026-02-10T13:17:08.223Z" },
+]
+
+[[package]]
+name = "supabase-functions"
+version = "2.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx", extra = ["http2"] },
+    { name = "strenum" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/ad/80014166587af84169bc0720d625e747f03815244efa29bfc461b82dbb87/supabase_functions-2.28.0.tar.gz", hash = "sha256:db3dddfc37aca5858819eb461130968473bd8c75bd284581013958526dac718b", size = 4677, upload-time = "2026-02-10T13:17:10.534Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/04/0b18abbcb5dcc4630637d08df91610d7513ae36727f7181b9a7536850003/supabase_functions-2.28.0-py3-none-any.whl", hash = "sha256:30bf2d586f8df285faf0621bb5d5bb3ec3157234fc820553ca156f009475e4ae", size = 8800, upload-time = "2026-02-10T13:17:09.798Z" },
+]
+
+[[package]]
 name = "syncer"
 version = "2.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3865,6 +4114,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload-time = "2025-03-05T20:02:36.695Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098, upload-time = "2025-03-05T20:02:37.985Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329, upload-time = "2025-03-05T20:02:39.298Z" },
+    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111, upload-time = "2025-03-05T20:02:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054, upload-time = "2025-03-05T20:02:41.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496, upload-time = "2025-03-05T20:02:43.304Z" },
+    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829, upload-time = "2025-03-05T20:02:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217, upload-time = "2025-03-05T20:02:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `@cl.password_auth_callback` with Supabase GoTrue integration for user authentication
- Add `@cl.on_chat_resume` handler to restore message history when resuming threads
- Add `asyncpg` and `supabase` dependencies to chainlit-chat
- Update `.env.example` with optional `DATABASE_URL`, `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `CHAINLIT_AUTH_SECRET` vars
- Document auth + persistence setup in `supabase-setup.md` guide
- Add Chainlit database schema migration (`supabase/migrations/00000000000001_chainlit.sql`)

## Behavior

- **Persistence**: Chainlit auto-detects `DATABASE_URL` and uses `ChainlitDataLayer` (asyncpg) — no decorator needed
- **Auth**: When `SUPABASE_URL` and `SUPABASE_ANON_KEY` are set, Chainlit shows a login form and validates against Supabase Auth (GoTrue)
- **Users**: Created/managed via Supabase Studio → Authentication → Users → "Create new user"

## Two different env vars, two different things

`supabase status` outputs several values — they map to different env vars:

| `supabase status` field | Env var | Port | Purpose |
|---|---|---|---|
| `DB URL` | `DATABASE_URL` | 54322 | Direct Postgres connection — Chainlit's `ChainlitDataLayer` (asyncpg) stores threads, steps, elements, feedback |
| `API URL` | `SUPABASE_URL` | 54321 | Supabase REST API — `supabase` Python client calls GoTrue's `/auth/v1/token` to validate credentials |
| `anon key` | `SUPABASE_ANON_KEY` | — | API key for the GoTrue auth client |

> **Note**: use the `API URL` for `SUPABASE_URL` — **not** the `REST URL` (`/rest/v1`). Using the REST URL causes a 404 because the client appends `/auth/v1/token` to whatever you set.

## Test plan

```bash
# 1. Apply database schema
supabase db reset

# 2. Get env vars
supabase status
# Copy:
#   "DB URL"   → DATABASE_URL
#   "API URL"  → SUPABASE_URL   (NOT the REST URL)
#   "anon key" → SUPABASE_ANON_KEY

# 3. Generate JWT secret
chainlit create-secret
# Copy output → CHAINLIT_AUTH_SECRET
```

- [x] Set all four env vars in `.env`
- [x] Create a user in Supabase Studio (http://localhost:54323) → Authentication → Users → "Create new user" with auto-confirm enabled
- [x] Run `just run chainlit` and verify login form appears
- [x] Login with created user credentials
- [x] Send a message, then refresh the page
- [x] Verify conversation appears in sidebar and can be resumed
- [x] Verify that omitting `SUPABASE_URL`/`SUPABASE_ANON_KEY` skips auth (no login form, no `CHAINLIT_AUTH_SECRET` needed)
- [x] Verify that omitting `DATABASE_URL` skips persistence (no sidebar history)

👾 Generated with [Letta Code](https://letta.com)