### PR TITLE
chore: update wt.toml to use pre-start instead of deprecated post-create

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,7 +1,7 @@
 # Worktrunk Project Configuration
 # See: https://worktrunk.dev/config/
 
-[post-create]
+[pre-start]
 # Install Python dependencies after worktree creation (blocking)
 deps = "uv sync"
 

--- a/.gitignore
+++ b/.gitignore
@@ -226,6 +226,7 @@ private/
 # rag-facile chat agent state (belongs in user projects, not source repo)
 .agent/
 .rag-facile/  # legacy (pre-v0.19)
+.ragtime/  # chat agent state (v0.19+)
 
 # npx skills — installed per-workspace by users, not tracked in source repo
 .agents/


### PR DESCRIPTION
## Summary

- Fixes the deprecation warning in `.config/wt.toml`
- Renames `[post-create]` hook to `[pre-start]` (worktrunk deprecated the old name)

## Test plan

- [ ] Run `wt config show` — no deprecation warning should appear

👾 Generated with [Letta Code](https://letta.com)