### PR TITLE
chore: add pre-commit ecosystem to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,10 @@ updates:
     commit-message:
       prefix: "fix"
       prefix-development: "chore"
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
## Summary

- Adds `pre-commit` as a package ecosystem in `.github/dependabot.yml`
- Dependabot will now parse `.pre-commit-config.yaml` weekly and open PRs to update `rev` values (e.g. `astral-sh/ruff-pre-commit`)
- `local` and `meta` hook entries are skipped automatically by Dependabot

This uses [native Dependabot pre-commit support](https://github.blog/changelog/2026-03-10-dependabot-now-supports-pre-commit-hooks/), announced 2026-03-10.

## Test plan

- [ ] Merge and check the Dependabot tab in the repo's dependency graph — `pre-commit` should appear as a monitored ecosystem
- [ ] Wait for (or manually trigger) the first weekly run — Dependabot should open a PR bumping `ruff-pre-commit` if a newer version is available

👾 Generated with [Letta Code](https://letta.com)