### PR TITLE
feat: add portless integration for stable localhost URLs

### DIFF
--- a/.moon/templates/chainlit-chat/app.py
+++ b/.moon/templates/chainlit-chat/app.py
@@ -30,6 +30,15 @@ load_dotenv()
 # Load RAG configuration
 rag_config = get_config()
 
+
+@cl.on_app_startup
+async def on_app_startup():
+    """Print the access URL when the app starts."""
+    portless_url = os.getenv("PORTLESS_URL")
+    if portless_url:
+        cl.logger.info(f"🌐 Access your app at: {portless_url}")
+
+
 # Configure OpenAI (API credentials still from env vars)
 api_key = os.getenv("OPENAI_API_KEY")
 base_url = os.getenv("OPENAI_BASE_URL")

--- a/.moon/templates/chainlit-chat/justfile
+++ b/.moon/templates/chainlit-chat/justfile
@@ -5,9 +5,14 @@ default:
 sync:
     uv sync
 
-# Run the Chainlit application
+# Run the Chainlit application (portless proxy if available)
 run:
-    uv run chainlit run app.py -w
+    #!/usr/bin/env sh
+    if [ "$PORTLESS" != "0" ] && command -v portless >/dev/null 2>&1; then
+        exec portless run --name chainlit -- sh -c 'uv run chainlit run app.py -w --port "$PORT"'
+    else
+        exec uv run chainlit run app.py -w
+    fi
 
 # Open the interactive RAG learning assistant
 learn:

--- a/.moon/templates/reflex-chat/justfile
+++ b/.moon/templates/reflex-chat/justfile
@@ -5,6 +5,11 @@ default:
 sync:
     uv sync --python 3.13.11
 
-# Run the Reflex application (opens browser when ready)
+# Run the Reflex application (opens browser when ready, portless proxy if available)
 run:
-    sh -c 'uv run python scripts/open_browser.py & uv run reflex run'
+    #!/usr/bin/env sh
+    if [ "$PORTLESS" != "0" ] && command -v portless >/dev/null 2>&1; then
+        exec portless run --name reflex --app-port 3000 -- sh -c 'uv run python scripts/open_browser.py & uv run reflex run'
+    else
+        exec sh -c 'uv run python scripts/open_browser.py & uv run reflex run'
+    fi

--- a/.moon/templates/reflex-chat/scripts/open_browser.py
+++ b/.moon/templates/reflex-chat/scripts/open_browser.py
@@ -1,11 +1,12 @@
 """Wait for the Reflex frontend to be ready, then open the browser."""
 
+import os
 import socket
 import time
 import webbrowser
 
 PORT = 3000
