### PR TITLE
feat: add persistence config to ragfacile.toml

### DIFF
--- a/.moon/templates/chainlit-chat/pyproject.toml
+++ b/.moon/templates/chainlit-chat/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "{{ project_name }}"
-version = "0.20.0" # x-release-please-version
+version = "0.21.0" # x-release-please-version
 description = "{{ description }}"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/.moon/templates/context/pyproject.toml
+++ b/.moon/templates/context/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "context"
-version = "0.20.0" # x-release-please-version
+version = "0.21.0" # x-release-please-version
 description = "Context assembly - format retrieved chunks into LLM-ready context strings"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/.moon/templates/ingestion/pyproject.toml
+++ b/.moon/templates/ingestion/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ingestion"
-version = "0.20.0" # x-release-please-version
+version = "0.21.0" # x-release-please-version
 description = "Document ingestion - parse and extract text from files (PDF, Markdown, HTML)"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/.moon/templates/pipelines/pyproject.toml
+++ b/.moon/templates/pipelines/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pipelines"
-version = "0.20.0" # x-release-please-version
+version = "0.21.0" # x-release-please-version
 description = "RAG pipeline orchestration - coordinate ingestion, retrieval, and context assembly"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/.moon/templates/rag-core/presets/accurate.toml
+++ b/.moon/templates/rag-core/presets/accurate.toml
@@ -109,3 +109,9 @@ include_sources = true
 enabled = true
 provider = "sqlite"
 database = ".rag-facile/traces.db"
+
+# ==============================================================================
+# PERSISTENCE & DATA LAYER
+# ==============================================================================
+[persistence]
+provider = "none"

--- a/.moon/templates/rag-core/presets/balanced.toml
+++ b/.moon/templates/rag-core/presets/balanced.toml
@@ -144,3 +144,9 @@ include_sources = true
 enabled = true
 provider = "sqlite"
 database = ".rag-facile/traces.db"
+
+# ==============================================================================
+# PERSISTENCE & DATA LAYER
+# ==============================================================================
+[persistence]
+provider = "none"

--- a/.moon/templates/rag-core/presets/fast.toml
+++ b/.moon/templates/rag-core/presets/fast.toml
@@ -106,3 +106,9 @@ include_sources = false  # Skip for speed
 enabled = true
 provider = "sqlite"
 database = ".rag-facile/traces.db"
+
+# ==============================================================================
+# PERSISTENCE & DATA LAYER
+# ==============================================================================
+[persistence]
+provider = "none"

--- a/.moon/templates/rag-core/presets/hr.toml
+++ b/.moon/templates/rag-core/presets/hr.toml
@@ -110,3 +110,9 @@ include_sources = true  # Show which policies were consulted
 enabled = true
 provider = "sqlite"
 database = ".rag-facile/traces.db"
+
+# ==============================================================================
+# PERSISTENCE & DATA LAYER
+# ==============================================================================
+[persistence]
+provider = "none"

--- a/.moon/templates/rag-core/presets/legal.toml
+++ b/.moon/templates/rag-core/presets/legal.toml
@@ -111,3 +111,9 @@ include_sources = true  # Show all sources consulted
 enabled = true
 provider = "sqlite"
 database = ".rag-facile/traces.db"
+
+# ==============================================================================
+# PERSISTENCE & DATA LAYER
+# ==============================================================================
+[persistence]
+provider = "none"

--- a/.moon/templates/rag-core/pyproject.toml
+++ b/.moon/templates/rag-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rag-core"
-version = "0.20.0" # x-release-please-version
+version = "0.21.0" # x-release-please-version
 description = "Core library for RAG Facile - configuration, utils, and shared models"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/.moon/templates/rag-core/src/rag_facile/core/schema.py
+++ b/.moon/templates/rag-core/src/rag_facile/core/schema.py
@@ -547,6 +547,33 @@ class TracingConfig(BaseModel):
 
 
 # ==============================================================================
+# PERSISTENCE (Conversation & Data Layer)
+# ==============================================================================
+
+
+class PersistenceConfig(BaseModel):
+    """Configuration for conversation persistence and data layer.
+
+    Persistence stores conversation history, user sessions, and feedback
+    in a PostgreSQL database (e.g., Supabase). This enables multi-user
+    support, conversation resumption, and audit trails.
+
+    The connection string should be set via the DATABASE_URL environment
+    variable for security (keeps credentials out of config files).
+    """
+
+    provider: Literal["none", "postgres"] = Field(
+        default="none",
+        description='Persistence provider ("none" disabled, "postgres" for Supabase/PostgreSQL)',
+    )
+    connection_string: str = Field(
+        default="",
+        description="PostgreSQL connection string (used when provider is 'postgres'). "
+        "Typically set via DATABASE_URL environment variable.",
+    )
+
+
+# ==============================================================================
 # ROOT CONFIG
 # ==============================================================================
 