-URL = f"http://localhost:{PORT}"
+URL = os.environ.get("PORTLESS_URL", f"http://localhost:{PORT}")
 TIMEOUT = 60  # seconds
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,32 @@ On macOS:
 brew install unzip
 ```
 
+### Portless (optional)
+
+[Portless](https://github.com/vercel-labs/portless) replaces port numbers with stable `.localhost` URLs for local development. When installed, `just run` automatically proxies through portless, giving you URLs like `http://chainlit.localhost:1355` instead of `http://localhost:8000`.
+
+In [bare repo worktrees](https://worktrunk.dev), portless auto-prefixes the branch name as a subdomain — each worktree gets its own URL with zero configuration:
+
+```
+# Main worktree
+just run  # -> http://chainlit.localhost:1355
+
+# Feature worktree on branch feat/dark-mode
+just run  # -> http://feat-dark-mode.chainlit.localhost:1355
+```
+
+Install globally (do not add as a project dependency):
+
+```bash
+npm install -g portless
+```
+
+Portless is entirely optional. Without it, `just run` starts the dev server on its default port as usual. To temporarily bypass portless even when installed:
+
+```bash
+PORTLESS=0 just run
+```
+
 ### 2. Clone and setup
 
 ```bash

--- a/apps/chainlit-chat/app.py
+++ b/apps/chainlit-chat/app.py
@@ -30,6 +30,15 @@ load_dotenv()
 # Load RAG configuration
 rag_config = get_config()
 
+
+@cl.on_app_startup
+async def on_app_startup():
+    """Print the access URL when the app starts."""
+    portless_url = os.getenv("PORTLESS_URL")
+    if portless_url:
+        cl.logger.info(f"🌐 Access your app at: {portless_url}")
+
+
 # Configure OpenAI (API credentials still from env vars)
 api_key = os.getenv("OPENAI_API_KEY")
 base_url = os.getenv("OPENAI_BASE_URL")

--- a/apps/chainlit-chat/justfile
+++ b/apps/chainlit-chat/justfile
@@ -5,9 +5,14 @@ default:
 sync:
     uv sync
 
-# Run the Chainlit application
+# Run the Chainlit application (portless proxy if available)
 run:
-    uv run chainlit run app.py -w
+    #!/usr/bin/env sh
+    if [ "$PORTLESS" != "0" ] && command -v portless >/dev/null 2>&1; then
+        exec portless run --name chainlit -- sh -c 'uv run chainlit run app.py -w --port "$PORT"'
+    else
+        exec uv run chainlit run app.py -w
+    fi
 
 # Open the interactive RAG learning assistant
 learn:

--- a/apps/reflex-chat/justfile
+++ b/apps/reflex-chat/justfile
@@ -5,6 +5,11 @@ default:
 sync:
     uv sync --python 3.13.11
 
-# Run the Reflex application (opens browser when ready)
+# Run the Reflex application (opens browser when ready, portless proxy if available)
 run:
-    sh -c 'uv run python scripts/open_browser.py & uv run reflex run'
+    #!/usr/bin/env sh
+    if [ "$PORTLESS" != "0" ] && command -v portless >/dev/null 2>&1; then
+        exec portless run --name reflex --app-port 3000 -- sh -c 'uv run python scripts/open_browser.py & uv run reflex run'
+    else
+        exec sh -c 'uv run python scripts/open_browser.py & uv run reflex run'
+    fi

--- a/apps/reflex-chat/scripts/open_browser.py
+++ b/apps/reflex-chat/scripts/open_browser.py
@@ -1,11 +1,12 @@
 """Wait for the Reflex frontend to be ready, then open the browser."""
 
+import os
 import socket
 import time
 import webbrowser
 
 PORT = 3000
-URL = f"http://localhost:{PORT}"
+URL = os.environ.get("PORTLESS_URL", f"http://localhost:{PORT}")
 TIMEOUT = 60  # seconds
 
 


### PR DESCRIPTION
## Summary

- Wrap dev server commands (`just run`) with optional [portless](https://github.com/vercel-labs/portless) proxy
- Provides consistent `.localhost` URLs across worktrees (e.g., `http://feat-dark-mode.chainlit.localhost:1355`)
- Graceful fallback: portless is entirely optional — without it, dev servers run on default ports as before

## Changes

| File | Change |
|------|--------|
| `apps/chainlit-chat/justfile` | Portless wrapper with `PORTLESS=0` bypass |
| `apps/reflex-chat/justfile` | Portless wrapper with `--app-port 3000` |
| `apps/reflex-chat/scripts/open_browser.py` | Read `PORTLESS_URL` env var |
| `.moon/templates/*` | Same changes for generated projects |
| `CONTRIBUTING.md` | Document optional portless setup |

## How it works

1. **With portless installed**: `just run` → `http://chainlit.localhost:1355` (or `http://feat-xyz.chainlit.localhost:1355` in worktrees)
2. **Without portless**: `just run` → `http://localhost:8000` (Chainlit) or `http://localhost:3000` (Reflex) as before
3. **Bypass**: `PORTLESS=0 just run` skips portless even when installed

## Test plan

- [ ] Install portless: `npm install -g portless`
- [ ] Run Chainlit: `cd apps/chainlit-chat && just run` → verify `.localhost:1355` URL
- [ ] Run Reflex: `cd apps/reflex-chat && just run` → verify `.localhost:1355` URL
- [ ] Bypass test: `PORTLESS=0 just run` → verify direct port (8000/3000)
- [ ] Without portless: uninstall and verify fallback to default ports

👾 Generated with [Letta Code](https://letta.com)