@@ -622,6 +649,10 @@ class RAGConfig(BaseModel):
     tracing: TracingConfig = Field(
         default_factory=TracingConfig,
         description="Pipeline tracing and observability",
+    )
+    persistence: PersistenceConfig = Field(
+        default_factory=PersistenceConfig,
+        description="Conversation persistence and data layer",
     )
 
     model_config = {
@@ -748,6 +779,13 @@ PIPELINE_STAGES: list[PipelineStage] = [
         description="Log queries, retrieved context, responses, and user feedback for pipeline improvement.",
         emoji="\U0001f50d",
         model=TracingConfig,
+    ),
+    PipelineStage(
+        key="persistence",
+        title="Persistence & Data Layer",
+        description="Store conversation history, user sessions, and feedback in PostgreSQL for multi-user support.",
+        emoji="\U0001f4be",
+        model=PersistenceConfig,
     ),
     PipelineStage(
         key="hallucination",

--- a/.moon/templates/reflex-chat/pyproject.toml
+++ b/.moon/templates/reflex-chat/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "{{ project_name }}"
-version = "0.20.0" # x-release-please-version
+version = "0.21.0" # x-release-please-version
 description = "{{ description }}"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/.moon/templates/reranking/pyproject.toml
+++ b/.moon/templates/reranking/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "reranking"
-version = "0.20.0" # x-release-please-version
+version = "0.21.0" # x-release-please-version
 description = "Reranking - re-score retrieved chunks with a cross-encoder for higher precision"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/.moon/templates/retrieval/pyproject.toml
+++ b/.moon/templates/retrieval/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "retrieval"
-version = "0.20.0" # x-release-please-version
+version = "0.21.0" # x-release-please-version
 description = "Unified retrieval package - basic context injection and Albert RAG"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/.moon/templates/storage/pyproject.toml
+++ b/.moon/templates/storage/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "storage"
-version = "0.20.0" # x-release-please-version
+version = "0.21.0" # x-release-please-version
 description = "Vector storage and collection management for the RAG pipeline"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/packages/rag-core/presets/accurate.toml
+++ b/packages/rag-core/presets/accurate.toml
@@ -109,3 +109,9 @@ include_sources = true
 enabled = true
 provider = "sqlite"
 database = ".rag-facile/traces.db"
+
+# ==============================================================================
+# PERSISTENCE & DATA LAYER
+# ==============================================================================
+[persistence]
+provider = "none"

--- a/packages/rag-core/presets/balanced.toml
+++ b/packages/rag-core/presets/balanced.toml
@@ -144,3 +144,9 @@ include_sources = true
 enabled = true
 provider = "sqlite"
 database = ".rag-facile/traces.db"
+
+# ==============================================================================
+# PERSISTENCE & DATA LAYER
+# ==============================================================================
+[persistence]
+provider = "none"

--- a/packages/rag-core/presets/fast.toml
+++ b/packages/rag-core/presets/fast.toml
@@ -106,3 +106,9 @@ include_sources = false  # Skip for speed
 enabled = true
 provider = "sqlite"
 database = ".rag-facile/traces.db"
+
+# ==============================================================================
+# PERSISTENCE & DATA LAYER
+# ==============================================================================
+[persistence]
+provider = "none"

--- a/packages/rag-core/presets/hr.toml
+++ b/packages/rag-core/presets/hr.toml
@@ -110,3 +110,9 @@ include_sources = true  # Show which policies were consulted
 enabled = true
 provider = "sqlite"
 database = ".rag-facile/traces.db"
+
+# ==============================================================================
+# PERSISTENCE & DATA LAYER
+# ==============================================================================
+[persistence]
+provider = "none"

--- a/packages/rag-core/presets/legal.toml
+++ b/packages/rag-core/presets/legal.toml
@@ -111,3 +111,9 @@ include_sources = true  # Show all sources consulted
 enabled = true
 provider = "sqlite"
 database = ".rag-facile/traces.db"
+
+# ==============================================================================
+# PERSISTENCE & DATA LAYER
+# ==============================================================================
+[persistence]
+provider = "none"

--- a/packages/rag-core/src/rag_facile/core/schema.py
+++ b/packages/rag-core/src/rag_facile/core/schema.py
@@ -547,6 +547,33 @@ class TracingConfig(BaseModel):
 
 
 # ==============================================================================
+# PERSISTENCE (Conversation & Data Layer)
+# ==============================================================================
+
+
+class PersistenceConfig(BaseModel):
+    """Configuration for conversation persistence and data layer.
+
+    Persistence stores conversation history, user sessions, and feedback
+    in a PostgreSQL database (e.g., Supabase). This enables multi-user
+    support, conversation resumption, and audit trails.
+
+    The connection string should be set via the DATABASE_URL environment
+    variable for security (keeps credentials out of config files).
+    """
+
+    provider: Literal["none", "postgres"] = Field(
+        default="none",
+        description='Persistence provider ("none" disabled, "postgres" for Supabase/PostgreSQL)',
+    )
+    connection_string: str = Field(
+        default="",
+        description="PostgreSQL connection string (used when provider is 'postgres'). "
+        "Typically set via DATABASE_URL environment variable.",
+    )
+
+
+# ==============================================================================
 # ROOT CONFIG
 # ==============================================================================
 
@@ -622,6 +649,10 @@ class RAGConfig(BaseModel):
     tracing: TracingConfig = Field(
         default_factory=TracingConfig,
         description="Pipeline tracing and observability",
+    )
+    persistence: PersistenceConfig = Field(
+        default_factory=PersistenceConfig,
+        description="Conversation persistence and data layer",
     )
 
     model_config = {
@@ -748,6 +779,13 @@ PIPELINE_STAGES: list[PipelineStage] = [
         description="Log queries, retrieved context, responses, and user feedback for pipeline improvement.",
         emoji="\U0001f50d",
         model=TracingConfig,
+    ),
+    PipelineStage(
+        key="persistence",
+        title="Persistence & Data Layer",
+        description="Store conversation history, user sessions, and feedback in PostgreSQL for multi-user support.",
+        emoji="\U0001f4be",
+        model=PersistenceConfig,
     ),
     PipelineStage(
         key="hallucination",

--- a/ragfacile.toml
+++ b/ragfacile.toml
@@ -100,3 +100,9 @@ include_sources = true
 enabled = true
 provider = "sqlite"
 database = ".rag-facile/traces.db"
+
+# ==============================================================================
+# PERSISTENCE & DATA LAYER
+# ==============================================================================
+[persistence]
+provider = "none"

--- a/uv.lock
+++ b/uv.lock
@@ -448,7 +448,7 @@ wheels = [
 
 [[package]]
 name = "chainlit-chat"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "apps/chainlit-chat" }
 dependencies = [
     { name = "albert-client" },
@@ -528,7 +528,7 @@ wheels = [
 
 [[package]]
 name = "context"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "packages/context" }
 dependencies = [
     { name = "rag-core" },
@@ -704,7 +704,7 @@ wheels = [
 
 [[package]]
 name = "evaluation"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "packages/evaluation" }
 dependencies = [
     { name = "httpx" },
@@ -1090,7 +1090,7 @@ wheels = [
 
 [[package]]
 name = "ingestion"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "packages/ingestion" }
 dependencies = [
     { name = "albert-client" },
@@ -2458,7 +2458,7 @@ wheels = [
 
 [[package]]
 name = "pipelines"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "packages/pipelines" }
 dependencies = [
     { name = "context" },
@@ -2994,7 +2994,7 @@ wheels = [
 
 [[package]]
 name = "query"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "packages/query" }
 dependencies = [
     { name = "albert-client" },
@@ -3021,7 +3021,7 @@ wheels = [
 
 [[package]]
 name = "rag-core"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "packages/rag-core" }
 dependencies = [
     { name = "pydantic" },
@@ -3038,7 +3038,7 @@ requires-dist = [
 
 [[package]]
 name = "rag-facile"
-version = "0.20.0"
+version = "0.21.0"
 source = { virtual = "." }
 dependencies = [
     { name = "albert-client" },
@@ -3105,7 +3105,7 @@ dev = [
 
 [[package]]
 name = "rag-facile-cli"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "apps/cli" }
 dependencies = [
     { name = "albert-client" },
@@ -3170,7 +3170,7 @@ dev = [
 
 [[package]]
 name = "rag-facile-lib"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "packages/rag-facile-lib" }
 dependencies = [
     { name = "albert-client" },
@@ -3251,7 +3251,7 @@ wheels = [
 
 [[package]]
 name = "reflex-chat"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "apps/reflex-chat" }
 dependencies = [
     { name = "albert-client" },
@@ -3343,7 +3343,7 @@ wheels = [
 
 [[package]]
 name = "reranking"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "packages/reranking" }
 dependencies = [
     { name = "albert-client" },
@@ -3370,7 +3370,7 @@ wheels = [
 
 [[package]]
 name = "retrieval"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "packages/retrieval" }
 dependencies = [
     { name = "albert-client" },
@@ -3633,7 +3633,7 @@ wheels = [
 
 [[package]]
 name = "storage"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "packages/storage" }
 dependencies = [
     { name = "albert-client" },
@@ -3914,7 +3914,7 @@ wheels = [
 
 [[package]]
 name = "tracing"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "packages/tracing" }
 dependencies = [
     { name = "rag-core" },


### PR DESCRIPTION
Refactor configuration architecture to explicitly declare persistence features in ragfacile.toml rather than relying implicitly on environment variables. This creates a feature-driven configuration standard and keeps ragfacile.toml generic for all application instances.

🚀 Generated with [Gemini CLI](https://github.com/google/gemini-cli)